### PR TITLE
[BF] - Customer with no country defaults to "Afghanistan"

### DIFF
--- a/app/Http/Controllers/Customer/CustomerController.php
+++ b/app/Http/Controllers/Customer/CustomerController.php
@@ -344,7 +344,7 @@ class CustomerController extends Controller
                 'billingAddress3'           => array_key_exists( 'billingAddress3',         $old    ) ? $old['billingAddress3']         : $cbd->getBillingAddress3(),
                 'billingTownCity'           => array_key_exists( 'billingTownCity',         $old    ) ? $old['billingTownCity']         : $cbd->getBillingTownCity(),
                 'billingPostcode'           => array_key_exists( 'billingPostcode',         $old    ) ? $old['billingPostcode']         : $cbd->getBillingPostcode(),
-                'billingCountry'            => array_key_exists( 'billingCountry',          $old    ) ? $old['billingCountry']          : ( $cbd->getBillingCountry() == "" ? '0' : $cbd->getBillingCountry() ),
+                'billingCountry'            => array_key_exists( 'billingCountry',          $old    ) ? $old['billingCountry']          : in_array( $cbd->getBillingCountry(),  array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ) ? $cbd->getBillingCountry() : null,
                 'billingEmail'              => array_key_exists( 'billingEmail',            $old    ) ? $old['billingEmail']            : $cbd->getBillingEmail(),
                 'billingTelephone'          => array_key_exists( 'billingTelephone',        $old    ) ? $old['billingTelephone']        : $cbd->getBillingTelephone(),
                 'purchaseOrderRequired'     => array_key_exists( 'purchaseOrderRequired',   $old    ) ? $old['purchaseOrderRequired']   : ( $cbd->getPurchaseOrderRequired() ? 1 : 0 ),
@@ -364,7 +364,7 @@ class CustomerController extends Controller
             'address3'                  => array_key_exists( 'address3',                        $old    ) ? $old['address3']        : $crd->getAddress3(),
             'townCity'                  => array_key_exists( 'townCity',                        $old    ) ? $old['townCity']        : $crd->getTownCity(),
             'postcode'                  => array_key_exists( 'postcode',                        $old    ) ? $old['postcode']        : $crd->getPostcode(),
-            'country'                   => array_key_exists( 'country',                         $old    ) ? $old['country']         : ( $crd->getCountry() == "" ? "0" : $crd->getCountry() ),
+            'country'                   => array_key_exists( 'country',                         $old    ) ? $old['country']         : in_array( $crd->getCountry(),  array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ) ? $crd->getCountry() : null,
         ];
 
 
@@ -373,7 +373,7 @@ class CustomerController extends Controller
         return view( 'customer/billing-registration' )->with([
             'c'                             => $c,
             'juridictions'                  => D2EM::getRepository( CompanyRegisteredDetailEntity::class )->getJuridictionsAsArray(),
-            'countries'                     => array_merge( Countries::getList('name' ), [ 999 => [ 'name' => '&nbsp;', 'iso_3166_2' => 0 ] ] )
+            'countries'                     => Countries::getList('name' )
         ]);
     }
 
@@ -407,7 +407,7 @@ class CustomerController extends Controller
         $crd->setAddress3(              $request->input( 'address3'             ) );
         $crd->setTownCity(              $request->input( 'townCity'             ) );
         $crd->setPostcode(              $request->input( 'postcode'             ) );
-        $crd->setCountry(       $request->input( 'country'              ) == 0 ? null : $request->input( 'country'              ) );
+        $crd->setCountry(               $request->input( 'country'              ) );
 
         $cbd->setBillingContactName(     $request->input( 'billingContactName'   ) );
         $cbd->setBillingFrequency(       $request->input( 'billingFrequency'     ) );
@@ -416,7 +416,7 @@ class CustomerController extends Controller
         $cbd->setBillingAddress3(        $request->input( 'billingAddress3'      ) );
         $cbd->setBillingTownCity(        $request->input( 'billingTownCity'      ) );
         $cbd->setBillingPostcode(        $request->input( 'billingPostcode'      ) );
