### PR TITLE
Update UserController.php - allow "." in usernames

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -274,7 +274,7 @@ class UserController extends Doctrine2Frontend {
     {
         $validator = Validator::make( $request->all(), [
             'name'                  => 'required|string|max:255',
-            'username'              => 'required|string|min:3|max:255|regex:/^[a-z0-9\-_]{3,255}$/|unique:Entities\User,username' . ( $request->input( 'id' ) ? ','. $request->input( 'id' ) : '' ),
+            'username'              => 'required|string|min:3|max:255|regex:/^[a-z0-9\-_\.]{3,255}$/|unique:Entities\User,username' . ( $request->input( 'id' ) ? ','. $request->input( 'id' ) : '' ),
             'custid'                => 'required|integer|exists:Entities\Customer,id',
             'email'                 => 'required|email|max:255',
             'authorisedMobile'      => 'nullable|string|max:50',


### PR DESCRIPTION
*Longer description*

Quite a few of our usernames contain "." character, but in latest release the username regexp is more restrictive and does not allow "."
This prevents editing of existing usernames, changing of passwords etc without changing the username also.
If there is no technical reason for it to be suddenly disallowed in this version, would propose just allowing it.

  
