### PR TITLE
[IM] - Change redirection after deleting a (virtual) interface - fixe…

### DIFF
--- a/resources/views/interfaces/virtual/add/vi-details.foil.php
+++ b/resources/views/interfaces/virtual/add/vi-details.foil.php
@@ -137,6 +137,13 @@
         ->value( $t->vi ? $t->vi->getId() : null )
     ?>
 
+    <?php if( $t->vi ): ?>
+        <?= Former::hidden( 'custid' )
+            ->id( "custid" )
+            ->value( $t->vi->getcustomer()->getId() )
+        ?>
+    <?php endif; ?>
+
     <?php if( $t->selectedCust ): ?>
         <?= Former::hidden( 'selectedCust' )
             ->value( $t->selectedCust->getId() )

--- a/resources/views/interfaces/virtual/js/interface.foil.php
+++ b/resources/views/interfaces/virtual/js/interface.foil.php
@@ -28,7 +28,12 @@ function deletePopup( id, viid, type ) {
     } else if( type === "vi" ) {
         objectName = "Virtual Interface";
         urlDelete = "<?= url( 'interfaces/virtual/delete' ) ?>" ;
-        urlRedirect = "<?= route( 'interfaces/virtual/list' ) ?>" ;
+        if( $( "#custid" ).val() !== undefined ){
+            urlRedirect = "<?= url( 'customer/overview' ) ?>/" + $( "#custid" ).val() + "/ports"  ;
+        }else{
+            urlRedirect = "<?= route( 'interfaces/virtual/list' ) ?>" ;
+        }
+
     } else if( type === "sflr" ) {
         objectName = "Sflow Receiver";
         urlDelete = "<?= url( 'interfaces/sflow-receiver/delete' ) ?>" ;


### PR DESCRIPTION
Change redirection after deleting a (virtual) interface
 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
