### PR TITLE
[BF] - Display reseller name on resold customer overview in admin pag…

### DIFF
--- a/resources/views/customer/overview.foil.php
+++ b/resources/views/customer/overview.foil.php
@@ -135,9 +135,15 @@
                     <a href="<?= $t->c->getCorpwww() ?>" target="_blank"><?= $t->nakedUrl( $t->c->getCorpwww() ?? '' ) ?></a>
 
                     <span class="tw-text-gray-600">
-                                - joined <?= $c->getDatejoin()->format('Y') ?>
-                            </span>
+                        - joined <?= $c->getDatejoin()->format('Y') ?>
+                    </span>
                 </p>
+
+                <?php if( $c->isResoldCustomer() ): ?>
+                    <h5>
+                        Reseller: <?= $c->getReseller()->getName() ?>
+                    </h5>
+                <?php endif; ?>
 
                 <p class="tw-mt-6">
 


### PR DESCRIPTION
Display reseller name on resold customer overview in admin page

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
