### PR TITLE
[BF] - p2p link from search needs updating - fixes inex/IXP-Manager#424

### DIFF
--- a/resources/views/search/do.foil.php
+++ b/resources/views/search/do.foil.php
@@ -11,7 +11,7 @@
     <div class="row">
 
         <div class="col-sm-12">
-
+            <?= $t->alerts() ?>
             <div class="well">
 
                 <form class="form-inline" method="get" action="<?= route( 'search' ) ?>">
@@ -92,7 +92,7 @@
                                     <a class="btn btn-default" href="<?= route( "statistics@member-drilldown" , [ "typeid" => $cust->getId(), "type" => "agg" ] ) ?>">
                                         Statistics
                                     </a>
-                                    <a class="btn btn-default" href="<?= url( 'statistics/p2p/shortname/' . $cust->getShortname() )?>">
+                                    <a class="btn btn-default" href="<?= route( 'statistics@p2p-get', [ "id" => $cust->getId() ] )?>">
                                         P2P
                                     </a>
                                     <a class="btn btn-default" href="<?= route( "customer@overview" , [ "id" => $cust->getId(), "tab" => "users" ] ) ?>">Users</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -96,7 +96,7 @@ Route::group( [ 'prefix' => 'statistics' ], function() {
     Route::get(  'members', 'StatisticsController@members' );
     Route::post( 'members', 'StatisticsController@members' )->name( 'statistics/members' );
 
-    Route::get(  'p2p/{cid}', 'StatisticsController@p2p' );
+    Route::get(  'p2p/{cid}', 'StatisticsController@p2p' )->name( 'statistics@p2p-get' );
     Route::post( 'p2p/{cid}', 'StatisticsController@p2p' )->name( 'statistics@p2p' );
 
     Route::get(  'member/{id?}',                                'StatisticsController@member'            )->name( 'statistics@member'             );


### PR DESCRIPTION

 p2p link from search needs updating

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
