### PR TITLE
Fix query build

### DIFF
--- a/application/Repositories/Vlan.php
+++ b/application/Repositories/Vlan.php
@@ -268,8 +268,7 @@ class Vlan extends EntityRepository
      */
     public function getPrivateVlanDetails( $infra = null )
     {
-        $q = $this->getEntityManager()->createQuery(
-                "SELECT vli, v, vi, pi, sp, s, l, cab, c, i, ixp
+        $q = "SELECT vli, v, vi, pi, sp, s, l, cab, c, i, ixp
                 FROM \\Entities\\Vlan v
                     LEFT JOIN v.VlanInterfaces vli
                     LEFT JOIN v.Infrastructure i


### PR DESCRIPTION
Here an attempt is being made to construct a string $q and then reassign $q as a query object using the string, but the front part of the query-construction code has been prepended to the string-construction (it is already present later, at line 295 where it is needed), creating a syntax error. This commit removes the extra code and fixes one bug, which by the way exposes another unrelated bug where in some places getInfrastructure() is returning a non-object, and then subsequent attempts to getIXP() on that "object" fail...
