### PR TITLE
Nf mac change

### DIFF
--- a/.idea/ixpv.iml
+++ b/.idea/ixpv.iml
@@ -237,7 +237,6 @@
           <root url="file://$MODULE_DIR$/vendor/symfony/http-foundation" />
           <root url="file://$MODULE_DIR$/vendor/symfony/http-kernel" />
           <root url="file://$MODULE_DIR$/vendor/symfony/polyfill-mbstring" />
-          <root url="file://$MODULE_DIR$/vendor/symfony/polyfill-php70" />
           <root url="file://$MODULE_DIR$/vendor/symfony/process" />
           <root url="file://$MODULE_DIR$/vendor/symfony/routing" />
           <root url="file://$MODULE_DIR$/vendor/symfony/serializer" />
@@ -356,7 +355,6 @@
           <root url="file://$MODULE_DIR$/vendor/symfony/http-foundation" />
           <root url="file://$MODULE_DIR$/vendor/symfony/http-kernel" />
           <root url="file://$MODULE_DIR$/vendor/symfony/polyfill-mbstring" />
-          <root url="file://$MODULE_DIR$/vendor/symfony/polyfill-php70" />
           <root url="file://$MODULE_DIR$/vendor/symfony/process" />
           <root url="file://$MODULE_DIR$/vendor/symfony/routing" />
           <root url="file://$MODULE_DIR$/vendor/symfony/serializer" />

