### PR TITLE
[BF] - Cannot delete clients - fixes inex/IXP-Manager#433

### DIFF
--- a/resources/views/customer/delete.foil.php
+++ b/resources/views/customer/delete.foil.php
@@ -140,6 +140,7 @@
                             <button id="notes-modal-btn-cancel"  type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> Cancel</button>
                             <button id="notes-modal-btn-confirm" type="submit" class="btn btn-primary"                     ><i class="fa fa-check"></i> Confirm</button>
                             <input type="hidden" name="id" value="<?= $c->getId() ?>">
+                            <input type="hidden" name="_token" value="<?= csrf_token() ?>">
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
Cannot delete clients

The CSRF token was missing in the delete form.

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
