### PR TITLE
Add Juniper to the vendors listed in fixtures.php

### DIFF
--- a/bin/fixtures.php.dist
+++ b/bin/fixtures.php.dist
@@ -241,7 +241,8 @@ $vendors = [
     [ "Hitachi Cable", 'Hitachi', 'hitachi' ],
     [ "MRV", 'MRV', 'mrv' ],
     [ "Transmode", 'Transmode', 'transmode' ],
-    [ "Brocade", 'Brocade', 'brocade' ]
+    [ "Brocade", 'Brocade', 'brocade' ],
+    [ "Juniper Networks", 'Juniper', 'juniper' ]
 ];
 
 foreach( $vendors as $vendor )


### PR DESCRIPTION
This just adds Juniper to the list of vendors in the fixtures file. I presume there is no specific required syntax for the "Short Name" and "Nagios Name"? (I just added something analogous to the other vendor-entries). I realise there may be the desire not to add/acknowledge the vendor yet in the "preset values" (if the support isn't robust enough yet, etc). In that case I thought perhaps this PR can just sit in waiting so no-one forgets to add to the fixtures file when the time is right).
