### PR TITLE
[BF] - v5.0.0 customer user unable to view notes - fixes inex/IXP-Man…

### DIFF
--- a/resources/views/customer/js/overview/notes.foil.php
+++ b/resources/views/customer/js/overview/notes.foil.php
@@ -304,7 +304,6 @@
             $( '.table-note' ).on( 'click', '.co-notes-notify', coNotesNotifyToggle );
             $( '.table-note' ).on( 'click', '.co-notes-edit',   coNotesEditDialog );
             $( '.table-note' ).on( 'click', '.co-notes-trash',  coNotesDelete );
-            $( '.table-note' ).on( 'click', '.co-notes-view',   coNotesViewDialog );
 
             $( "#co-notes-fpublic" ).on( "click", function() {
                 coNotesPublicCheckbox();
@@ -323,6 +322,8 @@
             });
 
         <?php endif; ?>
+
+        $( '.table-note' ).on( 'click', '.co-notes-view',   coNotesViewDialog );
 
         $( "#tab-notes" ).on( 'shown.bs.tab', function( ) {
             // mark notes as read and update the users last read time

--- a/resources/views/dashboard/dashboard-tabs/details.foil.php
+++ b/resources/views/dashboard/dashboard-tabs/details.foil.php
@@ -162,15 +162,3 @@
     </div>
 
 </div>
-
-
-<?php $this->section( 'scripts' ) ?>
-    <script>
-        <?php if( Auth::getUser()->isCustUser() ): ?>
-            $( document ).ready(function() {
-                $( "input" ).attr( "disabled", "disabled" );
-                $( "select" ).attr( "disabled", "disabled" )
-            });
-        <?php endif; ?>
-    </script>
-<?php $this->append() ?>

--- a/resources/views/dashboard/index.foil.php
+++ b/resources/views/dashboard/index.foil.php
@@ -171,7 +171,13 @@ $this->layout( 'layouts/ixpv4' );
             $($.fn.dataTable.tables(true)).DataTable()
                 .columns.adjust()
                 .responsive.recalc();
-        })
+        });
 
+        <?php if( Auth::getUser()->isCustUser() ): ?>
+            $( document ).ready(function() {
+                $( "#details input" ).attr( "disabled", "disabled" );
+                $( "#details select" ).attr( "disabled", "disabled" )
+            });
+        <?php endif; ?>
     </script>
 <?php $this->append() ?>


### PR DESCRIPTION
v5.0.0 customer user unable to view notes
 
In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
