### PR TITLE
Add extra dist-derived file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tools/perl-lib/IXPManager/blib/
 tools/perl-lib/IXPManager/pm_to_blib
 *.sublime-project
 *.sublime-workspace
+library/Minify/minify-options.php
 application/views/router-cli/tacacs/tacplus/key.cfg
 application/views/_skins/*/router-cli/tacacs/*/key.cfg
 application/configs/rc-inex-*conf


### PR DESCRIPTION
While searching for files to check against updates I found one of the libraries includes a .dist file which might on some occasions have an equivalent non-.dist file which should be gitignored (when people want their JS and CSS minified).
