### PR TITLE
Set character-set (utf8) for db-interface in config

### DIFF
--- a/application/configs/application.ini.dist
+++ b/application/configs/application.ini.dist
@@ -194,6 +194,7 @@ resources.doctrine2.connection.options.dbname   = 'ixp'
 resources.doctrine2.connection.options.user     = 'ixp'
 resources.doctrine2.connection.options.password = 'password'
 resources.doctrine2.connection.options.host     = '127.0.0.1'
+resources.doctrine2.connection.options.charset  = 'utf8'
 
 
 


### PR DESCRIPTION
I struck the famous mysql double-utf8-encoding problem when using Greek text without this being set. I think it is because for every version of Mysql up to something quite recent it still defaults to latin1 unless specifically set to utf8. This config addition fixed it for me entirely.
