### PR TITLE
Center icon (like for login page) in other pages too

### DIFF
--- a/application/views/auth/lost-password.phtml
+++ b/application/views/auth/lost-password.phtml
@@ -11,7 +11,9 @@
 <div class="row">
 
     <div class="span6 {if isset( $options.identity.biglogoconf.offset )}{$options.identity.biglogoconf.offset}{/if}">
-        <img src="{$options.identity.biglogo}" />
+        <p align="center">
+            <img src="{$options.identity.biglogo}" />
+        </p>
     </div>
     
 </div>

--- a/application/views/auth/lost-username.phtml
+++ b/application/views/auth/lost-username.phtml
@@ -13,7 +13,9 @@
 <div class="row">
 
     <div class="span6 {if isset( $options.identity.biglogoconf.offset )}{$options.identity.biglogoconf.offset}{/if}">
-        <img src="{$options.identity.biglogo}" />
+        <p align="center">
+            <img src="{$options.identity.biglogo}" />
+        </p>
     </div>
     
 </div>

--- a/application/views/auth/reset-password.phtml
+++ b/application/views/auth/reset-password.phtml
@@ -11,7 +11,9 @@
 <div class="row">
 
     <div class="span6 {if isset( $options.identity.biglogoconf.offset )}{$options.identity.biglogoconf.offset}{/if}">
-        <img src="{$options.identity.biglogo}" />
+        <p align="center">
+            <img src="{$options.identity.biglogo}" />
+        </p>
     </div>
     
 </div>


### PR DESCRIPTION
The icon is centred in the `login` view, and seems like it should be centred the same way in the `lost-password`, `lost-username` and `reset-password` views too. This PR centres the icon with the same markup as is used in the login view.