--- a/app/Events/Layer2Address/Added.php
+++ b/app/Events/Layer2Address/Added.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace IXP\Events\Layer2Address;
+
+use Entities\{
+    Layer2Address   as Layer2AddressEntity,
+    Customer        as CustomerEntity
+};
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class Added
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var string
+     */
+    public $action;
+
+    /**
+     * @var String
+     */
+    public $mac;
+
+    /**
+     * @var Customer
+     */
+    public $auth;
+
+    /**
+     * @var VlanInterface
+     */
+    public $vli;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param Layer2AddressEntity     $l2a
+     * @param CustomerEntity          $auth
+     *
+     * @return void
+     */
+    public function __construct(  $l2a,  $auth )
+    {
+        $this->action   = "add";
+        $this->mac      = $l2a->getMac();
+        $this->auth     = $auth;
+        $this->vli      = $l2a->getVlanInterface();
+
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Events/Layer2Address/Deleted.php
+++ b/app/Events/Layer2Address/Deleted.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace IXP\Events\Layer2Address;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class Deleted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var string
+     */
+    public $action;
+
+    /**
+     * @var string
+     */
+    public $mac;
+
+    /**
+     * @var Customer
+     */
+    public $auth;
+
+    /**
+     * @var VirtualInterface
+     */
+    public $vli;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param string                $mac
+     * @param VlanInterface         $vli
+     * @param Customer              $auth
+     *
+     * @return void
+     */
+    public function __construct( $mac, $vli, $auth )
+    {
+        $this->action   = "delete";
+        $this->mac      = $mac;
+        $this->auth     = $auth;
+        $this->vli      = $vli;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Listeners/Layer2Address/Changed.php
+++ b/app/Listeners/Layer2Address/Changed.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace IXP\Listeners\Layer2Address;
+
+use Mail;
+
+use IXP\Events\Layer2Address\Deleted;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+use IXP\Mail\Layer2Address\Email as EmailLayer2Address;
+
+class Changed
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  Deleted  $event
+     * @return void
+     */
+    public function handle( $event)
+    {
+        if( config( 'ixp_fe.layer2-addresses.email_on_superuser_change' ) || config( 'ixp_fe.layer2-addresses.email_on_customer_change' ) ){
+            $mailable = new EmailLayer2Address( $event->vli );
+            try {
+                $view = $mailable->view( "layer2-address/emails/changed" )->with( ['user' => $event->auth, 'vli' => $event->vli, "added" => $event->action == "add" ? true : false , "mac" => $event->mac ] )->render();
+                $mailable->prepareBody( $view );
+
+                Mail::send( $mailable );
+
+            } catch( MailableException $e ) {
+                AlertContainer::push( $e->getMessage(), Alert::DANGER );
+
+            }
+
+        }
+
+    }
+}

--- a/app/Mail/Layer2Address/Email.php
+++ b/app/Mail/Layer2Address/Email.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace IXP\Mail\Layer2Address;
+
+/*
+ * Copyright (C) 2009-2017 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+use Entities\{
+    Customer as CustomerEntity, VirtualInterface as VirtualInterfaceEntity, VlanInterface
+};
+
+
+/**
+ * Mailable for Layer2Address
+ *
+ * @author     Barry O'Donovan  <barry@islandbridgenetworks.ie>
+ * @author     Yanm Robin       <yann@islandbridgenetworks.ie>
+ * @category   Customer
+ * @package    IXP\Mail\Customer
+ * @copyright  Copyright (C) 2009-2017 Internet Neutral Exchange Association Company Limited By Guarantee
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class Email extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @var string
+     */
+    public $subject;
+
+    /**
+     * @var string The template to use to create the email
+     */
+    protected $tmpl;
+
+    /**
+     * @var string Temporary view file
+     */
+    protected $tmpfile;
+
+    /**
+     * @var string Temporary view name
+     */
+    protected $tmpname;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param VlanInterface $vi
+     */
+    public function __construct( VlanInterface $vli ) {
+        $this->from( config('identity.email'), config('identity.name') );
+        $this->subject( "Mac Address changed" );
+        $this->to( $vli->getVirtualInterface()->getCustomer()->getPeeringemail() );
+    }
+
+    /**
+     * Destructor
+     */
+    public function __destruct() {
+        // remove temporary file if it exists
+        if( $this->tmpfile && file_exists( $this->tmpfile ) ){
+            @unlink( $this->tmpfile );
+        }
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this;
+    }
+
+    /**
+     * Get the subject for an email
+     *
+     * @return string The subject for an email
+     */
+    public function getSubject(): string {
+        return $this->subject;
+    }
+
+
+
+    /**
+     * Get the email's body
+     *
+     * For this we assume Markdown and return the template as is (with
+     * rendered data).
+     *
+     * @return string The Email's body
+     * @throws
+     */
+    public function getBody(): string {
+        return view( $this->tmpl )->with( $this->buildViewData() )->render();
+    }
+
+
+    /**
+     * Set up Markdown body from a POST request.
+     *
+     * @param View $view
+     */
+
+    public function prepareBody( $view ) {
+        // Templating is slightly awkward here as Laravel's Mailable is built around reading the
+        // body from a template file be we have it via post.
+        //
+        // To work around this, we'll use a temporary file in a new view namespace.
+
+        $this->tmpfile = tempnam( sys_get_temp_dir(), 'l2a_email_' );
+        $this->tmpname = basename( $this->tmpfile );
+        $this->tmpfile = $this->tmpfile . '.blade.php';
+        file_put_contents( $this->tmpfile, "@component('mail::message')\n " . $view . " \n@endcomponent\n" );
+        view()->addNamespace('l2a_emails', sys_get_temp_dir() );
+        $this->markdown( 'l2a_emails::' . $this->tmpname );
+    }
+
+    /**
+     * Checks if we can send the email
+     * @throws MailableException
+     */
+    public function checkIfSendable() {
+        if( !count( $this->to ) ) {
+            throw new MailableException( "No valid recipients" );
+        }
+
+        if( !view()->exists( $this->markdown ) ) {
+            throw new MailableException( "Could not create / load temporary template" );
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -11,8 +11,11 @@ class EventServiceProvider extends ServiceProvider {
      * @var array
      */
     protected $listen = [
-        'event.name' => [
-            'EventListener',
+        'IXP\Events\Layer2Address\Added' => [
+            'IXP\Listeners\Layer2Address\Changed',
+        ],
+        'IXP\Events\Layer2Address\Deleted' => [
+            'IXP\Listeners\Layer2Address\Changed',
         ],
     ];
 

--- a/application/views/customer/overview-tabs/ports/port.phtml
+++ b/application/views/customer/overview-tabs/ports/port.phtml
@@ -218,8 +218,15 @@
                 <td><strong>Multicast Enabled:</strong></td>
                 <td id="value">{if $vli->getMcastenabled()}Yes{else}No{/if}</td>
                 <td></td>
-                <td><strong></strong></td>
-                <td id="value"></td>
+                <td><strong>Mac Address:</strong></td>
+                <td id="value">
+                    {foreach $vli->getLayer2AddressesAsArray() as $l2a}
+                        {$l2a}<br />
+                    {/foreach}
+                    {if count( $vli->getLayer2AddressesAsArray() ) > 0 && config( 'ixp_fe.layer2-addresses.customer_can_edit' ) }
+                        <a href="{route( "Layer2AddressController@forVlanInterface", [ "id" => {$vli->getId()} ] )}">Edit</a>
+                    {/if}
+                </td>
             </tr>
 
             <tr>
@@ -231,14 +238,18 @@
                 <td><strong>Route Server Client:</strong></td>
                 <td id="value">{if $vli->getRsclient()}Yes{else}No{/if}</td>
                 <td></td>
-                {if $as112UiActive}
-                    <td><strong>AS112 Client:</strong></td>
-                    <td id="value">{if $vli->getAs112client()}Yes{else}No{/if}</td>
-                {else}
-                    <td></td>
-                    <td></td>
-                {/if}
+
             </tr>
+                <tr>
+                    <td></td>
+                    {if $as112UiActive}
+                        <td><strong>AS112 Client:</strong></td>
+                        <td id="value">{if $vli->getAs112client()}Yes{else}No{/if}</td>
+                    {else}
+                        <td></td>
+                        <td></td>
+                    {/if}
+                </tr>
 
             </table>
 

--- a/config/ixp_fe.php
+++ b/config/ixp_fe.php
@@ -89,5 +89,27 @@ return [
     */
     'rs-prefixes' => [
         'access'  => env( 'IXP_FE_RS_PREFIXES_ACCESS', Entities\User::AUTH_SUPERUSER ),
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Customer Ability to Change Own MAC Addresses
+    |--------------------------------------------------------------------------
+    |
+    */
+    'layer2-addresses' => [
+
+        'customer_can_edit'  => env( 'IXP_FE_LAYER2_ADDRESSES_CUST_CAN_EDIT', false ),
+
+        'customer_params' => [
+            'min_addresses' => env( 'IXP_FE_LAYER2_ADDRESSES_CUST_PARAMS_MIN_ADDRESSES', 1 ),
+            'max_addresses' => env( 'IXP_FE_LAYER2_ADDRESSES_CUST_PARAMS_MAX_ADDRESSES', 2 ),
+        ],
+
+        'email_on_superuser_change'  => env( 'IXP_FE_LAYER2_ADDRESSES_EMAIL_ON_SUPERUSER_CHANGE', false ),
+        'email_on_customer_change'   => env( 'IXP_FE_LAYER2_ADDRESSES_EMAIL_ON_CUSTOMER_CHANGE',  false ),
+        'email_on_change_dest'       => env( 'IXP_FE_LAYER2_ADDRESSES_EMAIL_ON_CHANGE_DEST',      null  ),  // e.g. 'ops@ixp.example.net'
+
     ]
 ];

--- a/resources/views/layer2-address/emails/changed.blade.php
+++ b/resources/views/layer2-address/emails/changed.blade.php
@@ -1,0 +1,9 @@
+At {{ date('Y-m-d H:i:s') }} user {{ $user->getUsername() }}/{{$user->getEmail() }}
+<br>
+of {{ $user->getCustomer()->getName() }} {{ $added ? 'added' : 'deleted' }} the MAC
+address {{ $mac }} from
+<a href="{{ route( "Layer2AddressController@forVlanInterface" , [ "id" => $vli->getId() ] ) }}">this VLAN
+interface (id: {{ $vli->getId() }}) </a>.
+<br>
+You should view the link above before making any switch changes to ensure the customer
+has completed their editing.

--- a/resources/views/layer2-address/js/vlan-interface.foil.php
+++ b/resources/views/layer2-address/js/vlan-interface.foil.php
@@ -1,21 +1,27 @@
 <script>
+    const addl2a               = $('#add-l2a' );
+
     let table; // datatable handle
 
     $( document ).ready( function() {
         loadDataTable();
         $( "#list-area").show();
+
     });
 
     /**
      * on click even allow to add a mac address using prompt popup
      */
-    $( "#add-l2a" ).on( 'click', function( e ) {
-        e.preventDefault();
+
+
+
+    function add(){
+
         bootbox.prompt({
             title: "Enter a MAC Address.",
             inputType: 'text',
             callback: function ( result ) {
-                if( result != '' ) {
+                if( result != null ) {
                     $.ajax( "<?= action ( 'Api\V4\Layer2AddressController@add' ) ?>", {
                         type: 'POST',
                         data: {
@@ -24,25 +30,25 @@
                             _token : "<?= csrf_token() ?>"
                         }
                     })
-                    .done( function( data ) {
-                        $('.bootbox.modal').modal( 'hide' );
-                        result = ( data.success ) ? 'success': 'danger';
-                        if( result ) {
-                            refreshDataTable();
-                        }
+                        .done( function( data ) {
+                            $('.bootbox.modal').modal( 'hide' );
+                            result = ( data.success ) ? 'success': 'danger';
+                            if( result ) {
+                                refreshDataTable();
+                            }
 
-                        $( "#message" ).html( "<div class='alert alert-"+result+"' role='alert'>"+ data.message +"</div>" );
-                    })
-                    .fail( function() {
-                        $('.bootbox.modal').modal( 'hide' );
-                        $( "#message" ).html( "<div class='alert alert-danger' role='alert'>" +
-                            "Couldn't add MAC address. API / AJAX / network error</div>"
-                        );
-                    });
+                            $( "#message" ).html( "<div class='alert alert-"+result+"' role='alert'>"+ data.message +"</div>" );
+                        })
+                        .fail( function() {
+                            $('.bootbox.modal').modal( 'hide' );
+                            $( "#message" ).html( "<div class='alert alert-danger' role='alert'>" +
+                                "Couldn't add MAC address. API / AJAX / network error</div>"
+                            );
+                        });
                 }
             }
         });
-    });
+    }
 
     /**
      * on click even allow to delete a mac address
@@ -57,10 +63,13 @@
      * reloading only a part of the DOM
      */
     function refreshDataTable() {
+
         $( "#list-area").load( "<?= action ('Layer2AddressController@forVlanInterface' , [ 'id' => $t->vli->getId() ] ) ?> #layer-2-interface-list " ,function( ) {
             table.destroy();
             loadDataTable();
         });
+        $( "#pull-right").load( "<?= action ('Layer2AddressController@forVlanInterface' , [ 'id' => $t->vli->getId() ] ) ?> #add-btn " );
+        addl2a.on( 'click', add  );
     }
 
     /**
@@ -89,7 +98,8 @@
                             result = ( data.success ) ? 'success': 'danger';
 
                             if( result ){
-                                table.row( $(deleteBtn).parents('tr') ).remove().draw();
+                                //table.row( $(deleteBtn).parents('tr') ).remove().draw();
+                                refreshDataTable();
                                 $( "#message" ).html( "<div class='alert alert-"+result+"' role='alert'>"+ data.message +"</div>" );
                             }
 

--- a/resources/views/layer2-address/vlan-interface-cust.foil.php
+++ b/resources/views/layer2-address/vlan-interface-cust.foil.php
@@ -1,0 +1,80 @@
+<?php
+/** @var Foil\Template\Template $t */
+
+$this->layout( 'layouts/ixpv4' )
+?>
+
+<?php $this->section( 'title' ) ?>
+   <h3>MAC Address Management</a>
+<?php $this->append() ?>
+
+<?php $this->section( 'page-header-postamble' ) ?>
+
+<span class="pull-right" id="pull-right">
+    <?php if( count( $t->vli->getLayer2Addresses() ) < config( 'ixp_fe.layer2-addresses.customer_params.max_addresses' ) ): ?>
+        <div class="btn-group btn-group-xs" id="add-btn" role="group">
+            <a type="button" class="btn btn-default" id="add-l2a" onclick="add()">
+                <span class="glyphicon glyphicon-plus"></span>
+            </a>
+        </div>
+    <?php endif; ?>
+</span>
+
+<?php $this->append() ?>
+
+
+<?php $this->section( 'content' ) ?>
+<?= $t->alerts() ?>
+
+
+<div id="message"></div>
+<div id="list-area" class="collapse">
+    <table id='layer-2-interface-list' class="table">
+        <thead>
+        <tr>
+            <td>ID</td>
+            <td>MAC Address</td>
+            <td>Created At</td>
+            <td>Action</td>
+        </tr>
+        <thead>
+        <tbody >
+        <?php foreach( $t->vli->getLayer2Addresses() as $l2a ):
+            /** @var \Entities\Layer2Address $l2a */
+            ?>
+            <tr>
+                <td>
+                    <?= $l2a->getId() ?>
+                </td>
+                <td>
+                    <?= $l2a->getMacFormattedWithColons() ?>
+                </td>
+                <td>
+                    <?= $l2a->getCreatedAt()->format('Y-m-d') ?>
+                </td>
+                <td>
+                    <div class="btn-group btn-group-sm" role="group">
+                        <a class="btn btn btn-default" id="view-l2a-<?= $l2a->getId() ?>" name="<?= $l2a->getMac() ?>" href="#" title="View">
+                            <i class="glyphicon glyphicon-eye-open"></i>
+                        </a>
+                        <?php if( count( $t->vli->getLayer2Addresses() ) > config( 'ixp_fe.layer2-addresses.customer_params.min_addresses' ) ): ?>
+                            <button class="btn btn btn-default" id="delete-l2a-<?= $l2a->getId() ?>" href="#" title="Delete">
+                                <i class="glyphicon glyphicon-trash"></i>
+                            </button>
+                        <?php endif; ?>
+                    </div>
+                </td>
+            </tr>
+        <?php endforeach;?>
+        <tbody>
+    </table>
+</div>
+
+<?= $t->insert( 'layer2-address/modal-mac' ); ?>
+<?php $this->append() ?>
+
+<?php $this->section( 'scripts' ) ?>
+<?= $t->insert( 'layer2-address/js/clipboard' ); ?>
+<?= $t->insert( 'layer2-address/js/vlan-interface' ); ?>
+<?php $this->append() ?>
+

--- a/routes/apiv4-auth-superuser.php
+++ b/routes/apiv4-auth-superuser.php
@@ -133,8 +133,6 @@ Route::post( 'utils/markdown',                                  'UtilsController
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Layer 2 Address
 //
-Route::post( 'l2-address/add',                                  'Layer2AddressController@add' );
-Route::post( 'l2-address/delete/{id}',                          'Layer2AddressController@delete' );
 Route::get(  'l2-address/detail/{id}',                          'Layer2AddressController@detail' );
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/routes/apiv4.php
+++ b/routes/apiv4.php
@@ -86,3 +86,5 @@ Route::get( 'peering-db/fac', function() {
     }));
 })->name('api-v4-peering-db-fac');
 
+Route::post( 'l2-address/add',                                  'Layer2AddressController@add' );
+Route::post( 'l2-address/delete/{id}',                          'Layer2AddressController@delete' );

--- a/routes/web-auth.php
+++ b/routes/web-auth.php
@@ -16,3 +16,6 @@ Route::group( [ 'namespace' => 'PatchPanel', 'prefix' => 'patch-panel-port', 'mi
     Route::get( 'view/{id}',                        'PatchPanelPortController@view' );
 });
 
+Route::get(     'vlan-interface/{vliid}',   'Layer2AddressController@forVlanInterface' )->name( "Layer2AddressController@forVlanInterface" );
+Route::post(    'delete/{id}',              'Layer2AddressController@delete' );
+Route::post(    'add/{id}',              'Layer2AddressController@add' );


### PR DESCRIPTION
CUSTUSER MAC Address CRUD

[NF] - CUSTUSER MAC Address CRUD - closes  islandbridgenetworks/IXP-Manager#116

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
