### PR TITLE
Issue 435 - Customer note notification : Dont send notification email if customer has no email

### DIFF
--- a/app/Listeners/Customer/Note/EmailOnChange.php
+++ b/app/Listeners/Customer/Note/EmailOnChange.php
@@ -116,7 +116,7 @@ class EmailOnChange
                     continue;
                 }
 
-                if( $user->getContact()->getEmail() == null || filter_var( $user->getContact()->getEmail() , FILTER_VALIDATE_EMAIL ) == false ) {
+                if( !$user->getContact()->getEmail() || filter_var( $user->getContact()->getEmail() , FILTER_VALIDATE_EMAIL ) === false ) {
                     continue;
                 }
 

--- a/app/Listeners/Customer/Note/EmailOnChange.php
+++ b/app/Listeners/Customer/Note/EmailOnChange.php
@@ -116,6 +116,10 @@ class EmailOnChange
                     continue;
                 }
 
+                if( $user->getContact()->getEmail() == null ){
+                    continue;
+                }
+
                 if( !$user->getPreference( "customer-notes.notify" ) || $user->getPreference( "customer-notes.notify" ) == "default" || $user->getPreference( "customer-notes.notify" ) == "all" ) {
                     $to[] = [ 'name' => $user->getContact()->getName(), 'email' => $user->getContact()->getEmail() ];
                     continue;

--- a/app/Listeners/Customer/Note/EmailOnChange.php
+++ b/app/Listeners/Customer/Note/EmailOnChange.php
@@ -116,7 +116,7 @@ class EmailOnChange
                     continue;
                 }
 
-                if( $user->getContact()->getEmail() == null ){
+                if( $user->getContact()->getEmail() == null || filter_var( $user->getContact()->getEmail() , FILTER_VALIDATE_EMAIL ) == false ) {
                     continue;
                 }
 


### PR DESCRIPTION
Customer note notification : Dont send notification email if customer has no email

- check email is not null + check email valid
 
In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
