### PR TITLE
[BF] - Contact groups not appearing correctly in 4.8.0 interface - fi…

### DIFF
--- a/public/js/900-oss-framework.js
+++ b/public/js/900-oss-framework.js
@@ -754,3 +754,16 @@ jQuery.extend( jQuery.fn.dataTableExt.oSort, {
         return ((a < b) ? 1 : ((a > b) ? -1 : 0));
     }
 } );
+
+//See https://github.com/harvesthq/chosen/issues/92 for:
+function ossChosenFixWidth( obj, force ) {
+    if( ( force != undefined && force == true ) || obj.attr( 'chzn-fix-width' ) === '1' ) {
+        czn_id = "#" + obj.attr( "id" ) + "_chzn";
+        width = parseInt( obj.css( "width" ) );
+
+        if( $( czn_id ).length == 0)
+            czn_id = czn_id.replace( /\-/g, "_" );
+
+        $( czn_id ).css( "width", width + "px" );
+    }
+}


### PR DESCRIPTION
Contact groups not appearing correctly in 4.8.0 interface

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