-        $cbd->setBillingCountry(         $request->input( 'billingCountry'       ) == 0 ? null : $request->input( 'billingCountry'       ) );
+        $cbd->setBillingCountry(         $request->input( 'billingCountry'       ) );
         $cbd->setBillingEmail(           $request->input( 'billingEmail'         ) );
         $cbd->setBillingTelephone(       $request->input( 'billingTelephone'     ) );
         $cbd->setPurchaseOrderRequired(  $request->input( 'purchaseOrderRequired') ? 1 : 0 );

--- a/app/Http/Controllers/Customer/CustomerController.php
+++ b/app/Http/Controllers/Customer/CustomerController.php
@@ -344,7 +344,7 @@ class CustomerController extends Controller
                 'billingAddress3'           => array_key_exists( 'billingAddress3',         $old    ) ? $old['billingAddress3']         : $cbd->getBillingAddress3(),
                 'billingTownCity'           => array_key_exists( 'billingTownCity',         $old    ) ? $old['billingTownCity']         : $cbd->getBillingTownCity(),
                 'billingPostcode'           => array_key_exists( 'billingPostcode',         $old    ) ? $old['billingPostcode']         : $cbd->getBillingPostcode(),
-                'billingCountry'            => array_key_exists( 'billingCountry',          $old    ) ? $old['billingCountry']          : $cbd->getBillingCountry(),
+                'billingCountry'            => array_key_exists( 'billingCountry',          $old    ) ? $old['billingCountry']          : ( $cbd->getBillingCountry() == "" ? '0' : $cbd->getBillingCountry() ),
                 'billingEmail'              => array_key_exists( 'billingEmail',            $old    ) ? $old['billingEmail']            : $cbd->getBillingEmail(),
                 'billingTelephone'          => array_key_exists( 'billingTelephone',        $old    ) ? $old['billingTelephone']        : $cbd->getBillingTelephone(),
                 'purchaseOrderRequired'     => array_key_exists( 'purchaseOrderRequired',   $old    ) ? $old['purchaseOrderRequired']   : ( $cbd->getPurchaseOrderRequired() ? 1 : 0 ),
@@ -364,15 +364,16 @@ class CustomerController extends Controller
             'address3'                  => array_key_exists( 'address3',                        $old    ) ? $old['address3']        : $crd->getAddress3(),
             'townCity'                  => array_key_exists( 'townCity',                        $old    ) ? $old['townCity']        : $crd->getTownCity(),
             'postcode'                  => array_key_exists( 'postcode',                        $old    ) ? $old['postcode']        : $crd->getPostcode(),
-            'country'                   => array_key_exists( 'country',                         $old    ) ? $old['country']         : $crd->getCountry(),
+            'country'                   => array_key_exists( 'country',                         $old    ) ? $old['country']         : ( $crd->getCountry() == "" ? "0" : $crd->getCountry() ),
         ];
+
 
         Former::populate( array_merge( $dataRegistrationDetail, $dataBillingDetail ) );
 
         return view( 'customer/billing-registration' )->with([
             'c'                             => $c,
             'juridictions'                  => D2EM::getRepository( CompanyRegisteredDetailEntity::class )->getJuridictionsAsArray(),
-            'countries'                     => Countries::getList('name' )
+            'countries'                     => array_merge( Countries::getList('name' ), [ 999 => [ 'name' => '&nbsp;', 'iso_3166_2' => 0 ] ] )
         ]);
     }
 
@@ -406,7 +407,7 @@ class CustomerController extends Controller
         $crd->setAddress3(              $request->input( 'address3'             ) );
         $crd->setTownCity(              $request->input( 'townCity'             ) );
         $crd->setPostcode(              $request->input( 'postcode'             ) );
-        $crd->setCountry(               $request->input( 'country'              ) );
+        $crd->setCountry(       $request->input( 'country'              ) == 0 ? null : $request->input( 'country'              ) );
 
         $cbd->setBillingContactName(     $request->input( 'billingContactName'   ) );
         $cbd->setBillingFrequency(       $request->input( 'billingFrequency'     ) );
