### PR TITLE
Remove duplicated section in config file

### DIFF
--- a/application/configs/application.ini.dist
+++ b/application/configs/application.ini.dist
@@ -459,22 +459,6 @@ weathermap.1.height = 1200
 ; weathermap.2.name = "Weathermap for Peering LAN 2"
 ; ...
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; We use PHP-Weathermap which is publically available. Our true settings
-;; are commented out, please replace with your own
-;;
-
-weathermap.1.name   = "Weathermap for Peering LAN 1"
-weathermap.1.menu   = "Weathermap - LAN 1"
-; weathermap.1.url    = "https://www.inex.ie/noncms/weathermap-lan1-plain.html"
-weathermap.1.url    = "https://www.example.com/weathermap-lan1-plain.html"
-weathermap.1.width  = 900
-weathermap.1.height = 1200
-
-; weathermap.2.name = "Weathermap for Peering LAN 2"
-; ...
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Network Information default properties


### PR DESCRIPTION
The PHP-Weathermap section of the distributed config file is duplicated (probably double-copy-pasted). This removes one of the duplicates.
