### PR TITLE
fix vagrant setup script: 'php7.0-bcmath' missing

### DIFF
--- a/tools/installers/ubuntu-lts-1604-ixp-manager-v4.sh
+++ b/tools/installers/ubuntu-lts-1604-ixp-manager-v4.sh
@@ -301,7 +301,7 @@ echo -n "Installing PHP, Apache, MySQL, etc. Please be very patient..."
 # Prevent mrtg from prompting
 echo mrtg mrtg/conf_mods boolean true | debconf-set-selections
 
-log_break && apt-get install -qy apache2 php7.0 php7.0-intl php7.0-mysql php-rrd php7.0-cgi php7.0-cli php7.0-snmp php7.0-curl php7.0-mcrypt \
+log_break && apt-get install -qy apache2 php7.0 php7.0-bcmath php7.0-intl php7.0-mysql php-rrd php7.0-cgi php7.0-cli php7.0-snmp php7.0-curl php7.0-mcrypt \
     php-memcached libapache2-mod-php7.0 mysql-server mysql-client php-mysql memcached snmp nodejs nodejs-legacy npm     \
     php7.0-mbstring php7.0-xml php7.0-gd php-gettext bgpq3 php-memcache unzip php-zip git php-yaml php-ds               \
     libconfig-general-perl libnetaddr-ip-perl mrtg  libconfig-general-perl libnetaddr-ip-perl rrdtool librrds-perl      \


### PR DESCRIPTION
Hello,

I noticed an issue with the vagrant startup script.

During the "Running composer to install PHP dependencies (please be patient)..." step it broke.

I found the following error within the log:

```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for s1lentium/iptools v1.1.0 -> satisfiable by s1lentium/iptools[v1.1.0].
    - s1lentium/iptools v1.1.0 requires ext-bcmath * -> the requested PHP extension bcmath is missing from your system.
...
```

A `sudo apt install php7.0-bcmath` fixed it.

Perhaps also the Docs » Installation » Manual Installation page needs to be updated.

Moreover: are the `Vagrantfile` and `bootstrap.sh` files in the root still needed?

I take this opportunity to thank you for the great work!