### PR TITLE
[BF] - View on Login History has broken links - fixes inex/IXP-Manage…

### DIFF
--- a/app/Http/Controllers/LoginHistoryController.php
+++ b/app/Http/Controllers/LoginHistoryController.php
@@ -137,14 +137,14 @@ class LoginHistoryController extends Doctrine2Frontend {
      */
     public function view( Request $r, $id ): View
     {
-
-        if( !( $user = D2EM::getRepository( UserEntity::class )->find( $id ) ) ) {
+        /** @var $c2u CustomerToUserEntity */
+        if( !( $c2u = D2EM::getRepository( CustomerToUserEntity::class )->find( $id ) ) ) {
             abort(404 );
         }
 
         return view( 'login-history/view' )->with([
-            'histories'                 => D2EM::getRepository( UserLoginHistoryEntity::class)->getAllForFeList( $user->getId(), $r->input( 'limit', 0 ) ),
-            'user'                      => $user,
+            'histories'                 => D2EM::getRepository( UserLoginHistoryEntity::class)->getAllForFeList( $c2u->getUser()->getId(), $r->input( 'limit', 0 ) ),
+            'user'                      => $c2u->getUser(),
         ]);
     }
 }


### PR DESCRIPTION
View on Login History has broken links

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
