### PR TITLE
Fixed CONFFILE variable

### DIFF
--- a/tools/runtime/mrtg/ubuntu-mrtg-initd
+++ b/tools/runtime/mrtg/ubuntu-mrtg-initd
@@ -20,7 +20,7 @@ DESC="mrtg"
 NAME=mrtg
 DAEMON=/usr/bin/$NAME
 PIDFILE=/etc/${NAME}/$NAME.pid
-CONFFILE=/etc/${NAME}/$NAME.cfg
+CONFFILE=/etc/$NAME.cfg
 DAEMON_ARGS="--daemon --pid-file=$PIDFILE $CONFFILE"
 SCRIPTNAME=/etc/init.d/$NAME
 


### PR DESCRIPTION
CONFFILE variable referenced /etc/mrtg/mrtg.cfg but should reference /etc/mrtg.cfg in order to stay consistent with default mrtg.cfg location on Ubuntu 16.04 as well as the MRTG config update cron script referenced in the Grapher docs.

*PR template - remove this line and edit below*

[BF] Summary of fix - fixes [inex|islandbridgenetworks]/IXP-Manager#x

[NF] New feature summary - closes [inex|islandbridgenetworks]/IXP-Manager#x

*Longer description*
 

In addition to the above, I have:

 - [ ] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [ ] ensured appropriate checks against user privilege / resources accessed
 - [ ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
