### PR TITLE
[BF] - issue when the create date of a Layer 2 Address is null

### DIFF
--- a/resources/views/layer2-address/vlan-interface.foil.php
+++ b/resources/views/layer2-address/vlan-interface.foil.php
@@ -90,7 +90,7 @@ Vlan Interface / Configured MAC Address Management
                                 <?= $l2a->getMacFormattedWithColons() ?>
                             </td>
                             <td>
-                                <?= $l2a->getCreatedAt()->format('Y-m-d') ?>
+                                <?= $l2a->getCreatedAt() ? $l2a->getCreatedAt()->format('Y-m-d') : '' ?>
                             </td>
                             <td>
                                 <div class="btn-group btn-group-sm" role="group">


### PR DESCRIPTION
issue when the create date of a Layer 2 Address is null

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
