### PR TITLE
[BF] - Visual bug in display output of private vlans - fixes islandbr…

### DIFF
--- a/resources/views/customer/overview-tabs/ports/port.foil.php
+++ b/resources/views/customer/overview-tabs/ports/port.foil.php
@@ -227,11 +227,9 @@
                                     <?php if( count( $pvlans[ $vli->getVlan()->getId() ][ 'members'] ) == 1 ): ?>
                                         <em>None - single member</em>
                                     <?php else: ?>
-                                        <div class="well" style="overflow-y: scroll; height:400px;">
-                                            <?php foreach( $pvlans[ $vli->getVlan()->getId() ][ 'members'] as $m ): ?>
-                                                <?= $t->ee( $m->getAbbreviatedName() )?> <br />
-                                            <?php endforeach; ?>
-                                        </div>
+                                        <?php foreach( $pvlans[ $vli->getVlan()->getId() ][ 'members'] as $m ): ?>
+                                            <?= $t->ee( $m->getAbbreviatedName() )?> <br />
+                                        <?php endforeach; ?>
                                     <?php endif; ?>
                                 </td>
                             </tr>

--- a/resources/views/customer/overview-tabs/private-vlans.foil.php
+++ b/resources/views/customer/overview-tabs/private-vlans.foil.php
@@ -50,20 +50,20 @@
                         <?php endforeach; ?>
                     </td>
                     <td>
-                        <div class="well" style="overflow-y: scroll; height:400px;">
-                            <?php $others =  0 ?>
-                            <?php foreach( $pv[ "members" ] as $m ): ?>
-                                <?php if( $m->getId() != $t->c->getId() ): ?>
-                                    <a href="<?= route( "customer@overview" , [ "id" => $m->getId() ]) ?>">
-                                        <?= $t->ee( $m->getAbbreviatedName() ) ?>
-                                    </a><br />
-                                    <?php $others =  1 ?>
-                                <?php endif; ?>
-                            <?php endforeach; ?>
-                            <?php if( !$others): ?>
-                                <em>None - single member</em>
+
+                        <?php $others =  0 ?>
+                        <?php foreach( $pv[ "members" ] as $m ): ?>
+                            <?php if( $m->getId() != $t->c->getId() ): ?>
+                                <a href="<?= route( "customer@overview" , [ "id" => $m->getId() ]) ?>">
+                                    <?= $t->ee( $m->getAbbreviatedName() ) ?>
+                                </a><br />
+                                <?php $others =  1 ?>
                             <?php endif; ?>
-                        </div>
+                        <?php endforeach; ?>
+                        <?php if( !$others): ?>
+                            <em>None - single member</em>
+                        <?php endif; ?>
+
                     </td>
                 </tr>
             <?php endforeach; ?>


### PR DESCRIPTION
Visual bug in display output of private vlans

[BF] Visual bug in display output of private vlans - fixes inex/IXP-Manager#132

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
