### PR TITLE
Fix subtle bug in StatisticsController::members()

### DIFF
--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -328,6 +328,9 @@ class StatisticsController extends Controller
                 if( $t->isGraphable() ) {
                     $g = $grapher->customer( $t );
                 }
+                else {
+                    continue;
+                }
             }
 
             /** @var Graph $g */


### PR DESCRIPTION
There is a bug in the logic of the loop iterating over $targets in StatisticsController::members(), see line 320 of app/Http/Controllers/StatisticsController.php. In the case where $infra and $vlan are false, the loop will try to check whether $t->isGraphable() (line 328). But if it is not, the loop will *not* stop, and the graph $g will retain the value from the previous loop. Which means that the previous diagram $g will be pushed into $graphs and shown once more. The final effect is that, for each non-graphable member, the previous member's graph gets shown twice. This is obviously a bug. To correct, we simply add an 'else { continue; }' to go directly to the next loop.

*PR template - remove this line and edit below*

[BF] Summary of fix - fixes [inex|islandbridgenetworks]/IXP-Manager#x

[NF] New feature summary - closes [inex|islandbridgenetworks]/IXP-Manager#x

*Longer description*
 

In addition to the above, I have:

 - [ ] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [ ] ensured appropriate checks against user privilege / resources accessed
 - [ ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
