### PR TITLE
[BF] - Wrong tooltip over 'Delete' button at the customer list view -…

### DIFF
--- a/resources/views/customer/list.foil.php
+++ b/resources/views/customer/list.foil.php
@@ -190,10 +190,10 @@ $this->layout( 'layouts/ixpv4' );
                     </td>
                     <td>
                         <div class="btn-group btn-group-sm" role="group">
-                            <a class="btn btn btn-default" href="<?= route( "customer@overview" , [ "id" => $c->getId() ] ) ?>" title="View">
+                            <a class="btn btn btn-default" href="<?= route( "customer@overview" , [ "id" => $c->getId() ] ) ?>" title="Overview">
                                 <i class="glyphicon glyphicon-eye-open"></i>
                             </a>
-                            <a class="btn btn btn-default" href="<?= route ( "customer@delete-recap", [ "id" => $c->getId() ] )   ?>" title="View">
+                            <a class="btn btn btn-default" href="<?= route ( "customer@delete-recap", [ "id" => $c->getId() ] )   ?>" title="Delete">
                                 <i class="glyphicon glyphicon-trash"></i>
                             </a>
                         </div>


### PR DESCRIPTION
… inex/IXP-Manager#468

*PR template - remove this line and edit below*

[BF] Summary of fix - fixes [inex|islandbridgenetworks]/IXP-Manager#x

[NF] New feature summary - closes [inex|islandbridgenetworks]/IXP-Manager#x

*Longer description*
 

In addition to the above, I have:

 - [ ] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [ ] ensured appropriate checks against user privilege / resources accessed
 - [ ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
