### PR TITLE
Add broadcast packet graphs for MRTG

### DIFF
--- a/app/Services/Grapher/Graph.php
+++ b/app/Services/Grapher/Graph.php
@@ -115,6 +115,11 @@ abstract class Graph {
     const CATEGORY_DISCARDS = 'discs';
 
     /**
+     * 'Broadcasts' category for graphs
+     */
+    const CATEGORY_BROADCASTS = 'bcasts';
+
+    /**
      * Default category
      */
     const CATEGORY_DEFAULT  = self::CATEGORY_BITS;
@@ -129,10 +134,11 @@ abstract class Graph {
      * Array of valid categories for graphs
      */
     const CATEGORIES = [
-        self::CATEGORY_BITS     => self::CATEGORY_BITS,
-        self::CATEGORY_PACKETS  => self::CATEGORY_PACKETS,
-        self::CATEGORY_ERRORS   => self::CATEGORY_ERRORS,
-        self::CATEGORY_DISCARDS => self::CATEGORY_DISCARDS
+        self::CATEGORY_BITS       => self::CATEGORY_BITS,
+        self::CATEGORY_PACKETS    => self::CATEGORY_PACKETS,
+        self::CATEGORY_ERRORS     => self::CATEGORY_ERRORS,
+        self::CATEGORY_DISCARDS   => self::CATEGORY_DISCARDS,
+        self::CATEGORY_BROADCASTS => self::CATEGORY_BROADCASTS,
     ];
 
     /**
@@ -148,10 +154,11 @@ abstract class Graph {
      * Array of valid categories for graphs
      */
     const CATEGORY_DESCS = [
-        self::CATEGORY_BITS     => 'Bits',
-        self::CATEGORY_PACKETS  => 'Packets',
-        self::CATEGORY_ERRORS   => 'Errors',
-        self::CATEGORY_DISCARDS => 'Discards',
+        self::CATEGORY_BITS       => 'Bits',
+        self::CATEGORY_PACKETS    => 'Packets',
+        self::CATEGORY_ERRORS     => 'Errors',
+        self::CATEGORY_DISCARDS   => 'Discards',
+        self::CATEGORY_BROADCASTS => 'Broadcasts',
     ];
 
     /**

--- a/app/Services/Grapher/Renderer/Extensions/Grapher.php
+++ b/app/Services/Grapher/Renderer/Extensions/Grapher.php
@@ -85,7 +85,7 @@ class Grapher implements ExtensionInterface {
             $formats = [
                 "Bytes", "KBytes", "MBytes", "GBytes", "TBytes"
             ];
-        } else if( in_array( $format, [ 'pkts', 'errs', 'discs' ] ) ) {
+        } else if( in_array( $format, [ 'pkts', 'errs', 'discs', 'bcasts' ] ) ) {
             $formats = [
                 "pps", "Kpps", "Mpps", "Gpps", "Tpps"
             ];

--- a/app/Utils/Grapher/Mrtg.php
+++ b/app/Utils/Grapher/Mrtg.php
@@ -98,6 +98,12 @@ class Mrtg
             'options' => 'growright',
             'name'    => 'Discards'
         ],
+        Graph::CATEGORY_BROADCASTS  => [
+            'in'      => 'oidInBroadcasts',
+            'out'     => 'oidOutBroadcasts',
+            'options' => 'growright',
+            'name'    => 'Broadcasts'
+        ],
     ];
 
     /**

--- a/database/Entities/SwitchPort.php
+++ b/database/Entities/SwitchPort.php
@@ -898,6 +898,22 @@ class SwitchPort
     }
 
     /**
+     * Get the appropriate OID for in broadcasts
+     * @return string
+     */
+    public function oidInBroadcasts(): string {
+        return \OSS_SNMP\MIBS\Iface::OID_IF_HC_IN_BROADCAST;
+    }
+
+    /**
+     * Get the appropriate OID for out broadcasts
+     * @return string
+     */
+    public function oidOutBroadcasts(): string {
+        return \OSS_SNMP\MIBS\Iface::OID_IF_HC_OUT_BROADCAST;
+    }
+
+    /**
      * Is this a peering port?
      * @return boolean
      */


### PR DESCRIPTION
In addition to the rest of the existing categories of packet and
traffic graphs, broadcast packet graphs are added.