### PR TITLE
Ensure string-validate uses UTF-8, not system-default

### DIFF
--- a/library/IXP/Form/Auth/ResetPassword.php
+++ b/library/IXP/Form/Auth/ResetPassword.php
@@ -42,7 +42,7 @@ class IXP_Form_Auth_ResetPassword extends IXP_Form
         $this->addElement(
             OSS_Form_Auth::createPasswordElement()
                 ->removeValidator( 'stringLength' )
-                ->addValidator( 'stringLength', false, array( 8, 30 ) )
+                ->addValidator( 'stringLength', false, array( 8, 30, 'UTF-8' ) )
         );
         $this->addElement( OSS_Form_Auth::createPasswordConfirmElement() );
         $this->addElement( OSS_Form::createSubmitElement( 'submit', _( 'Reset Password' ) ) );

--- a/library/IXP/Form/Cabinet.php
+++ b/library/IXP/Form/Cabinet.php
@@ -36,7 +36,7 @@ class IXP_Form_Cabinet extends IXP_Form
     public function init()
     {
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setAttrib( 'class', 'span3' )
             ->setLabel( 'Name' )
@@ -49,7 +49,7 @@ class IXP_Form_Cabinet extends IXP_Form
 
 
         $cololocation = $this->createElement( 'text', 'cololocation' );
-        $cololocation->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $cololocation->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( true )
             ->setLabel( 'Colo Location' )
@@ -59,7 +59,7 @@ class IXP_Form_Cabinet extends IXP_Form
 
         
         $type = $this->createElement( 'text', 'type' );
-        $type->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $type->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( false )
             ->setLabel( 'Type' )

--- a/library/IXP/Form/ChangePassword.php
+++ b/library/IXP/Form/ChangePassword.php
@@ -48,7 +48,7 @@ class IXP_Form_ChangePassword extends IXP_Form
         $this->addElement(
             OSS_Form_Auth::createPasswordElement( 'new_password' )
                 ->removeValidator( 'stringLength' )
-                ->addValidator( 'stringLength', false, array( 8, 255 ) )
+                ->addValidator( 'stringLength', false, array( 8, 255, 'UTF-8' ) )
                 ->setLabel( _( 'New Password' ) )
                 ->setAttrib( 'class', 'span6' )
         );

--- a/library/IXP/Form/ConsoleServerConnection.php
+++ b/library/IXP/Form/ConsoleServerConnection.php
@@ -35,7 +35,7 @@ class IXP_Form_ConsoleServerConnection extends IXP_Form
     public function init()
     {
         $description = $this->createElement( 'text', 'description' );
-        $description->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $description->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setAttrib( 'class', 'span3' )
             ->setLabel( 'Description' )
@@ -48,7 +48,7 @@ class IXP_Form_ConsoleServerConnection extends IXP_Form
         $this->addElement( IXP_Form_Switch::getPopulatedSelect( 'switchid', \Entities\Switcher::TYPE_CONSOLESERVER ) );
         
         $port = $this->createElement( 'text', 'port' );
-        $port->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $port->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Port' )
             ->setAttrib( 'class', 'span3' )

--- a/library/IXP/Form/Contact.php
+++ b/library/IXP/Form/Contact.php
@@ -37,7 +37,7 @@ class IXP_Form_Contact extends IXP_Form
         $this->setDecorators( [ [ 'ViewScript', [ 'viewScript' => 'contact/forms/edit.phtml' ] ] ] );
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Name' )
             //->setAttrib( 'class', 'span3' )
@@ -47,7 +47,7 @@ class IXP_Form_Contact extends IXP_Form
         $this->addElement( $name );
 
         $position = $this->createElement( 'text', 'position' );
-        $position->addValidator( 'stringLength', false, array( 1, 50 ) )
+        $position->addValidator( 'stringLength', false, array( 1, 50, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Position' )
             //->setAttrib( 'class', 'span3' )
@@ -66,7 +66,7 @@ class IXP_Form_Contact extends IXP_Form
             ->setAttrib( 'class', "" );
 
         $phone = $this->createElement( 'text', 'phone' );
-        $phone->addValidator( 'stringLength', false, array( 1, 32 ) )
+        $phone->addValidator( 'stringLength', false, array( 1, 32, 'UTF-8' ) )
             ->setLabel( _( 'Phone' ) )
             //->setAttrib( 'class', 'span3' )
             ->addFilter( 'StringTrim' )
@@ -75,7 +75,7 @@ class IXP_Form_Contact extends IXP_Form
         $this->addElement( $phone );
 
         $mobile = $this->createElement( 'text', 'mobile' );
-        $mobile->addValidator( 'stringLength', false, array( 1, 32 ) )
+        $mobile->addValidator( 'stringLength', false, array( 1, 32, 'UTF-8' ) )
             ->setLabel( _( 'Mobile' ) )
             ->addFilter( 'StringTrim' )
             ->addFilter( 'StripTags' )
@@ -125,14 +125,14 @@ class IXP_Form_Contact extends IXP_Form
         $this->addElement( $login );
 
         $username = OSS_Form_Auth::createUsernameElement();
-        $username->addValidator( 'stringLength', false, array( 2, 30 ) )
+        $username->addValidator( 'stringLength', false, array( 2, 30, 'UTF-8' ) )
             ->addValidator( 'regex', true, array( '/^[a-zA-Z0-9\-_\.]+$/' ) )
             ->setRequired( false )
             ->setAttrib( 'class', '' );
         $this->addElement( $username );
 
         $password = $this->createElement( 'text', 'password' );
-        $password->addValidator( 'stringLength', false, array( 8, 30 ) )
+        $password->addValidator( 'stringLength', false, array( 8, 30, 'UTF-8' ) )
             ->setRequired( false )
             //->setAttrib( 'class', 'span3' )
             ->setLabel( 'Password' )

--- a/library/IXP/Form/ContactGroup.php
+++ b/library/IXP/Form/ContactGroup.php
@@ -36,7 +36,7 @@ class IXP_Form_ContactGroup extends IXP_Form
     public function init()
     {
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 20 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 20, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Name' )
             ->setAttrib( 'class', 'span3' )
@@ -45,7 +45,7 @@ class IXP_Form_ContactGroup extends IXP_Form
         $this->addElement( $name );
         
         $description = $this->createElement( 'text', 'description' );
-        $description->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $description->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Description' )
             ->setAttrib( 'class', 'span3' )

--- a/library/IXP/Form/CustKit.php
+++ b/library/IXP/Form/CustKit.php
@@ -36,7 +36,7 @@ class IXP_Form_CustKit extends IXP_Form
     public function init()
     {
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Name' )
             ->setAttrib( 'class', 'span3' )

--- a/library/IXP/Form/Customer.php
+++ b/library/IXP/Form/Customer.php
@@ -38,7 +38,7 @@ class IXP_Form_Customer extends IXP_Form
         $this->setDecorators( [ [ 'ViewScript', [ 'viewScript' => 'customer/forms/edit.phtml' ] ] ] );
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Name' )
             ->setAttrib( 'class', 'span10' )
@@ -56,7 +56,7 @@ class IXP_Form_Customer extends IXP_Form
         $this->addElement( $type );
 
         $shortname = $this->createElement( 'text', 'shortname' );
-        $shortname->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $shortname->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->addValidator( 'alnum' )
             ->addValidator( 'regex', false, array('/^[a-z0-9]+/' ) )
             ->setRequired( true )
@@ -67,7 +67,7 @@ class IXP_Form_Customer extends IXP_Form
         $this->addElement( $shortname  );
 
         $corpwww = $this->createElement( 'text', 'corpwww' );
-        $corpwww->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $corpwww->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'placeholder', 'http://www.example.com/' )
             ->setAttrib( 'class', 'span10' )
@@ -77,7 +77,7 @@ class IXP_Form_Customer extends IXP_Form
         $this->addElement( $corpwww );
 
         $datejoin = $this->createElement( 'text', 'datejoin' );
-        $datejoin->addValidator( 'stringLength', false, array( 10, 10 ) )
+        $datejoin->addValidator( 'stringLength', false, array( 10, 10, 'UTF-8' ) )
             ->addValidator( 'regex', false, array('/^\d\d\d\d-\d\d-\d\d/' ) )
             ->setRequired( false )
             ->setLabel( 'Date Joined' )
@@ -88,7 +88,7 @@ class IXP_Form_Customer extends IXP_Form
         $this->addElement( $datejoin );
 
         $dateleave = $this->createElement( 'text', 'dateleave' );
-        $dateleave->addValidator( 'stringLength', false, array( 10, 10 ) )
+        $dateleave->addValidator( 'stringLength', false, array( 10, 10, 'UTF-8' ) )
             ->addValidator( 'regex', false, array('/^\d\d\d\d-\d\d-\d\d/' ) )
             ->setRequired( false )
             ->setAttrib( 'placeholder', 'YYYY-MM-DD' )
@@ -141,7 +141,7 @@ class IXP_Form_Customer extends IXP_Form
 
         $peeringemail = $this->createElement( 'text', 'peeringemail' );
         $peeringemail->addValidator('emailAddress' )
-            ->addValidator( 'stringLength', false, array( 0, 64 ) )
+            ->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span8' )
             ->setAttrib( 'placeholder', 'peering@example.com' )
@@ -159,7 +159,7 @@ class IXP_Form_Customer extends IXP_Form
 
 
         $peeringmacro = $this->createElement( 'text', 'peeringmacro' );
-        $peeringmacro->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $peeringmacro->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Peering Macro' )
             ->addFilter( 'StringTrim' )
@@ -185,7 +185,7 @@ class IXP_Form_Customer extends IXP_Form
         $this->getDisplayGroup( 'peeringDisplayGroup' )->setLegend( 'Peering Details' );
 
         $nocphone = $this->createElement( 'text', 'nocphone' );
-        $nocphone->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $nocphone->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Phone' )
             ->setAttrib( 'placeholder', '+353 1 123 4567' )
@@ -195,7 +195,7 @@ class IXP_Form_Customer extends IXP_Form
         $this->addElement( $nocphone );
 
         $noc24hphone = $this->createElement( 'text', 'noc24hphone' );
-        $noc24hphone->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $noc24hphone->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'placeholder', '+353 86 876 5432' )
             ->setAttrib( 'class', 'span8' )
@@ -205,7 +205,7 @@ class IXP_Form_Customer extends IXP_Form
         $this->addElement( $noc24hphone );
 
         $nocfax = $this->createElement( 'text', 'nocfax' );
-        $nocfax->addValidator( 'stringLength', false, array( 0, 40 ) )
+        $nocfax->addValidator( 'stringLength', false, array( 0, 40, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Fax' )
             ->setAttrib( 'placeholder', '+353 1 765 4321' )
@@ -216,7 +216,7 @@ class IXP_Form_Customer extends IXP_Form
 
         $nocemail = $this->createElement( 'text', 'nocemail' );
         $nocemail->addValidator('emailAddress' )
-            ->addValidator( 'stringLength', false, array( 0, 40 ) )
+            ->addValidator( 'stringLength', false, array( 0, 40, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span8' )
             ->setAttrib( 'placeholder', 'noc@example.com' )
@@ -233,7 +233,7 @@ class IXP_Form_Customer extends IXP_Form
 
 
         $nocwww = $this->createElement( 'text', 'nocwww' );
-        $nocwww->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $nocwww->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Website' )
             ->setAttrib( 'placeholder', 'http://www.noc.example.com/' )

--- a/library/IXP/Form/Customer/BillingDetails.php
+++ b/library/IXP/Form/Customer/BillingDetails.php
@@ -35,7 +35,7 @@ class IXP_Form_Customer_BillingDetails extends IXP_Form
     public function init()
     {
         $billingContact = $this->createElement( 'text', 'billingContactName' );
-        $billingContact->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingContact->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Contact' )
             ->addFilter( 'StringTrim' )
@@ -45,7 +45,7 @@ class IXP_Form_Customer_BillingDetails extends IXP_Form
         $this->addElement( $billingContact );
 
         $billingAddress1 = $this->createElement( 'text', 'billingAddress1' );
-        $billingAddress1->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingAddress1->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Address' )
             ->setAttrib( 'class', 'span6' )
@@ -55,7 +55,7 @@ class IXP_Form_Customer_BillingDetails extends IXP_Form
         $this->addElement( $billingAddress1 );
 
         $billingAddress2 = $this->createElement( 'text', 'billingAddress2' );
-        $billingAddress2->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingAddress2->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setLabel( '' )
@@ -65,7 +65,7 @@ class IXP_Form_Customer_BillingDetails extends IXP_Form
         $this->addElement( $billingAddress2 );
 
         $billingAddress3 = $this->createElement( 'text', 'billingAddress3' );
-        $billingAddress3->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingAddress3->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setLabel( '' )
@@ -75,7 +75,7 @@ class IXP_Form_Customer_BillingDetails extends IXP_Form
         $this->addElement( $billingAddress3 );
 
         $billingCity = $this->createElement( 'text', 'billingTownCity' );
-        $billingCity->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingCity->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span4' )
             ->setLabel( 'City' )
@@ -85,7 +85,7 @@ class IXP_Form_Customer_BillingDetails extends IXP_Form
         $this->addElement( $billingCity );
 
         $billingPostcode = $this->createElement( 'text', 'billingPostcode' );
-        $billingPostcode->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingPostcode->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span4' )
             ->setLabel( 'Postcode' )
@@ -118,7 +118,7 @@ class IXP_Form_Customer_BillingDetails extends IXP_Form
         $this->addElement( $billingEmail );
 
         $billingTelephone = $this->createElement( 'text', 'billingTelephone' );
-        $billingTelephone->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingTelephone->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setAttrib( 'placeholder', '+353 1 234 5678' )
@@ -131,7 +131,7 @@ class IXP_Form_Customer_BillingDetails extends IXP_Form
         /* Probably do not want to let the customer update this themselves...
 
             $vatNumber = $this->createElement( 'text', 'vatNumber' );
-            $vatNumber->addValidator( 'stringLength', false, array( 0, 64 ) )
+            $vatNumber->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
                 ->setRequired( false )
                 ->setAttrib( 'class', 'span6' )
                 ->setLabel( 'VAT Number' )
@@ -141,7 +141,7 @@ class IXP_Form_Customer_BillingDetails extends IXP_Form
             $this->addElement( $vatNumber );
 
             $vatRate = $this->createElement( 'text', 'vatRate' );
-            $vatRate->addValidator( 'stringLength', false, array( 0, 64 ) )
+            $vatRate->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
                 ->setRequired( false )
                 ->setAttrib( 'class', 'span4' )
                 ->setLabel( 'VAT Rate' )

--- a/library/IXP/Form/Customer/BillingRegistration.php
+++ b/library/IXP/Form/Customer/BillingRegistration.php
@@ -38,7 +38,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->setDecorators( [ [ 'ViewScript', [ 'viewScript' => 'customer/forms/billing-registration.phtml' ] ] ] );
         
         $billingContact = $this->createElement( 'text', 'billingContactName' );
-        $billingContact->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingContact->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Contact' )
             ->addFilter( 'StringTrim' )
@@ -47,7 +47,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $billingContact );
 
         $billingAddress1 = $this->createElement( 'text', 'billingAddress1' );
-        $billingAddress1->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingAddress1->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Address' )
             ->setAttrib( 'class', 'span6' )
@@ -56,7 +56,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $billingAddress1 );
 
         $billingAddress2 = $this->createElement( 'text', 'billingAddress2' );
-        $billingAddress2->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingAddress2->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setLabel( '' )
@@ -65,7 +65,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $billingAddress2 );
 
         $billingAddress3 = $this->createElement( 'text', 'billingAddress3' );
-        $billingAddress3->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingAddress3->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setLabel( '' )
@@ -74,7 +74,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $billingAddress3 );
 
         $billingTownCity = $this->createElement( 'text', 'billingTownCity' );
-        $billingTownCity->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingTownCity->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span4' )
             ->setLabel( 'City' )
@@ -93,7 +93,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $billingCountry );
 
         $billingPostcode = $this->createElement( 'text', 'billingPostcode' );
-        $billingPostcode->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingPostcode->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span4' )
             ->setLabel( 'Postcode' )
@@ -112,7 +112,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $billingEmail );
 
         $billingTelephone = $this->createElement( 'text', 'billingTelephone' );
-        $billingTelephone->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $billingTelephone->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setAttrib( 'placeholder', '+353 1 234 5678' )
@@ -155,7 +155,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $invoiceEmail );
         
         $vatNumber = $this->createElement( 'text', 'vatNumber' );
-        $vatNumber->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $vatNumber->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setLabel( 'VAT Number' )
@@ -164,7 +164,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $vatNumber );
 
         $vatRate = $this->createElement( 'text', 'vatRate' );
-        $vatRate->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $vatRate->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span4' )
             ->setLabel( 'VAT Rate' )
@@ -173,7 +173,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $vatRate );
 
         $registeredName = $this->createElement( 'text', 'registeredName' );
-        $registeredName->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $registeredName->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Registered Name' )
             ->addFilter( 'StringTrim' )
@@ -182,7 +182,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $registeredName );
 
         $companyNumber = $this->createElement( 'text', 'companyNumber' );
-        $companyNumber->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $companyNumber->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Company Number' )
             ->addFilter( 'StringTrim' )
@@ -191,7 +191,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $companyNumber );
 
         $jurisdiction = new OSS_Form_Element_DatabaseDropdown( 'jurisdiction', [ 'dql' => 'select crd.jurisdiction from \\Entities\\CompanyRegisteredDetail crd WHERE crd.jurisdiction IS NOT NULL' ] );
-        $jurisdiction->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $jurisdiction->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Jurisdiction' )
             ->addFilter( 'StringTrim' )
@@ -199,7 +199,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $jurisdiction );
 
         $address1 = $this->createElement( 'text', 'address1' );
-        $address1->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $address1->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Address' )
             ->setAttrib( 'class', 'span6' )
@@ -208,7 +208,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $address1 );
 
         $address2 = $this->createElement( 'text', 'address2' );
-        $address2->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $address2->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setLabel( '' )
@@ -217,7 +217,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $address2 );
 
         $address3 = $this->createElement( 'text', 'address3' );
-        $address3->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $address3->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setLabel( '' )
@@ -226,7 +226,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $address3 );
 
         $townCity = $this->createElement( 'text', 'townCity' );
-        $townCity->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $townCity->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span4' )
             ->setLabel( 'City' )
@@ -245,7 +245,7 @@ class IXP_Form_Customer_BillingRegistration extends IXP_Form
         $this->addElement( $country );
 
         $postcode = $this->createElement( 'text', 'postcode' );
-        $postcode->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $postcode->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span4' )
             ->setLabel( 'Postcode' )

--- a/library/IXP/Form/Customer/NocDetails.php
+++ b/library/IXP/Form/Customer/NocDetails.php
@@ -37,7 +37,7 @@ class IXP_Form_Customer_NocDetails extends IXP_Form
     public function init()
     {
         $nocphone = $this->createElement( 'text', 'nocphone' );
-        $nocphone->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $nocphone->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Phone' )
             ->setAttrib( 'placeholder', '+353 1 123 4567' )
@@ -48,7 +48,7 @@ class IXP_Form_Customer_NocDetails extends IXP_Form
         $this->addElement( $nocphone );
 
         $noc24hphone = $this->createElement( 'text', 'noc24hphone' );
-        $noc24hphone->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $noc24hphone->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'placeholder', '+353 86 876 5432' )
             ->setAttrib( 'class', 'span4' )
@@ -59,7 +59,7 @@ class IXP_Form_Customer_NocDetails extends IXP_Form
         $this->addElement( $noc24hphone );
 
         $nocfax = $this->createElement( 'text', 'nocfax' );
-        $nocfax->addValidator( 'stringLength', false, array( 0, 40 ) )
+        $nocfax->addValidator( 'stringLength', false, array( 0, 40, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Fax' )
             ->setAttrib( 'placeholder', '+353 1 765 4321' )
@@ -71,7 +71,7 @@ class IXP_Form_Customer_NocDetails extends IXP_Form
 
         $nocemail = $this->createElement( 'text', 'nocemail' );
         $nocemail->addValidator('emailAddress' )
-            ->addValidator( 'stringLength', false, array( 0, 40 ) )
+            ->addValidator( 'stringLength', false, array( 0, 40, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setAttrib( 'placeholder', 'noc@example.com' )
@@ -91,7 +91,7 @@ class IXP_Form_Customer_NocDetails extends IXP_Form
 
 
         $nocwww = $this->createElement( 'text', 'nocwww' );
-        $nocwww->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $nocwww->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Website' )
             ->setAttrib( 'placeholder', 'http://www.noc.example.com/' )

--- a/library/IXP/Form/Customer/Notes.php
+++ b/library/IXP/Form/Customer/Notes.php
@@ -42,7 +42,7 @@ class IXP_Form_Customer_Notes extends IXP_Form
         $this->addElement( $noteid );
 
         $title = $this->createElement( 'text', 'title' );
-        $title->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $title->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Title' )
             ->addFilter( 'StringTrim' )

--- a/library/IXP/Form/Customer/SendEmail.php
+++ b/library/IXP/Form/Customer/SendEmail.php
@@ -41,7 +41,7 @@ class IXP_Form_Customer_SendEmail extends IXP_Form
         $this->setDecorators( [ [ 'ViewScript', [ 'viewScript' => 'customer/forms/send-email.phtml' ] ] ] );
 
         $to = $this->createElement( 'text', 'to', [ 'size' => 100 ] );
-        $to->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $to->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'To' )
             ->setAttrib( 'class', 'span9' )
@@ -50,7 +50,7 @@ class IXP_Form_Customer_SendEmail extends IXP_Form
         $this->addElement( $to );
 
         $cc = $this->createElement( 'text', 'cc', [ 'size' => 100 ] );
-        $cc->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $cc->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'CC' )
             ->setAttrib( 'class', 'span9' )
@@ -59,7 +59,7 @@ class IXP_Form_Customer_SendEmail extends IXP_Form
         $this->addElement( $cc );
 
         $bcc = $this->createElement( 'text', 'bcc', [ 'size' => 100 ] );
-        $bcc->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $bcc->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'BCC' )
             ->setAttrib( 'class', 'span9' )
@@ -68,7 +68,7 @@ class IXP_Form_Customer_SendEmail extends IXP_Form
         $this->addElement( $bcc );
 
         $subject = $this->createElement( 'text', 'subject', [ 'size' => 100 ] );
-        $subject->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $subject->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Subject' )
             ->setAttrib( 'class', 'span9' )
@@ -78,7 +78,7 @@ class IXP_Form_Customer_SendEmail extends IXP_Form
 
 
         $message = $this->createElement( 'textarea', 'message', [ 'cols' => 80, 'rows' => 20 ] );
-        $message->addValidator( 'stringLength', false, array( 1, 40960 ) )
+        $message->addValidator( 'stringLength', false, array( 1, 40960, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Message' )
             ->setAttrib( 'class', 'span9' )

--- a/library/IXP/Form/IXP.php
+++ b/library/IXP/Form/IXP.php
@@ -37,7 +37,7 @@ class IXP_Form_IXP extends IXP_Form
     {
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Name' )
             ->addFilter( 'StringTrim' )
@@ -45,7 +45,7 @@ class IXP_Form_IXP extends IXP_Form
         $this->addElement( $name  );
 
         $shortname = $this->createElement( 'text', 'shortname' );
-        $shortname->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $shortname->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->addValidator( 'alnum' )
             ->setRequired( true )
             ->setLabel( 'Shortname' )
@@ -53,7 +53,7 @@ class IXP_Form_IXP extends IXP_Form
         $this->addElement( $shortname  );
 
         $address1 = $this->createElement( 'text', 'address1' );
-        $address1->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $address1->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Address' )
             ->addFilter( 'StringTrim' )
@@ -61,7 +61,7 @@ class IXP_Form_IXP extends IXP_Form
         $this->addElement( $address1 );
 
         $address2 = $this->createElement( 'text', 'address2' );
-        $address2->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $address2->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( '' )
             ->addFilter( 'StringTrim' )
@@ -69,7 +69,7 @@ class IXP_Form_IXP extends IXP_Form
         $this->addElement( $address2 );
 
         $address3 = $this->createElement( 'text', 'address3' );
-        $address3->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $address3->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( '' )
             ->addFilter( 'StringTrim' )
@@ -77,7 +77,7 @@ class IXP_Form_IXP extends IXP_Form
         $this->addElement( $address3 );
 
         $address4 = $this->createElement( 'text', 'address4' );
-        $address4->addValidator( 'stringLength', false, array( 0, 64 ) )
+        $address4->addValidator( 'stringLength', false, array( 0, 64, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( '' )
             ->addFilter( 'StringTrim' )
@@ -95,7 +95,7 @@ class IXP_Form_IXP extends IXP_Form
         $this->addElement( $country );
 
         $mrtgPath = $this->createElement( 'text', 'mrtg_path' );
-        $mrtgPath->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $mrtgPath->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'MRTG Path' )
             ->addFilter( 'StringTrim' )
@@ -103,7 +103,7 @@ class IXP_Form_IXP extends IXP_Form
         $this->addElement( $mrtgPath  );
         
         $p2pPath = $this->createElement( 'text', 'mrtg_p2p_path' );
-        $p2pPath->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $p2pPath->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'MRTG P2P Path' )
             ->addFilter( 'StringTrim' )
@@ -113,7 +113,7 @@ class IXP_Form_IXP extends IXP_Form
         $this->addElement( self::createAggregateGraphNameElement() );
         
         $smokeping = $this->createElement( 'text', 'smokeping' );
-        $smokeping->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $smokeping->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Smokeping URL' )
             ->addFilter( 'StringTrim' )

--- a/library/IXP/Form/Infrastructure.php
+++ b/library/IXP/Form/Infrastructure.php
@@ -38,7 +38,7 @@ class IXP_Form_Infrastructure extends IXP_Form
         $this->setDecorators( [ [ 'ViewScript', [ 'viewScript' => 'infrastructure/forms/edit.phtml' ] ] ] );
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Name' )
             ->addFilter( 'StringTrim' )
@@ -46,7 +46,7 @@ class IXP_Form_Infrastructure extends IXP_Form
         $this->addElement( $name  );
 
         $shortname = $this->createElement( 'text', 'shortname' );
-        $shortname->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $shortname->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Short Name' )
             ->addFilter( 'StringToLower' )

--- a/library/IXP/Form/Interface/AddWizard.php
+++ b/library/IXP/Form/Interface/AddWizard.php
@@ -44,7 +44,7 @@ class IXP_Form_Interface_AddWizard extends IXP_Form
         // VIRTUAL INTERFACE DETAILS
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Virtual Interface Name' )
             ->addFilter( 'StringTrim' )
@@ -54,7 +54,7 @@ class IXP_Form_Interface_AddWizard extends IXP_Form
 
         $descr = $this->createElement( 'text', 'description' );
         $descr->setLabel( 'Description' )
-            ->addValidator( 'stringLength', false, array( 0, 255 ) )
+            ->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->addFilter( new OSS_Filter_StripSlashes() )
             ->addFilter( 'StringTrim' );
@@ -161,14 +161,14 @@ class IXP_Form_Interface_AddWizard extends IXP_Form
         $this->addElement( $ipv4addressid );
 
         $ipv4hostname = $this->createElement( 'text', 'ipv4hostname' );
-        $ipv4hostname->addValidator( 'stringLength', false, array( 1, 64 ) )
+        $ipv4hostname->addValidator( 'stringLength', false, array( 1, 64, 'UTF-8' ) )
             ->setLabel( 'IPv4 Hostname' )
             ->addFilter( 'StringTrim' )
             ->addFilter( new OSS_Filter_StripSlashes() );
         $this->addElement( $ipv4hostname  );
 
         $ipv4bgpmd5secret = $this->createElement( 'text', 'ipv4bgpmd5secret' );
-        $ipv4bgpmd5secret->addValidator( 'stringLength', false, array( 1, 64 ) )
+        $ipv4bgpmd5secret->addValidator( 'stringLength', false, array( 1, 64, 'UTF-8' ) )
             ->setLabel( 'IPv4 BGP MD5 Secret' )
             ->setAttrib( 'class', 'span10' )
             ->addFilter( 'StringTrim' )
@@ -209,14 +209,14 @@ class IXP_Form_Interface_AddWizard extends IXP_Form
         $this->addElement( $ipv6addressid );
 
         $ipv6hostname = $this->createElement( 'text', 'ipv6hostname' );
-        $ipv6hostname->addValidator( 'stringLength', false, array( 1, 64 ) )
+        $ipv6hostname->addValidator( 'stringLength', false, array( 1, 64, 'UTF-8' ) )
             ->setLabel( 'IPv6 Hostname' )
             ->addFilter( 'StringTrim' )
             ->addFilter( new OSS_Filter_StripSlashes() );
         $this->addElement( $ipv6hostname  );
 
         $ipv6bgpmd5secret = $this->createElement( 'text', 'ipv6bgpmd5secret' );
-        $ipv6bgpmd5secret->addValidator( 'stringLength', false, array( 1, 64 ) )
+        $ipv6bgpmd5secret->addValidator( 'stringLength', false, array( 1, 64, 'UTF-8' ) )
             ->setLabel( 'IPv6 BGP MD5 Secret' )
             ->setAttrib( 'class', 'span10' )
             ->addFilter( 'StringTrim' )

--- a/library/IXP/Form/Interface/Virtual.php
+++ b/library/IXP/Form/Interface/Virtual.php
@@ -42,7 +42,7 @@ class IXP_Form_Interface_Virtual extends IXP_Form
         $this->getElement( 'custid' )->setAttrib( 'class', 'chzn-select span8' );
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Virtual Interface Name' )
             ->addFilter( 'StringTrim' )
@@ -52,7 +52,7 @@ class IXP_Form_Interface_Virtual extends IXP_Form
 
         $descr = $this->createElement( 'text', 'description' );
         $descr->setLabel( 'Description' )
-            ->addValidator( 'stringLength', false, array( 0, 255 ) )
+            ->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->addFilter( new OSS_Filter_StripSlashes() )
             ->addFilter( 'StringTrim' );

--- a/library/IXP/Form/Interface/Vlan.php
+++ b/library/IXP/Form/Interface/Vlan.php
@@ -60,14 +60,14 @@ class IXP_Form_Interface_Vlan extends IXP_Form
         $this->addElement( $ipv4addressid );
 
         $ipv4hostname = $this->createElement( 'text', 'ipv4hostname' );
-        $ipv4hostname->addValidator( 'stringLength', false, array( 1, 64 ) )
+        $ipv4hostname->addValidator( 'stringLength', false, array( 1, 64, 'UTF-8' ) )
             ->setLabel( 'IPv4 Hostname' )
             ->addFilter( 'StringTrim' )
             ->addFilter( new OSS_Filter_StripSlashes() );
         $this->addElement( $ipv4hostname  );
 
         $ipv4bgpmd5secret = $this->createElement( 'text', 'ipv4bgpmd5secret' );
-        $ipv4bgpmd5secret->addValidator( 'stringLength', false, array( 1, 64 ) )
+        $ipv4bgpmd5secret->addValidator( 'stringLength', false, array( 1, 64, 'UTF-8' ) )
             ->setLabel( 'IPv4 BGP MD5 Secret' )
             ->addFilter( 'StringTrim' )
             ->addFilter( new OSS_Filter_StripSlashes() );
@@ -105,14 +105,14 @@ class IXP_Form_Interface_Vlan extends IXP_Form
         $this->addElement( $ipv6addressid );
 
         $ipv6hostname = $this->createElement( 'text', 'ipv6hostname' );
-        $ipv6hostname->addValidator( 'stringLength', false, array( 1, 64 ) )
+        $ipv6hostname->addValidator( 'stringLength', false, array( 1, 64, 'UTF-8' ) )
             ->setLabel( 'IPv6 Hostname' )
             ->addFilter( 'StringTrim' )
             ->addFilter( new OSS_Filter_StripSlashes() );
         $this->addElement( $ipv6hostname  );
 
         $ipv6bgpmd5secret = $this->createElement( 'text', 'ipv6bgpmd5secret' );
-        $ipv6bgpmd5secret->addValidator( 'stringLength', false, array( 1, 64 ) )
+        $ipv6bgpmd5secret->addValidator( 'stringLength', false, array( 1, 64, 'UTF-8' ) )
             ->setLabel( 'IPv6 BGP MD5 Secret' )
             ->addFilter( 'StringTrim' )
             ->addFilter( new OSS_Filter_StripSlashes() );

--- a/library/IXP/Form/IrrdbConfig.php
+++ b/library/IXP/Form/IrrdbConfig.php
@@ -36,7 +36,7 @@ class IXP_Form_IrrdbConfig extends IXP_Form
     public function init()
     {
         $host = $this->createElement( 'text', 'host' );
-        $host->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $host->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Host' )
             ->setAttrib( 'class', 'span3' )
@@ -45,7 +45,7 @@ class IXP_Form_IrrdbConfig extends IXP_Form
         $this->addElement( $host );
 
         $protocol = $this->createElement( 'text', 'protocol' );
-        $protocol->addValidator( 'stringLength', false, array( 1, 10 ) )
+        $protocol->addValidator( 'stringLength', false, array( 1, 10, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Protocol' )
             ->setAttrib( 'class', 'span3' )
@@ -54,7 +54,7 @@ class IXP_Form_IrrdbConfig extends IXP_Form
         $this->addElement( $protocol );
 
         $source = $this->createElement( 'text', 'source' );
-        $source->addValidator( 'stringLength', false, array( 1, 50 ) )
+        $source->addValidator( 'stringLength', false, array( 1, 50, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Source' )
             ->setAttrib( 'class', 'span3' )

--- a/library/IXP/Form/Location.php
+++ b/library/IXP/Form/Location.php
@@ -36,7 +36,7 @@ class IXP_Form_Location extends IXP_Form
     public function init()
     {
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( true )
             ->setLabel( 'Name' )
@@ -46,7 +46,7 @@ class IXP_Form_Location extends IXP_Form
 
 
     $shortname = $this->createElement( 'text', 'shortname' );
-    $shortname->addValidator( 'stringLength', false, array( 1, 255 ) )
+    $shortname->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
         ->setAttrib( 'class', 'span3' )
         ->setRequired( true )
         ->setLabel( 'Short Name' )
@@ -55,7 +55,7 @@ class IXP_Form_Location extends IXP_Form
     $this->addElement( $shortname );
 
     $tag = $this->createElement( 'text', 'tag' );
-    $tag->addValidator( 'stringLength', false, array( 1, 255 ) )
+    $tag->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
         ->setAttrib( 'class', 'span3' )
         ->setRequired( true )
         ->setLabel( 'Tag' )
@@ -64,7 +64,7 @@ class IXP_Form_Location extends IXP_Form
     $this->addElement( $tag );
 
         $address = $this->createElement( 'textarea', 'address' );
-        $address->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $address->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setLabel( 'Address' )
             ->addFilter( new OSS_Filter_StripSlashes() )
             ->setAttrib( 'cols', 60 )
@@ -73,7 +73,7 @@ class IXP_Form_Location extends IXP_Form
         $this->addElement( $address );
 
         $nocphone = $this->createElement( 'text', 'nocphone' );
-        $nocphone->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $nocphone->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( false )
             ->setLabel( 'Phone' )
@@ -82,7 +82,7 @@ class IXP_Form_Location extends IXP_Form
         $this->addElement( $nocphone );
 
         $nocfax = $this->createElement( 'text', 'nocfax' );
-        $nocfax->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $nocfax->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( false )
             ->setLabel( 'Fax' )
@@ -93,7 +93,7 @@ class IXP_Form_Location extends IXP_Form
         $nocemail = $this->createElement( 'text', 'nocemail' );
         $nocemail->addValidator('emailAddress' )
             ->setAttrib( 'class', 'span3' )
-            ->addValidator( 'stringLength', false, array( 0, 255 ) )
+            ->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'E-Mail' );
         $this->addElement( $nocemail );
@@ -106,7 +106,7 @@ class IXP_Form_Location extends IXP_Form
         $this->getDisplayGroup( 'nocDisplayGroup' )->setLegend( 'NOC Details' );
 
         $officephone = $this->createElement( 'text', 'officephone' );
-        $officephone->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $officephone->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( false )
             ->setLabel( 'Phone' )
@@ -115,7 +115,7 @@ class IXP_Form_Location extends IXP_Form
         $this->addElement( $officephone );
 
         $officefax = $this->createElement( 'text', 'officefax' );
-        $officefax->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $officefax->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( false )
             ->setLabel( 'Fax' )
@@ -126,7 +126,7 @@ class IXP_Form_Location extends IXP_Form
         $officeemail = $this->createElement( 'text', 'officeemail' );
         $officeemail->addValidator('emailAddress' )
             ->setAttrib( 'class', 'span3' )
-            ->addValidator( 'stringLength', false, array( 0, 255 ) )
+            ->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'E-Mail' );
         $this->addElement( $officeemail );

--- a/library/IXP/Form/Meeting.php
+++ b/library/IXP/Form/Meeting.php
@@ -37,7 +37,7 @@ class IXP_Form_Meeting extends IXP_Form
     {
 
         $title = $this->createElement( 'text', 'title', array( 'size' => '100' ) );
-        $title->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $title->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Title' )
             ->setValue( 'Members\' Meeting' )
@@ -66,7 +66,7 @@ class IXP_Form_Meeting extends IXP_Form
         $this->addElement( $after_text );
 
         $date = $this->createElement( 'text', 'date' );
-        $date->addValidator( 'stringLength', false, array( 10, 10 ) )
+        $date->addValidator( 'stringLength', false, array( 10, 10, 'UTF-8' ) )
             ->addValidator( 'regex', false, array('/^\d\d\d\d-\d\d-\d\d/' ) )
             ->setRequired( true )
             ->setLabel( 'Date' )
@@ -75,7 +75,7 @@ class IXP_Form_Meeting extends IXP_Form
         $this->addElement( $date );
 
         $time = $this->createElement( 'text', 'time' );
-        $time->addValidator( 'stringLength', false, array( 5, 8 ) )
+        $time->addValidator( 'stringLength', false, array( 5, 8, 'UTF-8' ) )
             ->addValidator( 'regex', false, array('/^\d\d:\d\d(:\d\d){0,1}/' ) )
             ->setRequired( true )
             ->setValue( 'HH:MM' )
@@ -84,7 +84,7 @@ class IXP_Form_Meeting extends IXP_Form
         $this->addElement( $time );
 
         $venue = $this->createElement( 'text', 'venue', array( 'size' => '100' ) );
-        $venue->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $venue->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Venue' )
             ->addFilter( 'StringTrim' )
@@ -93,7 +93,7 @@ class IXP_Form_Meeting extends IXP_Form
         $this->addElement( $venue );
 
         $venue_url = $this->createElement( 'text', 'venue_url', array( 'size' => '100' ) );
-        $venue_url->addValidator( 'stringLength', false, array( 0, 255 ) )
+        $venue_url->addValidator( 'stringLength', false, array( 0, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Venue URL' )
             ->addFilter( 'StringTrim' )

--- a/library/IXP/Form/Meeting/Item.php
+++ b/library/IXP/Form/Meeting/Item.php
@@ -39,7 +39,7 @@ class IXP_Form_Meeting_Item extends IXP_Form
         $this->getElement( 'meeting_id' )->setAttrib( 'class', 'chzn-select span6' );
         
         $title = $this->createElement( 'text', 'title', array( 'size' => '100' ) );
-        $title->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $title->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Title' )
             ->setAttrib( 'class', 'span6' )
@@ -48,7 +48,7 @@ class IXP_Form_Meeting_Item extends IXP_Form
         $this->addElement( $title );
 
         $name = $this->createElement( 'text', 'name', array( 'size' => '100' ) );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setAttrib( 'class', 'span6' )
             ->setLabel( 'Name' )
@@ -57,7 +57,7 @@ class IXP_Form_Meeting_Item extends IXP_Form
         $this->addElement( $name );
 
         $role = $this->createElement( 'text', 'role', array( 'size' => '100' ) );
-        $role->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $role->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setAttrib( 'class', 'span6' )
             ->setLabel( 'Role' )
@@ -66,7 +66,7 @@ class IXP_Form_Meeting_Item extends IXP_Form
         $this->addElement( $role );
 
         $email = $this->createElement( 'text', 'email', array( 'size' => '100' ) );
-        $email->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $email->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'E-Mail' )
             ->setAttrib( 'class', 'span6' )
@@ -75,7 +75,7 @@ class IXP_Form_Meeting_Item extends IXP_Form
         $this->addElement( $email );
 
         $company = $this->createElement( 'text', 'company', array( 'size' => '100' ) );
-        $company->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $company->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Company' )
             ->setAttrib( 'class', 'span6' )
@@ -84,7 +84,7 @@ class IXP_Form_Meeting_Item extends IXP_Form
         $this->addElement( $company );
 
         $company_url = $this->createElement( 'text', 'company_url', array( 'size' => '100' ) );
-        $company_url->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $company_url->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Company URL' )
             ->setAttrib( 'class', 'span6' )
@@ -109,7 +109,7 @@ class IXP_Form_Meeting_Item extends IXP_Form
         $this->addElement( $presentation );
 
         $video_url = $this->createElement( 'text', 'video_url', array( 'size' => '100' ) );
-        $video_url->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $video_url->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'Video' )
             ->setAttrib( 'class', 'span6' )

--- a/library/IXP/Form/PeeringRequest.php
+++ b/library/IXP/Form/PeeringRequest.php
@@ -57,7 +57,7 @@ class IXP_Form_PeeringRequest extends IXP_Form
 
 
         $to = $this->createElement( 'text', 'to' );
-        $to->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $to->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'To' )
             ->setAttrib( 'class', 'span5' )
@@ -69,7 +69,7 @@ class IXP_Form_PeeringRequest extends IXP_Form
         $this->addElement( $to );
 
         $cc = $this->createElement( 'text', 'cc' );
-        $cc->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $cc->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'CC' )
             ->setAttrib( 'class', 'span5' )
@@ -81,7 +81,7 @@ class IXP_Form_PeeringRequest extends IXP_Form
         $this->addElement( $cc );
 
         $bcc = $this->createElement( 'text', 'bcc' );
-        $bcc->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $bcc->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'BCC' )
             ->setAttrib( 'class', 'span5' )
@@ -92,7 +92,7 @@ class IXP_Form_PeeringRequest extends IXP_Form
         $this->addElement( $bcc );
 
         $subject = $this->createElement( 'text', 'subject' );
-        $subject->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $subject->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Subject' )
             ->setAttrib( 'class', 'span5' )
@@ -107,7 +107,7 @@ class IXP_Form_PeeringRequest extends IXP_Form
             [ 'cols' => 50, 'rows' => 8 ]
         );
 
-        $message->addValidator( 'stringLength', false, array( 1, 40960 ) )
+        $message->addValidator( 'stringLength', false, array( 1, 40960, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Message' )
             ->setAttrib( 'class', 'span5 mono' )

--- a/library/IXP/Form/Profile.php
+++ b/library/IXP/Form/Profile.php
@@ -42,7 +42,7 @@ class IXP_Form_Profile extends IXP_Form
             ->setAction( OSS_Utils::genUrl( 'profile', 'change-profile' ) );
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Name' )
             ->setAttrib( 'class', 'span6' )
@@ -52,7 +52,7 @@ class IXP_Form_Profile extends IXP_Form
         $this->addElement( $name );
 
         $position = $this->createElement( 'text', 'position' );
-        $position->addValidator( 'stringLength', false, array( 1, 50 ) )
+        $position->addValidator( 'stringLength', false, array( 1, 50, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Position' )
             ->setAttrib( 'class', 'span6' )
@@ -70,7 +70,7 @@ class IXP_Form_Profile extends IXP_Form
         $this->addElement( $mobile );
 
         $phone = $this->createElement( 'text', 'phone' );
-        $phone->addValidator( 'stringLength', false, array( 1, 32 ) )
+        $phone->addValidator( 'stringLength', false, array( 1, 32, 'UTF-8' ) )
             ->setLabel( _( 'Phone' ) )
             ->setAttrib( 'class', 'span6' )
             ->addFilter( 'StringTrim' )

--- a/library/IXP/Form/Provision/InterfaceEmail.php
+++ b/library/IXP/Form/Provision/InterfaceEmail.php
@@ -56,7 +56,7 @@ class IXP_Form_Provision_InterfaceEmail extends Zend_Form
                 'size' => 100
             )
         );
-        $to->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $to->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'To' )
             ->addFilter( 'StringTrim' )
@@ -70,7 +70,7 @@ class IXP_Form_Provision_InterfaceEmail extends Zend_Form
             )
         );
 
-        $cc->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $cc->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'CC' )
             ->addFilter( 'StringTrim' )
@@ -84,7 +84,7 @@ class IXP_Form_Provision_InterfaceEmail extends Zend_Form
             )
         );
 
-        $bcc->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $bcc->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( false )
             ->setLabel( 'BCC' )
             ->addFilter( 'StringTrim' )
@@ -98,7 +98,7 @@ class IXP_Form_Provision_InterfaceEmail extends Zend_Form
             )
         );
 
-        $subject->addValidator( 'stringLength', false, array( 1, 4096 ) )
+        $subject->addValidator( 'stringLength', false, array( 1, 4096, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Subject' )
             ->addFilter( 'StringTrim' )
@@ -115,7 +115,7 @@ class IXP_Form_Provision_InterfaceEmail extends Zend_Form
             )
         );
 
-        $message->addValidator( 'stringLength', false, array( 1, 40960 ) )
+        $message->addValidator( 'stringLength', false, array( 1, 40960, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Message' )
             ->addFilter( 'StringTrim' )

--- a/library/IXP/Form/SubForm/PatchPanel.php
+++ b/library/IXP/Form/SubForm/PatchPanel.php
@@ -56,7 +56,7 @@ class IXP_Form_SubForm_PatchPanel extends IXP_Form_SubForm
         ////////////////////////////////////////////////
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib('size', 50 )
             ->setAttrib('maxlength', 255)
             ->setRequired( true )
@@ -93,7 +93,7 @@ class IXP_Form_SubForm_PatchPanel extends IXP_Form_SubForm
 
 
         $colo_ref = $this->createElement( 'text', 'colo_ref' );
-        $colo_ref->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $colo_ref->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib('size', 40 )
             ->setAttrib('maxlength', 255)
             ->setRequired( true )

--- a/library/IXP/Form/SubForm/PatchPanelPort.php
+++ b/library/IXP/Form/SubForm/PatchPanelPort.php
@@ -63,7 +63,7 @@ class IXP_Form_SubForm_PatchPanelPort extends IXP_Form_SubForm
         $this->addElement( $side );
 
         $colo_ref = $this->createElement( 'text', 'colo_ref' );
-        $colo_ref->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $colo_ref->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib('size', 40 )
             ->setAttrib('maxlength', 255)
             ->setRequired( true )

--- a/library/IXP/Form/Switch.php
+++ b/library/IXP/Form/Switch.php
@@ -37,7 +37,7 @@ class IXP_Form_Switch extends IXP_Form
     {
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( true )
             ->setLabel( 'Name' )
@@ -46,7 +46,7 @@ class IXP_Form_Switch extends IXP_Form
         $this->addElement( $name );
 
         $hostname = $this->createElement( 'text', 'hostname' );
-        $hostname->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $hostname->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( true )
             ->setLabel( 'Hostname' )
@@ -69,7 +69,7 @@ class IXP_Form_Switch extends IXP_Form
         $this->addElement( $infrastructure );
 
         $ipv4addr = $this->createElement( 'text', 'ipv4addr' );
-        $ipv4addr->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $ipv4addr->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( true )
             ->setLabel( 'IPv4 Address' )
@@ -78,7 +78,7 @@ class IXP_Form_Switch extends IXP_Form
         $this->addElement( $ipv4addr );
 
         $ipv6addr = $this->createElement( 'text', 'ipv6addr' );
-        $ipv6addr->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $ipv6addr->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setLabel( 'IPv6 Address' )
             ->addFilter( 'StringTrim' )
@@ -86,7 +86,7 @@ class IXP_Form_Switch extends IXP_Form
         $this->addElement( $ipv6addr );
 
         $snmppasswd = $this->createElement( 'text', 'snmppasswd' );
-        $snmppasswd->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $snmppasswd->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setLabel( 'SNMP Community' )
             ->addFilter( 'StringTrim' )
@@ -97,7 +97,7 @@ class IXP_Form_Switch extends IXP_Form
         
 
         $model = $this->createElement( 'text', 'model' );
-        $model->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $model->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setLabel( 'Model' )
             ->setAttrib( 'class', 'span3' )
             ->addFilter( 'StringTrim' )

--- a/library/IXP/Form/Switch/AddBySNMP.php
+++ b/library/IXP/Form/Switch/AddBySNMP.php
@@ -37,7 +37,7 @@ class IXP_Form_Switch_AddBySNMP extends IXP_Form
     {
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( true )
             ->setLabel( 'Name' )
@@ -46,7 +46,7 @@ class IXP_Form_Switch_AddBySNMP extends IXP_Form
         $this->addElement( $name );
 
         $hostname = $this->createElement( 'text', 'hostname' );
-        $hostname->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $hostname->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setRequired( true )
             ->setLabel( 'Hostname' )
@@ -69,7 +69,7 @@ class IXP_Form_Switch_AddBySNMP extends IXP_Form
         $this->addElement( $infrastructure );
 
         $snmppasswd = $this->createElement( 'text', 'snmppasswd' );
-        $snmppasswd->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $snmppasswd->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setAttrib( 'class', 'span3' )
             ->setLabel( 'SNMP Community' )
             ->addFilter( 'StringTrim' )

--- a/library/IXP/Form/User.php
+++ b/library/IXP/Form/User.php
@@ -41,7 +41,7 @@ class IXP_Form_User extends IXP_Form
 
         // let's capture the user's name and add them to the contact table also
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 2, 64 ) )
+        $name->addValidator( 'stringLength', false, array( 2, 64, 'UTF-8' ) )
             ->setRequired( true )
             ->setAttrib( 'size', 50 )
             ->setAttrib( 'class', 'span3' )
@@ -56,7 +56,7 @@ class IXP_Form_User extends IXP_Form
 
         $username = OSS_Form_Auth::createUsernameElement();
 
-        $username->addValidator( 'stringLength', false, array( 2, 30 ) )
+        $username->addValidator( 'stringLength', false, array( 2, 30, 'UTF-8' ) )
             ->addValidator( 'regex', true, array( '/^[a-zA-Z0-9\-_\.]+$/' ) );
 
         $this->addElement( $username );
@@ -65,7 +65,7 @@ class IXP_Form_User extends IXP_Form
 
 
         $password = $this->createElement( 'text', 'password' );
-        $password->addValidator( 'stringLength', false, array( 8, 30 ) )
+        $password->addValidator( 'stringLength', false, array( 8, 30, 'UTF-8' ) )
             ->setRequired( true )
             ->setAttrib( 'class', 'span3' )
             ->setLabel( 'Password' )
@@ -113,7 +113,7 @@ class IXP_Form_User extends IXP_Form
     {
         $mobile = new Zend_Form_Element_Text( $name );
 
-        $mobile->addValidator( 'stringLength', false, array( 0, 30 ) )
+        $mobile->addValidator( 'stringLength', false, array( 0, 30, 'UTF-8' ) )
                ->setRequired( false )
                ->setLabel( 'Mobile' )
                ->setAttrib( 'placeholder', '+353 86 123 4567' )

--- a/library/IXP/Form/Vendor.php
+++ b/library/IXP/Form/Vendor.php
@@ -36,7 +36,7 @@ class IXP_Form_Vendor extends IXP_Form
     public function init()
     {
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setAttrib( 'class', 'span3' )
             ->setLabel( 'Name' )
@@ -46,7 +46,7 @@ class IXP_Form_Vendor extends IXP_Form
         $this->addElement( $name );
 
         $shortname = $this->createElement( 'text', 'shortname' );
-        $shortname->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $shortname->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setAttrib( 'class', 'span3' )
             ->setLabel( 'Short Name' )
@@ -56,7 +56,7 @@ class IXP_Form_Vendor extends IXP_Form
         $this->addElement( $shortname );
 
         $nagios_name = $this->createElement( 'text', 'nagios_name' );
-        $nagios_name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $nagios_name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setAttrib( 'class', 'span3' )
             ->setLabel( 'Nagios Name' )

--- a/library/IXP/Form/Vlan.php
+++ b/library/IXP/Form/Vlan.php
@@ -37,7 +37,7 @@ class IXP_Form_VLAN extends IXP_Form
     {
 
         $name = $this->createElement( 'text', 'name' );
-        $name->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $name->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setRequired( true )
             ->setLabel( 'Name' )
             ->setAttrib( 'class', 'span3' )
@@ -62,7 +62,7 @@ class IXP_Form_VLAN extends IXP_Form
         $this->addElement( $infrastructure );
 
         $rcvrfname = $this->createElement( 'text', 'rcvrfname' );
-        $rcvrfname->addValidator( 'stringLength', false, array( 1, 255 ) )
+        $rcvrfname->addValidator( 'stringLength', false, array( 1, 255, 'UTF-8' ) )
             ->setLabel( 'RC VRF Name' )
             ->addFilter( 'StringTrim' )
             ->setAttrib( 'class', 'span3' )


### PR DESCRIPTION
See #213 for details. If this turns out to be the way to go, I will force-change this commit to add the 'UTF-8' parameter to all addValidator("stringLength") calls.