### PR TITLE
ixpmanager.conf: Dedupe dbase_host and dbase_hostname (latter is used)

### DIFF
--- a/tools/perl-lib/IXPManager/ixpmanager.conf
+++ b/tools/perl-lib/IXPManager/ixpmanager.conf
@@ -19,7 +19,6 @@
 
 <sql>
 	dbase_type	= mysql
-	dbase_host	= localhost
 	dbase_database	= ixpmanagerdatabase
 	dbase_username	= ixpmanagerusername
 	dbase_password	= mys00persekr1tp4ssw0rd


### PR DESCRIPTION
Having grepped the entire tree and even submodules, I can't find anything that references the `dbase_host` entry in `tools/perl-lib/IXPManager/ixpmanager.conf`. Everything seems to reference the `dbase_hostname` entry. It seems the first is a redundant entry. This removes it.