@@ -415,7 +416,7 @@ class CustomerController extends Controller
         $cbd->setBillingAddress3(        $request->input( 'billingAddress3'      ) );
         $cbd->setBillingTownCity(        $request->input( 'billingTownCity'      ) );
         $cbd->setBillingPostcode(        $request->input( 'billingPostcode'      ) );
-        $cbd->setBillingCountry(         $request->input( 'billingCountry'       ) );
+        $cbd->setBillingCountry(         $request->input( 'billingCountry'       ) == 0 ? null : $request->input( 'billingCountry'       ) );
         $cbd->setBillingEmail(           $request->input( 'billingEmail'         ) );
         $cbd->setBillingTelephone(       $request->input( 'billingTelephone'     ) );
         $cbd->setPurchaseOrderRequired(  $request->input( 'purchaseOrderRequired') ? 1 : 0 );

--- a/app/Http/Requests/Customer/BillingInformation.php
+++ b/app/Http/Requests/Customer/BillingInformation.php
@@ -63,7 +63,7 @@ class BillingInformation extends FormRequest
             'address3'              => 'nullable|string|max:255',
             'townCity'              => 'nullable|string|max:255',
             'postcode'              => 'nullable|string|max:255',
-            'country'               => 'nullable|string|max:255|in:' . implode( ',', array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ) . ',0',
+            'country'               => 'nullable|string|max:255|in:' . implode( ',', array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ),
 
             'billingContactName'    => 'nullable|string|max:255',
             'billingFrequency'      => 'nullable|string|max:255|in:' . implode( ',', array_keys( CompanyBillingDetailEntity::$BILLING_FREQUENCIES ) ),
@@ -72,7 +72,7 @@ class BillingInformation extends FormRequest
             'billingAddress3'       => 'nullable|string|max:255',
             'billingTownCity'       => 'nullable|string|max:255',
             'billingPostcode'       => 'nullable|string|max:255',
-            'billingCountry'        => 'nullable|string|max:255|in:' . implode( ',', array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ) . ',0',
+            'billingCountry'        => 'nullable|string|max:255|in:' . implode( ',', array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ),
             'billingEmail'          => 'nullable|email|max:255',
             'billingTelephone'      => 'nullable|string|max:255',
             'invoiceMethod'         => 'nullable|string|max:255|in:' . implode( ',', array_keys( CompanyBillingDetailEntity::$INVOICE_METHODS ) ),

--- a/app/Http/Requests/Customer/BillingInformation.php
+++ b/app/Http/Requests/Customer/BillingInformation.php
@@ -63,7 +63,7 @@ class BillingInformation extends FormRequest
             'address3'              => 'nullable|string|max:255',
             'townCity'              => 'nullable|string|max:255',
             'postcode'              => 'nullable|string|max:255',
-            'country'               => 'nullable|string|max:255|in:' . implode( ',', array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ),
+            'country'               => 'nullable|string|max:255|in:' . implode( ',', array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ) . ',0',
 
             'billingContactName'    => 'nullable|string|max:255',
             'billingFrequency'      => 'nullable|string|max:255|in:' . implode( ',', array_keys( CompanyBillingDetailEntity::$BILLING_FREQUENCIES ) ),
@@ -72,7 +72,7 @@ class BillingInformation extends FormRequest
             'billingAddress3'       => 'nullable|string|max:255',
             'billingTownCity'       => 'nullable|string|max:255',
             'billingPostcode'       => 'nullable|string|max:255',
-            'billingCountry'        => 'nullable|string|max:255|in:' . implode( ',', array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ),
+            'billingCountry'        => 'nullable|string|max:255|in:' . implode( ',', array_values( Countries::getListForSelect( 'iso_3166_2' ) ) ) . ',0',
             'billingEmail'          => 'nullable|email|max:255',
             'billingTelephone'      => 'nullable|string|max:255',
             'invoiceMethod'         => 'nullable|string|max:255|in:' . implode( ',', array_keys( CompanyBillingDetailEntity::$INVOICE_METHODS ) ),


### PR DESCRIPTION
Customer with no country defaults to "Afghanistan"

I dont know if it was the best way to fix that bug, the countries are generated with the [Laravel Countries](https://github.com/webpatser/laravel-countries) with a dedicated table in the DB. 

The other way was to add a new entry in the table with empty fields.
 
In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
