### PR TITLE
importing LAG MAC addresses 

### DIFF
--- a/tools/runtime/l2database/update-l2database.pl
+++ b/tools/runtime/l2database/update-l2database.pl
@@ -94,7 +94,7 @@ if ($debug) {
 	print STDERR $debug_output;
 }
 
-$query = "SELECT id, switchport, switchportid, spifname, switch, status, infrastructure FROM view_switch_details_by_custid";
+$query = "SELECT id, switchport, switchportid, spifname, switch, status, infrastructure, virtualinterfacename FROM view_switch_details_by_custid";
 ($sth = $dbh->prepare($query)) or die "$dbh->errstr\n";
 $sth->execute() or die "$dbh->errstr\n";
 my $ports = $sth->fetchall_hashref( [qw (switch switchport)] );
@@ -119,6 +119,11 @@ foreach my $switch (keys %{$ports}) {
 			$do_nothing or $insertsth->execute($ports->{$switch}->{$port}->{id}, $mac) or die "$dbh->errstr\n";
 #			$ports->{$switch}->{$port}->{mac} = $l2mapping->{$switch}->{$port};
 		}
+                my $virtualinterfacename = $ports->{$switch}->{$port}->{'virtualinterfacename'};
+                foreach my $mac (@{$l2mapping->{$switch}->{$virtualinterfacename}}) {
+                        $debug && print STDERR "INSERT: $mac -> $switch:$virtualinterfacename\n";
+                        $do_nothing or $insertsth->execute($ports->{$switch}->{$port}->{id}, $mac) or die "$dbh->errstr\n";
+                }
 	}
 }
 

--- a/tools/runtime/l2database/update-l2database.pl
+++ b/tools/runtime/l2database/update-l2database.pl
@@ -119,10 +119,12 @@ foreach my $switch (keys %{$ports}) {
 			$do_nothing or $insertsth->execute($ports->{$switch}->{$port}->{id}, $mac) or die "$dbh->errstr\n";
 #			$ports->{$switch}->{$port}->{mac} = $l2mapping->{$switch}->{$port};
 		}
-                my $virtualinterfacename = $ports->{$switch}->{$port}->{'virtualinterfacename'};
-                foreach my $mac (@{$l2mapping->{$switch}->{$virtualinterfacename}}) {
-                        $debug && print STDERR "INSERT: $mac -> $switch:$virtualinterfacename\n";
-                        $do_nothing or $insertsth->execute($ports->{$switch}->{$port}->{id}, $mac) or die "$dbh->errstr\n";
+                if ($ports->{$switch}->{$port}->{'virtualinterfacename'} ne "") {
+                        my $virtualinterfacename = $ports->{$switch}->{$port}->{'virtualinterfacename'};
+                        foreach my $mac (@{$l2mapping->{$switch}->{$virtualinterfacename}}) {
+                                $debug && print STDERR "INSERT: $mac -> $switch:$virtualinterfacename\n";
+                                $do_nothing or $insertsth->execute($ports->{$switch}->{$port}->{id}, $mac) or die "$dbh->errstr\n";
+                        }
                 }
 	}
 }

--- a/tools/sql/views.sql
+++ b/tools/sql/views.sql
@@ -72,6 +72,7 @@ CREATE VIEW view_switch_details_by_custid AS
 	SELECT
 		vi.id AS id,
 		vi.custid,
+		vi.name AS virtualinterfacename,
 		pi.virtualinterfaceid,
 		pi.status,
 		pi.speed,


### PR DESCRIPTION
MACs which are behind a logical interface are imported by saving the virtual interface name in the DB and matching on those. This fixes the issues discussed in https://github.com/inex/IXP-Manager/issues/126 for me and gives me sFlow stats for LAGs.