### PR TITLE
gitignore perl-lib ixpmanager.conf,there is .dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tools/perl-lib/IXPManager/MYMETA.yml
 tools/perl-lib/IXPManager/Makefile
 tools/perl-lib/IXPManager/blib/
 tools/perl-lib/IXPManager/pm_to_blib
+tools/perl-lib/IXPManager/ixpmanager.conf
 *.sublime-project
 *.sublime-workspace
 application/views/router-cli/tacacs/tacplus/key.cfg


### PR DESCRIPTION
In a previous commit (6aad7a29fe170000af8cd1bd6f0d944b9eb84029) tools/perl-lib/IXPManager/ixpmanager.conf was moved to tools/perl-lib/IXPManager/ixpmanager.conf.dist, so like for the other .dist files it is useful to gitignore the non-dot-dist version.