### PR TITLE
Add script for updating AS/prefix tables & RS-configs

### DIFF
--- a/tools/runtime/route-servers/example-update-rs-info.sh
+++ b/tools/runtime/route-servers/example-update-rs-info.sh
@@ -211,10 +211,15 @@ if test 0 -eq $STDOUT && test 1 -eq $USE_GIT && test -n "`git status --porcelain
 
     # Email
     if test 1 -eq `git rev-list --min-parents=0 'HEAD' 2>/dev/null | wc -l` || \
-       test -n "`git diff --patch-with-raw 'HEAD^' 2>/dev/null | grep -v '^\([^+-]\|--- \|+++ \|[+-]# \+Generated: \)'`"; then
-        git show 'HEAD' 2>/dev/null | \
-         mail -s "Route Server config changes on `hostname`" $MAIL_RECIPIENTS >/dev/null 2>&1 || \
-           bork $? 'emailing config-changes'
+      test -n "`git diff --patch-with-raw 'HEAD^' 2>/dev/null | grep -v '^\([^+-]\|--- \|+++ \|[+-]# \+Generated: \)'`"; then
+        hostname="`hostname`"
+        {
+            printf 'Route server config changes on $hostname, git-diff output:\n\n'
+            # try "previous -> present commit", fallback to show whole log if only one commit
+            git log -p --stat 'HEAD^..HEAD' 2>/dev/null || \
+              git log -p --stat 2>/dev/null
+        } | mail -a "From: IXP-Manager <root@example-ixp.com>" -s "Route server config changes on $hostname" $MAIL_RECIPIENTS >/dev/null 2>&1 || \
+          bork $? 'emailing config-changes'
     fi
 
 fi


### PR DESCRIPTION
I know there are already example scripts, including one for using the API, but I thought I'd PR this in case you want to take some/all of it as an example of a quite feature-full script appropriate for cron-use (or to incorporate some of it into existing scripts). It adds things like efficiently looking up the vlan-id in the DB by vlan-number, git-versioning, emailing if changes (other than timestamp) happen, optional updating of AS/prefix table beforehand, debug-output, output to stdout or to files, etc. Maybe it's overkill for merging as an example, but let me know if some/any of it is useful, and what needs changing for the PR if so.
