### PR TITLE
[BF] - Don't send billing update email for resold customers - inex/IX…

### DIFF
--- a/app/Listeners/Customer/BillingDetailsChanged.php
+++ b/app/Listeners/Customer/BillingDetailsChanged.php
@@ -49,7 +49,7 @@ class BillingDetailsChanged
      */
     public function handle( BillingDetailsChangedEvent $e )
     {
-        if( !config( 'ixp_fe.customer.billing_updates_notify' ) ) {
+        if( !config( 'ixp_fe.customer.billing_updates_notify' ) || $e->ocbd->getCustomer()->isResoldCustomer() ) {
             return;
         }
 


### PR DESCRIPTION
Don't send billing update email for resold customers 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
