### PR TITLE
Add Connected Capacity totals to admin interface

### DIFF
--- a/application/views/admin/index.phtml
+++ b/application/views/admin/index.phtml
@@ -156,6 +156,7 @@
                     {/foreach}
 
                     <th>Total</th>
+                    <th>Connected<br>Capacity</th>
                 </tr>
             </thead>
             <tbody>
@@ -163,6 +164,7 @@
                 {foreach from=$bylan key=n item=spds}
 
                     {assign var=rowcount value=0}
+                    {assign var=rowcap value=0}
 
                     <tr>
                         <td>{$n}</td>
@@ -171,24 +173,29 @@
                                 {if isset( $spds.$k )}
                                     {$spds.$k}
                                     {assign var=rowcount value=$rowcount+$spds.$k}
+                                    {assign var=rowcap value=$rowcap+$spds.$k*$k}
                                 {else}
                                     0
                                 {/if}
                             </td>
                         {/foreach}
                         <td>{$rowcount}</td>
+                        <td>{$rowcap/1000}G</td>
                     </tr>
                     {assign var=colcount value=$rowcount+$colcount}
                 {/foreach}
 
                 <tr>
                     <td><strong>Totals</strong></td>
+                    {assign var=rowcap value=0}
                     {foreach from=$speeds key=k item=i}
+                        {assign var=rowcap value=$rowcap+$i*$k}
                         <td>
                             <strong>{$i}</strong>
                         </td>
                     {/foreach}
                     <td><strong>{$colcount}</strong></td>
+                    <td><strong>{$rowcap/1000}G</strong></td>
                 </tr>
 
             </tbody>


### PR DESCRIPTION
Add total connected capacity sums to Customer Ports by Infrastructure section.

You might find the 'divide by 1000 and convert to G' methodology awful. I don't know. ;)
![screen shot 2015-04-29 at 12 36 13](https://cloud.githubusercontent.com/assets/2152161/7390101/68954800-ee6c-11e4-9766-312a9d04e475.png)
