### PR TITLE
[BF] - p2p breadcrumb links give 404s - fixes islandbridgenetworks/IX…

### DIFF
--- a/application/views/statistics/p2p.phtml
+++ b/application/views/statistics/p2p.phtml
@@ -9,7 +9,7 @@
             <a href="{genUrl controller='statistics' action='members'}">Statistics</a> <span class="divider">/</span>
         </li>
         <li>
-             <a href="{genUrl controller="customer" action="overview" id=$cust->getId()}">{$cust->getFormattedName()}</a> <span class="divider">/</span>
+             <a href="{route( "customer@overview", [ "id" => $cust->getId() ] ) }">{$cust->getFormattedName()}</a> <span class="divider">/</span>
         </li>
         <li class="active">
             Peer to Peer Statistics


### PR DESCRIPTION
p2p breadcrumb links give 404s

[BF] p2p breadcrumb links give 404s - fixes islandbridgenetworks/IXP-Manager#131

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
