### PR TITLE
De-INEXify/de-hardcode switch suffix in customer details

### DIFF
--- a/application/views/customer/detail.phtml
+++ b/application/views/customer/detail.phtml
@@ -163,7 +163,7 @@
     <table id="myDetailsTable">
         <tr>
             <td width="200"><strong>Switch:</strong></td>
-            <td width="200" id="value">{$pi->getSwitchPort()->getSwitcher()->getName()}.inex.ie</td>
+            <td width="200" id="value">{$pi->getSwitchPort()->getSwitcher()->getName()}{$options.identity.switch_domain}</td>
             <td width="40"></td>
             <td width="200"><strong>Switch Port:</strong></td>
             <td width="200" id="value">{$pi->getSwitchPort()->getName()}</td>


### PR DESCRIPTION
Reference (possibly empty) switch suffix from config, rather than hard-coding ".inex.ie". When this change was made to other files, obviously this one was just missed.
