### PR TITLE
Improve mrtg init file

### DIFF
--- a/tools/runtime/mrtg/ubuntu-mrtg-initd
+++ b/tools/runtime/mrtg/ubuntu-mrtg-initd
@@ -19,8 +19,9 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="mrtg"
 NAME=mrtg
 DAEMON=/usr/bin/$NAME
-PIDFILE=/etc/mrtg/$NAME.pid
-DAEMON_ARGS="--daemon --pid-file=$PIDFILE /etc/mrtg/mrtg.cfg"
+PIDFILE=/etc/${NAME}/$NAME.pid
+CONFFILE=/etc/${NAME}/$NAME.cfg
+DAEMON_ARGS="--daemon --pid-file=$PIDFILE $CONFFILE"
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the mrtg package is not installed


### PR DESCRIPTION
Three commits. Third commit is more cosmetic/less important. The git-branch name is improve_mrtg_conf - it should say improve_mrtg_init, but it will take me a while to change that so I'll leave it...
## 

(commit 1/3)
Put --daemon in mrtg initfile (different semantics than in conf)

 [as explained in the MRTG manpage]...

```
 --daemon
  Put MRTG into the background, running as a daemon. This works the same
  way as the config file option, but the switch is required for proper
  FHS operation (because /var/run is writable only by root)
```

...and the init file should _always_ spawn mrtg as a daemon anyway if at
all possible (otherwise init needs to brute-force backgrounding it after
the fact, which is advised against in start-stop-daemon manpage on Debian,
and probably applies in other init systems too).

(commit 2/3)
Put --pid-file in mrtg init daemonargs (always needed)

Explicitly set mrtg flag --pid-file=$PIDFILE in init file because (being
init) pid file is _always_ needed, and is already hard-coded there for
the stop() command. This avoids code-duplication in the config file, and
consequent possibility for mismatches (resulting in non-killed mrtg
processes). Set PIDFILE _before_ referencing it (reorder setting of
vars).

(commit 3/3)
Make setting and use of vars in init-file more DRY
