### PR TITLE
Prefix analysis tool tweaks

### DIFF
--- a/tools/runtime/route-servers/compare-route-server-prefixes.pl
+++ b/tools/runtime/route-servers/compare-route-server-prefixes.pl
@@ -120,7 +120,7 @@ foreach my $protocol (qw(4 6)) {
 			next;
 		}
 
-		my @pfxlist = split(/,\s*/, $prefixes);
+		my @pfxlist = split(/\s*,\s*/, $prefixes);
 		foreach my $prefix (@pfxlist) {
 			my $ip = new NetAddr::IP::Lite $prefix;
 			next unless $ip;

--- a/tools/runtime/route-servers/compare-route-server-prefixes.pl
+++ b/tools/runtime/route-servers/compare-route-server-prefixes.pl
@@ -32,7 +32,7 @@
 #
 #
 # NB: Ensure you set $vlanid, $conffile and $sockfile in the protocols loop
-# below (search for XXX-SET-ME)
+#     below (search for XXX-SET-ME)
 
 
 use strict;
@@ -130,7 +130,7 @@ foreach my $protocol (qw(4 6)) {
 				$p->{irrdb} = 1;
 				$p->{changed} = 1;
 			}
-		} 
+		}
 		$asn = undef; $address = undef; $prefixes = '';
 	}
 	close (INPUT);
@@ -148,7 +148,7 @@ foreach my $protocol (qw(4 6)) {
 	}
 	close (INPUT);
 
-	$dbh->do('START TRANSACTION') or die $dbh->errstr;
+	$do_nothing or $dbh->do('START TRANSACTION') or die $dbh->errstr;
                                    
 	foreach my $asn (@asnlist) {
 		my $cmd = '/usr/sbin/birdc -s '.$sockfile.' show route table t_' . $vliidhash{ $asn } . '_as'.$asn.' protocol pb_' . $vliidhash{ $asn } . '_as'.$asn;
@@ -195,6 +195,5 @@ foreach my $protocol (qw(4 6)) {
 		}
 	}
 
-	$dbh->do('COMMIT') or die $dbh->errstr;
+	$do_nothing or $dbh->do('COMMIT') or die $dbh->errstr;
 }
-


### PR DESCRIPTION
These are two trivial changes I did while tweaking the RS prefix analysis tool for our setup. I realise the intention is to migrate all of this to core PHP code anyway, but in the meantime these are small/non-invasive and can't hurt for the perl version.

Also, I just sent to the mailing-list (*not* part of a pull-request) the git-diff of other bigger site-specific tweaks I had to make for our configs, as it obviously isn't intended to be applied upstream, but purely as a helpful reference. It applies on top of these commits.