### PR TITLE
Make update-l2database.pl lookup lib and conf file

### DIFF
--- a/tools/runtime/l2database/update-l2database.pl
+++ b/tools/runtime/l2database/update-l2database.pl
@@ -55,6 +55,12 @@
 #				support.
 
 use strict;
+
+use FindBin qw($Bin);
+use File::Spec;
+use lib File::Spec->catdir( $Bin, File::Spec->updir(), File::Spec->updir(), 'perl-lib', 'IXPManager', 'lib' );
+use lib File::Spec->catdir( $Bin, File::Spec->updir(), 'lib', 'perl5' );
+
 use Net_SNMP_util;
 use Getopt::Long;
 use Data::Dumper;
@@ -62,7 +68,15 @@ use Data::Dumper;
 use IXPManager::Config;
 use IXPManager::Const;
 
-my $ixpconfig = new IXPManager::Config;
+my @candidates = (
+  File::Spec->catdir( $Bin, File::Spec->updir(), 'etc', 'ixpmanager.conf' ),
+  '/usr/local/etc/ixpmanager.conf',
+  '/etc/ixpmanager.conf',
+);
+my $configfile = ( map { ( -f $_ )? $_ : () } @candidates )[0] ||
+  die "Cannot find a suitable config file. I tried to find one of these files:".join(' ',@candidates);
+
+my $ixpconfig = IXPManager::Config->new( configfile => $configfile );
 my $dbh = $ixpconfig->{db};
 my $debug = 0;
 my $do_nothing = 0;


### PR DESCRIPTION
The Perl script update-l2database.pl, which is used to update mac
addresses learned by exchange point switches, is changed so that:
- It can be run from inside its original location in tools/runtime/
l2database. This is accomplished by the first 'use lib...' statement,
which tries to find the library to the relative directory ../../
perl-lib/IXPManager/lib. This means that the administrator may choose
not to install the library to the system, thus avoiding spreading
files in /usr/ locations.
- It also searches for libraries in ../lib/perl5, anticipating setups
where the script may be copied in a directory outside the IXP repo.
In that directory, the update-l2database.pl should be placed under
the bin/ subdirectory and the IXPManager library dir should be placed
under the lib/perl5/ subdirectory. This is accomplished by the second
'use lib ...' statement.
- The ixpmanager.conf file is also looked up in several locations.
Fist, in accordance to the previously mentioned scenario, the ../etc
relative directory is searched. Then, the /usr/local/etc and then the
/etc paths are searched. If none of the three contains the
ixpmanager.conf file, the script will complain and exit.