### PR TITLE
Fix exception when BillingFrequency or InvoiceMethod is empty

### DIFF
--- a/application/views/customer/overview-tabs/details.phtml
+++ b/application/views/customer/overview-tabs/details.phtml
@@ -51,8 +51,10 @@
             <tr>
                 <th>Billing Period</th>
                 <td>
-                    {if isset( BillingDetails::$BILLING_FREQUENCIES[$bdetails->getBillingFrequency()] )}
-                        {BillingDetails::$BILLING_FREQUENCIES[$bdetails->getBillingFrequency()]}
+                    {if $bdetails->getBillingFrequency() != ''}
+                      {if isset( BillingDetails::$BILLING_FREQUENCIES[$bdetails->getBillingFrequency()] )}
+                          {BillingDetails::$BILLING_FREQUENCIES[$bdetails->getBillingFrequency()]}
+                      {/if}
                     {/if}
                 </td>
             </tr>
@@ -85,8 +87,10 @@
             <tr>
                 <th>Invoice Method</th>
                 <td>
-                    {if isset( BillingDetails::$INVOICE_METHODS[$bdetails->getInvoiceMethod()] )}
-                        {BillingDetails::$INVOICE_METHODS[$bdetails->getInvoiceMethod()]}
+                    {if $bdetails->getInvoiceMethod() != ''}
+                      {if isset( BillingDetails::$INVOICE_METHODS[$bdetails->getInvoiceMethod()] )}
+                          {BillingDetails::$INVOICE_METHODS[$bdetails->getInvoiceMethod()]}
+                      {/if}
                     {/if}
                 </td>
             </tr>


### PR DESCRIPTION
When getBillingFrequency or getInvoiceMethod for a client is the
empty string (example database includes some clients with those
two db fields empty), the application/views/customer/
overview-tabs/details.phtml will throw an error complaining about
an undefined index. Indeed, the CompanyBillingDetail entity includes two
static arrays named $INVOICE_METHODS and $BILLING_FREQUENCIES.
Neither has the '' empty string key, hence the undefined index exception.
To fix, we check for the empty string with both getBillingFrequency
and getInvoiceMethod before trying to use their value as the array
index.