### PR TITLE
[BF] - Bad link for Test API Key - fixes inex/IXP-Manager#451

### DIFF
--- a/resources/views/api-key/list-postamble.foil.php
+++ b/resources/views/api-key/list-postamble.foil.php
@@ -16,8 +16,8 @@
     The API key can be passed in the header (preferred) or on the URL. For example:
 <ul>
     <li> <code>curl -X GET -H "X-IXP-Manager-API-Key: <?= $example_api_key?> " <?= url( "/api/v4/test" ) ?></code></li>
-    <li> <code>wget <?= url( "/api/v4/test" ) ?>apikey=<?= $example_api_key ?></code></li>
-    <li> <a href="<?= url( "/api/v4/test" ) ?>apikey=<?= $example_api_key ?>"><?= url( "/api/v4/test" ) ?>apikey=<?= $example_api_key ?></a></li>
+    <li> <code>wget <?= url( "/api/v4/test" ) ?>?apikey=<?= $example_api_key ?></code></li>
+    <li> <a href="<?= url( "/api/v4/test" ) ?>?apikey=<?= $example_api_key ?>"><?= url( "/api/v4/test" ) ?>?apikey=<?= $example_api_key ?></a></li>
 </ul>
 </p>
 


### PR DESCRIPTION
Bad link for Test API Key
 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
