### PR TITLE
Add PHP 7.1 and 7.2 to Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: php
 
 php:
-    - "7.0"
+    - 7.0
+    - 7.1
+    - 7.2
 
 services:
     - memcached


### PR DESCRIPTION
[NF] Adds two more recent PHP versions to Travis CI
