### PR TITLE
[IM] - Prewired duplex ports - fixes inex/IXP-Manager#449

### DIFF
--- a/database/Repositories/PatchPanelPort.php
+++ b/database/Repositories/PatchPanelPort.php
@@ -107,8 +107,11 @@ class PatchPanelPort extends EntityRepository
 
         $listAvailablePort = array();
 
-        foreach($availablePorts as $port){
-            $listAvailablePort[$port->getId()] = $port->getPatchPanel()->getPortPrefix().$port->getNumber();
+        /** @var PatchPanelPortEntity $port */
+        foreach( $availablePorts as $port ){
+            if( !$port->getDuplexSlavePort() ){
+                $listAvailablePort[$port->getId()] = $port->getPatchPanel()->getPortPrefix().$port->getNumber();
+            }
         }
         return $listAvailablePort;
     }


### PR DESCRIPTION
Prewired duplex ports

While prewiring ports, if set to duplex ports, the partner port is still able to be allocated to other ports as a partner port.
 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
