### PR TITLE
[IM] Use ifName directly when generting MRTG configurations

### DIFF
--- a/tools/perl-lib/IXPManager/lib/IXPManager/Config.pm
+++ b/tools/perl-lib/IXPManager/lib/IXPManager/Config.pm
@@ -39,7 +39,7 @@ use vars qw(@ISA @EXPORT_OK @EXPORT $VERSION $AUTOLOAD);
 
 @ISA = ("Config");
 
-$VERSION = '0.22';
+$VERSION = '0.23';
 
 1;
 

--- a/tools/perl-lib/IXPManager/lib/IXPManager/Utils.pm
+++ b/tools/perl-lib/IXPManager/lib/IXPManager/Utils.pm
@@ -54,3 +54,18 @@ sub switchporttosnmpidentifier {
 
 	return $shortport;
 }
+
+
+sub switchportifnametosnmpidentifier {
+       my ($ifname) = @_;
+
+       # escape special characters in ifName as per
+       # http://oss.oetiker.ch/mrtg/doc/mrtg-reference.en.html - "Interface by Name" section
+
+       $ifname =~ s/:/\\:/g; 
+       $ifname =~ s/&/\\&/g;   
+       $ifname =~ s/@/\\@/g;  
+       $ifname =~ s/\ /\\\ /g; 
+       
+       return $ifname;
+}

--- a/tools/runtime/mrtg/update-mrtg-config-from-db.pl
+++ b/tools/runtime/mrtg/update-mrtg-config-from-db.pl
@@ -136,7 +136,7 @@ $query = 'SELECT
 		sw.vendorid,
 		sw.name		AS switchname,
 		sw.snmppasswd,
-		sp.name		AS switchport
+		sp.ifName	AS switchport
 	FROM
 		switch sw,
 		switchport sp
@@ -172,7 +172,7 @@ foreach my $infra (keys %{$lans}) {
 	foreach my $traffictype (keys %{$traffictypes}) {
 		foreach my $switchid (@{$lans->{$infra}->{switchids}}) {
 			foreach my $switchport (@{$lans->{$infra}->{$switchid}->{ports}}) {
-				my $spidentifier = IXPManager::Utils::switchporttosnmpidentifier($switchport, $lans->{$infra}->{$switchid}->{vendorid});
+				my $spidentifier = IXPManager::Utils::switchportifnametosnmpidentifier($switchport);
 				$debug && print STDERR ("INFO: per-infra aggregate pushed $spidentifier (\"$switchport\") to infra $infra\n");
 				my $mrtgobj =	$traffictypes->{$traffictype}->{in}.'#'.$spidentifier.
 						'&'.
@@ -224,7 +224,7 @@ $query = 'SELECT
 		sw.vendorid,
 		sw.name		AS switchname,
 		sw.snmppasswd,
-		sp.name		AS switchport
+		sp.ifName	AS switchport
 	FROM
 		switch sw,
 		switchport sp
@@ -242,7 +242,7 @@ $sth->execute() || die "$dbh->errstr\n";
 my $switchports;
 # slurp everything in from SQL
 while (my $rec = $sth->fetchrow_hashref) {
-	my $spidentifier = IXPManager::Utils::switchporttosnmpidentifier($rec->{switchport}, $rec->{vendorid});
+	my $spidentifier = IXPManager::Utils::switchportifnametosnmpidentifier($rec->{switchport});
 	foreach my $traffictype (keys %{$traffictypes}) {
 		my $mrtgobj =	$traffictypes->{$traffictype}->{in}.'#'.$spidentifier.
 				'&'.
@@ -279,7 +279,7 @@ $query = 'SELECT
 		cu.name,
 		cu.shortname,
 		sd.switch,
-		sd.switchport,
+		sd.spifname,
 		sd.vendorid,
 		sd.snmppasswd,
 		pi.speed,
@@ -305,7 +305,7 @@ while (my $rec = $sth->fetchrow_hashref) {
 	my $membername = $rec->{name};
 	my $shortname = $rec->{shortname};
 	my $switch = $rec->{switch};
-	my $switchport = $rec->{switchport};
+	my $switchport = $rec->{spifname};
 	my $speed = $rec->{speed};
 	my $index = $rec->{monitorindex};
 
@@ -314,7 +314,7 @@ while (my $rec = $sth->fetchrow_hashref) {
 	my $speedpkts  = int ($speedbytes / 64);
 	my $speeddisc  = int ($speedbytes / 10);
 
-	my $shortport = IXPManager::Utils::switchporttosnmpidentifier($switchport, $rec->{vendorid});
+	my $shortport = IXPManager::Utils::switchportifnametosnmpidentifier($switchport);
 
 	$rec->{shortport} = $shortport;
 

--- a/tools/sql/views.sql
+++ b/tools/sql/views.sql
@@ -80,6 +80,7 @@ CREATE VIEW view_switch_details_by_custid AS
 		pi.notes,
 		sp.name AS switchport,
 		sp.id AS switchportid,
+		sp.ifName AS spifname,
 		sw.name AS switch,
 		sw.id AS switchid,
 		sw.vendorid,


### PR DESCRIPTION
The schema original stored ifDescription (as switchport.name) requiring a
per vendor translation function for generating MRTG configurations:

```
IXPManager::Utils::switchporttosnmpidentifier($switchport, $vendor);
```

However, we now also store the ifName directly (which is what MRTG
authors consider "the only sensible way to reference the interfaces of
your switches.

This commit updates the scripts (and sql views) to use ifName directly
including a new utility function to escape characters such as ':',
'@', ' ' and '&' as required by MRTG.
