### PR TITLE
Change redirection after deleting a (virtual) interface

### DIFF
--- a/resources/views/interfaces/virtual/add/vi-details.foil.php
+++ b/resources/views/interfaces/virtual/add/vi-details.foil.php
@@ -137,6 +137,13 @@
         ->value( $t->vi ? $t->vi->getId() : null )
     ?>
 
+    <?php if( $t->vi ): ?>
+        <?= Former::hidden( 'custid' )
+            ->id( "custid" )
+            ->value( $t->vi->getcustomer()->getId() )
+        ?>
+    <?php endif; ?>
+
     <?php if( $t->selectedCust ): ?>
         <?= Former::hidden( 'selectedCust' )
             ->value( $t->selectedCust->getId() )

--- a/resources/views/interfaces/virtual/js/interface.foil.php
+++ b/resources/views/interfaces/virtual/js/interface.foil.php
@@ -28,7 +28,12 @@ function deletePopup( id, viid, type ) {
     } else if( type === "vi" ) {
         objectName = "Virtual Interface";
         urlDelete = "<?= url( 'interfaces/virtual/delete' ) ?>" ;
-        urlRedirect = "<?= route( 'interfaces/virtual/list' ) ?>" ;
+        if( $( "#custid" ).val() !== undefined ){
+            urlRedirect = "<?= url( 'customer/overview' ) ?>/" + $( "#custid" ).val() + "/ports"  ;
+        }else{
+            urlRedirect = "<?= route( 'interfaces/virtual/list' ) ?>" ;
+        }
+
     } else if( type === "sflr" ) {
         objectName = "Sflow Receiver";
         urlDelete = "<?= url( 'interfaces/sflow-receiver/delete' ) ?>" ;

--- a/tests/Browser/VirtualInterfaceControllerTest.php
+++ b/tests/Browser/VirtualInterfaceControllerTest.php
@@ -44,7 +44,7 @@ class VirtualInterfaceControllerTest extends DuskTestCase
                 ->waitForText( 'Do you really want to delete this Virtual Interface?' )
                 ->press( "Delete" )
                 ->waitForReload()
-                ->assertPathIs('/interfaces/virtual/list' )
+                ->assertPathIs('/customer/overview/' . $vi->getCustomer()->getId() . '/ports' )
                 ->assertSee('The Virtual Interface has been deleted successfully.' );
 
         });
@@ -684,7 +684,7 @@ class VirtualInterfaceControllerTest extends DuskTestCase
         $browser->press("#delete-vli-" . $vli->getId() )
             ->waitForText( 'Do you really want to delete this Vlan Interface?' )
             ->press('Delete')
-            ->assertPathIs('/customer/overview/' . $vi->getCustomer()->getId() . '/ports' )
+            ->assertPathIs('/interfaces/virtual/edit/' . $vi->getId() )
             ->waitForReload()
             ->assertSee( 'The Vlan Interface has been deleted successfully.' );
 

--- a/tests/Browser/VirtualInterfaceControllerTest.php
+++ b/tests/Browser/VirtualInterfaceControllerTest.php
@@ -684,7 +684,7 @@ class VirtualInterfaceControllerTest extends DuskTestCase
         $browser->press("#delete-vli-" . $vli->getId() )
             ->waitForText( 'Do you really want to delete this Vlan Interface?' )
             ->press('Delete')
-            ->assertPathIs('/interfaces/virtual/edit/' . $vi->getId() )
+            ->assertPathIs('/customer/overview/' . $vi->getCustomer()->getId() . '/ports' )
             ->waitForReload()
             ->assertSee( 'The Vlan Interface has been deleted successfully.' );
 


### PR DESCRIPTION
Change redirection after deleting a (virtual) interface + dusk test modification
 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
