### PR TITLE
Fix capitalisation inconsistency in Entity file

### DIFF
--- a/application/Entities/Switcher.php
+++ b/application/Entities/Switcher.php
@@ -57,7 +57,7 @@ class Switcher
     /**
      * @var \Entities\Infrastructure
      */
-    protected $infrastructure;
+    protected $Infrastructure;
 
     /**
      * @var integer $switchtype
@@ -758,11 +758,5 @@ class Switcher
     
         return $this;
     }
-
-    /**
-     * @var \Entities\Infrastructure
-     */
-    private $Infrastructure;
-
 
 }


### PR DESCRIPTION
There appear to be two different declarations of the same variable with different capitalisation. This removes the (wrong?) one. I am not sure if this requires also editing any XML files from which this file is created? or if this edit is enough... (or if this edit is "wrong"?). This was required in order to remove a `[ReflectionException] Property Entities\Switcher::$Infrastructure does not exist` error when running `doctrine2-cli.php` command (and `Entities\Switcher has no association Infrastructure` errors on the web interface).
