### PR TITLE
[BF] - Contact groups layout not appearing correctly in v5.0.0 interf…

### DIFF
--- a/resources/views/contact/edit-form.foil.php
+++ b/resources/views/contact/edit-form.foil.php
@@ -113,7 +113,7 @@
 
                     <?php if( $t->data[ 'params'][ "allGroups" ] && count( $t->data[ 'params'][ "allGroups" ] ) > 1 || ( count( $t->data[ 'params'][ "allGroups" ] ) == 1 && !isset( $t->data[ 'params'][ "allGroups" ]['ROLE'] ) )): ?>
 
-                        <div class="form-group" style="display: inline; display: inline-flex">
+                        <div class="form-group">
 
                             <label for="mayauthorize" class="control-label col-lg-2 col-sm-4">&nbsp;Groups&nbsp;</label>
 
@@ -124,7 +124,7 @@
                                     <?php if( $gname != "ROLE" && config('contact_group.types.' . $gname ) ): ?>
                                         <tr>
                                             <td>
-                                                <label for="mayauthorize" class="control-label col-lg-2 col-sm-4">&nbsp;<?= $gname ?>&nbsp;</label>
+                                                <label for="mayauthorize" class="control-label col-lg-2 col-sm-4" style="display: grid">&nbsp;<?= $gname ?>&nbsp;</label>
                                             </td>
 
                                             <?php foreach( $gvalue as $ggroup ): ?>


### PR DESCRIPTION
 Contact groups layout not appearing correctly in v5.0.0
 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
