### PR TITLE
[BF] - New customer controller does not link customer to IXP - fixes …

### DIFF
--- a/app/Http/Controllers/Customer/CustomerController.php
+++ b/app/Http/Controllers/Customer/CustomerController.php
@@ -42,6 +42,7 @@ use Entities\{
     Customer                as CustomerEntity,
     CustomerNote            as CustomerNoteEntity,
     IRRDBConfig             as IRRDBConfigEntity,
+    IXP                     as IXPEntity,
     NetworkInfo             as NetworkInfoEntity,
     RSPrefix                as RSPrefixEntity,
     User                    as UserEntity
@@ -244,6 +245,8 @@ class CustomerController extends Controller
 
             $c->setBillingDetails( $bdetail );
             $c->setRegistrationDetails( $rdetail );
+
+            $c->addIXP( D2EM::getRepository( IXPEntity::class )->getDefault() );
         }
 
         if( $r->input( 'irrdb' ) ) {


### PR DESCRIPTION
New customer controller does not link customer to IXP

[BF] New customer controller does not link customer to IXP - fixes inex/IXP-Manager#406



 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
