### PR TITLE
[BF] - Cannot save Left date in 4.8.0 interface.

### DIFF
--- a/app/Http/Controllers/Customer/CustomerController.php
+++ b/app/Http/Controllers/Customer/CustomerController.php
@@ -247,7 +247,7 @@ class CustomerController extends Controller
         $c->setMD5Support(           $r->input( 'md5support'           ) );
         $c->setAbbreviatedName(      $r->input( 'abbreviatedName'      ) );
         $c->setDatejoin(  $r->input( 'datejoin'                  )  ? new \DateTime( $r->input( 'datejoin'    ) ) : null );
-        $c->setDateleave($r->input( 'dateleave'                 )  ? new \DateTime( $r->input( 'dateleave'   ) ) : null );
+        $c->setDateleave($r->input( 'dateleft'                 )  ? new \DateTime( $r->input( 'dateleft'   ) ) : null );
 
         $c->setAutsys(               $r->input( 'autsys'               ) );
         $c->setMaxprefixes(          $r->input( 'maxprefixes'          ) );


### PR DESCRIPTION
Cannot save Left date in 4.8.0 interface.

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
