### PR TITLE
When viewing a patch panel port, make the customer name a hyperlink

### DIFF
--- a/resources/views/patch-panel-port/view.foil.php
+++ b/resources/views/patch-panel-port/view.foil.php
@@ -214,7 +214,14 @@
                                                     </b>
                                                 </td>
                                                 <td>
-                                                    <?= !$current ? $p->getCustomer() : ( $p->getCustomer() ? $t->ee( $p->getCustomer()->getName() ) : '' ) ?>
+                                                    <?php if( !$current ): ?>
+                                                        <?= $p->getCustomer() ?>
+                                                    <?php else: ?>
+
+                                                        <a href="<?= route( 'customer@overview' , [ 'id' => $p->getCustomer()->getId() ] ) ?>" >
+                                                            <?= $t->ee( $p->getCustomer()->getName() ) ?>
+                                                        </a>
+                                                    <?php endif; ?>
                                                 </td>
                                             </tr>
                                         <?php endif; ?>

--- a/resources/views/patch-panel-port/view.foil.php
+++ b/resources/views/patch-panel-port/view.foil.php
@@ -215,7 +215,7 @@
                                                 </td>
                                                 <td>
                                                     <?php if( !$current ): ?>
-                                                        <?= $p->getCustomer() ?>
+                                                        <?= $t->ee( $p->getCustomer() ) ?>
                                                     <?php else: ?>
 
                                                         <a href="<?= route( 'customer@overview' , [ 'id' => $p->getCustomer()->getId() ] ) ?>" >


### PR DESCRIPTION
When viewing a patch panel port, make the customer name a hype

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
