### PR TITLE
[IM] - Persistent Value in 'Show XY entries' - fixes inex/IXP-Manager#496

### DIFF
--- a/resources/views/customer/details.foil.php
+++ b/resources/views/customer/details.foil.php
@@ -133,6 +133,8 @@
             $( '#customer-list' ).show();
 
             $( '#customer-list' ).dataTable( {
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 responsive: false,
                 "iDisplayLength": 100
             });

--- a/resources/views/customer/js/overview/notes.foil.php
+++ b/resources/views/customer/js/overview/notes.foil.php
@@ -271,6 +271,8 @@
         $('.table-note').show();
 
         $('.table-note').DataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             ordering: false,
             searching: false,

--- a/resources/views/customer/js/overview/peers.foil.php
+++ b/resources/views/customer/js/overview/peers.foil.php
@@ -1,6 +1,8 @@
 <script>
 
     $( '.peers-table').DataTable({
+        stateSave: true,
+        stateDuration : DATATABLE_STATE_DURATION,
         responsive: true,
         "columns": [
             null,

--- a/resources/views/customer/list.foil.php
+++ b/resources/views/customer/list.foil.php
@@ -187,14 +187,7 @@ $this->layout( 'layouts/ixpv4' );
 
             $('#customer-list').DataTable( {
                 responsive: true,
-                // if I did not put the parseInt, it did not work for "All" which is the "-1"
-                // pageLength:parseInt(pageLength),
                 stateSave: true,
-                "stateSaveParams": function (settings, data) {
-                    data.search.search = "";
-                    data.order = [];
-                    data.start = 0;
-                },
                 columnDefs: [
                     { responsivePriority: 1, targets: 0 },
                     { responsivePriority: 2, targets: -1 }

--- a/resources/views/customer/list.foil.php
+++ b/resources/views/customer/list.foil.php
@@ -187,6 +187,14 @@ $this->layout( 'layouts/ixpv4' );
 
             $('#customer-list').DataTable( {
                 responsive: true,
+                // if I did not put the parseInt, it did not work for "All" which is the "-1"
+                // pageLength:parseInt(pageLength),
+                stateSave: true,
+                "stateSaveParams": function (settings, data) {
+                    data.search.search = "";
+                    data.order = [];
+                    data.start = 0;
+                },
                 columnDefs: [
                     { responsivePriority: 1, targets: 0 },
                     { responsivePriority: 2, targets: -1 }

--- a/resources/views/customer/list.foil.php
+++ b/resources/views/customer/list.foil.php
@@ -188,6 +188,7 @@ $this->layout( 'layouts/ixpv4' );
             $('#customer-list').DataTable( {
                 responsive: true,
                 stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 columnDefs: [
                     { responsivePriority: 1, targets: 0 },
                     { responsivePriority: 2, targets: -1 }

--- a/resources/views/customer/overview.foil.php
+++ b/resources/views/customer/overview.foil.php
@@ -410,6 +410,8 @@
                 searching: false,
                 paging:   false,
                 info:   false,
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
             } );
 
             $('.table-responsive-ixp-action').show();
@@ -419,6 +421,8 @@
                 searching: false,
                 paging:   false,
                 info:   false,
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 columnDefs: [
                     { responsivePriority: 1, targets: 0 },
                     { responsivePriority: 2, targets: -1 }

--- a/resources/views/customer/unread-notes.foil.php
+++ b/resources/views/customer/unread-notes.foil.php
@@ -84,6 +84,8 @@
         $('.table-responsive-ixp').show();
 
         $('.table-responsive-ixp').DataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             ordering: false,
             searching: false,

--- a/resources/views/dashboard/index.foil.php
+++ b/resources/views/dashboard/index.foil.php
@@ -190,6 +190,8 @@ $this->layout( 'layouts/ixpv4' );
         $('.table-responsive-ixp').show();
 
         $('.table-responsive-ixp').DataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             ordering: false,
             searching: false,

--- a/resources/views/frontend/js/list.foil.php
+++ b/resources/views/frontend/js/list.foil.php
@@ -48,9 +48,17 @@
 
         tableList.show();
 
+
         tableList.dataTable({
 
             responsive: true,
+            stateSave: true,
+            "stateSaveParams": function (settings, data) {
+                data.search.search = "";
+                data.order = [];
+                data.start = 0;
+                console.log(settings);
+            },
 
             "aLengthMenu": [ [ 20, 50, 100, 500, -1 ], [ 20, 50, 100, 500, "All" ] ],
 
@@ -86,6 +94,5 @@
                 <?php endif; ?>
             ]
         });
-
     });
 </script>

--- a/resources/views/frontend/js/list.foil.php
+++ b/resources/views/frontend/js/list.foil.php
@@ -50,7 +50,8 @@
 
 
         tableList.dataTable({
-
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             "aLengthMenu": [ [ 20, 50, 100, 500, -1 ], [ 20, 50, 100, 500, "All" ] ],
 

--- a/resources/views/frontend/js/list.foil.php
+++ b/resources/views/frontend/js/list.foil.php
@@ -52,14 +52,6 @@
         tableList.dataTable({
 
             responsive: true,
-            stateSave: true,
-            "stateSaveParams": function (settings, data) {
-                data.search.search = "";
-                data.order = [];
-                data.start = 0;
-                console.log(settings);
-            },
-
             "aLengthMenu": [ [ 20, 50, 100, 500, -1 ], [ 20, 50, 100, 500, "All" ] ],
 
             columnDefs: [

--- a/resources/views/interfaces/core-bundle/js/edit-wizard.foil.php
+++ b/resources/views/interfaces/core-bundle/js/edit-wizard.foil.php
@@ -4,6 +4,8 @@
         $('.table-responsive-ixp-no-header').show();
 
         $('.table-responsive-ixp-no-header').DataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             ordering: false,
             searching: false,

--- a/resources/views/interfaces/core-bundle/list.foil.php
+++ b/resources/views/interfaces/core-bundle/list.foil.php
@@ -115,6 +115,8 @@ $this->layout( 'layouts/ixpv4' );
             $( '#table-cb' ).DataTable( {
                 responsive : true,
                 "iDisplayLength": 100,
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 "columnDefs": [
                     { responsivePriority: 1, targets: 0 },
                     { responsivePriority: 2, targets: -1 },

--- a/resources/views/interfaces/physical/list.foil.php
+++ b/resources/views/interfaces/physical/list.foil.php
@@ -125,6 +125,8 @@ $this->layout( 'layouts/ixpv4' );
             $( '#table-pi' ).show();
 
             $( '#table-pi' ).DataTable( {
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 responsive : true,
                 "iDisplayLength": 100,
                 "columnDefs": [

--- a/resources/views/interfaces/virtual/js/interface.foil.php
+++ b/resources/views/interfaces/virtual/js/interface.foil.php
@@ -24,11 +24,6 @@ $( document ).ready(function() {
     $('.table-responsive-ixp-with-header').DataTable( {
         responsive: true,
         stateSave: true,
-        "stateSaveParams": function (settings, data) {
-            data.search.search = "";
-            data.order = [];
-            data.start = 0;
-        },
         columnDefs: [
             { responsivePriority: 1, targets: 0 },
             { responsivePriority: 2, targets: -1 }

--- a/resources/views/interfaces/virtual/js/interface.foil.php
+++ b/resources/views/interfaces/virtual/js/interface.foil.php
@@ -8,6 +8,8 @@ $( document ).ready(function() {
     $('.table-responsive-ixp-no-header').show();
 
     $('.table-responsive-ixp-no-header').DataTable( {
+        stateSave: true,
+        stateDuration : DATATABLE_STATE_DURATION,
         responsive: true,
         ordering: false,
         searching: false,
@@ -22,6 +24,8 @@ $( document ).ready(function() {
     $('.table-responsive-ixp-with-header').show();
 
     $('.table-responsive-ixp-with-header').DataTable( {
+        stateSave: true,
+        stateDuration : DATATABLE_STATE_DURATION,
         responsive: true,
         stateSave: true,
         columnDefs: [

--- a/resources/views/interfaces/virtual/js/interface.foil.php
+++ b/resources/views/interfaces/virtual/js/interface.foil.php
@@ -23,6 +23,12 @@ $( document ).ready(function() {
 
     $('.table-responsive-ixp-with-header').DataTable( {
         responsive: true,
+        stateSave: true,
+        "stateSaveParams": function (settings, data) {
+            data.search.search = "";
+            data.order = [];
+            data.start = 0;
+        },
         columnDefs: [
             { responsivePriority: 1, targets: 0 },
             { responsivePriority: 2, targets: -1 }

--- a/resources/views/ip-address/delete-by-network.foil.php
+++ b/resources/views/ip-address/delete-by-network.foil.php
@@ -191,6 +191,8 @@
 
         $(document).ready( function() {
             $( '#table-ip'   ).dataTable( {
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 responsive : true,
                 ordering: false,
                 paging:   false,

--- a/resources/views/ip-address/js/list.foil.php
+++ b/resources/views/ip-address/js/list.foil.php
@@ -6,6 +6,8 @@
         $( '#ip-address-list' ).show();
 
         $( '#ip-address-list' ).dataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive : true,
             "autoWidth": false,
             pageLength: 50,

--- a/resources/views/irrdb/list.foil.php
+++ b/resources/views/irrdb/list.foil.php
@@ -169,6 +169,8 @@ $this->layout( 'layouts/ixpv4' );
             $('.table-responsive-ixp-with-header').show();
 
             $('.table-responsive-ixp-with-header').DataTable( {
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 responsive: true,
                 paging: false,
                 columnDefs: [

--- a/resources/views/layer2-address/js/vlan-interface.foil.php
+++ b/resources/views/layer2-address/js/vlan-interface.foil.php
@@ -133,6 +133,8 @@
      */
     function loadDataTable(){
         table = $( '#layer-2-interface-list' ).DataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive : true,
             columnDefs: [
                 { responsivePriority: 1, targets: 0 },

--- a/resources/views/layouts/ixpv4.foil.php
+++ b/resources/views/layouts/ixpv4.foil.php
@@ -91,9 +91,10 @@
 
 
         <script>
-            const WHOIS_ASN_URL    = "<?= url( "api/v4/aut-num" )      ?>";
-            const WHOIS_PREFIX_URL = "<?= url( "api/v4/prefix-whois" ) ?>";
-            const MARKDOWN_URL     = "<?= route( "utils@markdown" )   ?>";
+            const WHOIS_ASN_URL             = "<?= url( "api/v4/aut-num" )      ?>";
+            const WHOIS_PREFIX_URL          = "<?= url( "api/v4/prefix-whois" ) ?>";
+            const MARKDOWN_URL              = "<?= route( "utils@markdown" )   ?>";
+            const DATATABLE_STATE_DURATION  = 0;
         </script>
         <script type="text/javascript" src="<?= url ('') . mix('js/ixp-pack.js') ?>"></script>
 

--- a/resources/views/login-history/view.foil.php
+++ b/resources/views/login-history/view.foil.php
@@ -68,6 +68,8 @@
 
             $( '.table-responsive-ixp-with-header' ).DataTable({
                 responsive: true,
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 columnDefs: [
                     { responsivePriority: 1, targets: 0 },
                     { responsivePriority: 2, targets: -1 },

--- a/resources/views/patch-panel-port/js/index.foil.php
+++ b/resources/views/patch-panel-port/js/index.foil.php
@@ -15,6 +15,8 @@
         $( '#table-ppp' ).show();
 
         $( '#table-ppp' ).DataTable({
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive : true,
             "paging":   pagination,
             columnDefs: [

--- a/resources/views/patch-panel-port/js/view.foil.php
+++ b/resources/views/patch-panel-port/js/view.foil.php
@@ -4,6 +4,8 @@
         $( '.table-responsive-ixp-no-header' ).show();
 
         $( '.table-responsive-ixp-no-header' ).DataTable({
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             ordering: false,
             searching: false,

--- a/resources/views/patch-panel/index.foil.php
+++ b/resources/views/patch-panel/index.foil.php
@@ -218,6 +218,8 @@
         $('.table-responsive-ixp-with-header').show();
 
         $('.table-responsive-ixp-with-header').DataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             columnDefs: [
                 { responsivePriority: 1, targets: 0 },

--- a/resources/views/peering-manager/js/index.foil.php
+++ b/resources/views/peering-manager/js/index.foil.php
@@ -74,6 +74,8 @@
         $('.table').show();
 
         $('.table').DataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             ordering: false,
             searching: false,

--- a/resources/views/router/index.foil.php
+++ b/resources/views/router/index.foil.php
@@ -139,6 +139,8 @@
         $('.table-responsive-ixp-with-header').show();
 
         $('.table-responsive-ixp-with-header').DataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             columnDefs: [
                 { responsivePriority: 1, targets: 0 },

--- a/resources/views/router/status.foil.php
+++ b/resources/views/router/status.foil.php
@@ -258,6 +258,8 @@ $this->layout( 'layouts/ixpv4' );
         }); // handles.forEach( function( handle, index ) {
 
     }).dataTable({
+        stateSave: true,
+        stateDuration : DATATABLE_STATE_DURATION,
         responsive: true,
         // paging is disabled as it's complicated to update off screen cells with pagination
         "paging": false

--- a/resources/views/rs-prefixes/list.foil.php
+++ b/resources/views/rs-prefixes/list.foil.php
@@ -62,6 +62,8 @@
             $( '.table' ).show();
 
             $( '.table' ).dataTable({
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 responsive : true,
                 pageLength: 100
             } );

--- a/resources/views/rs-prefixes/view.foil.php
+++ b/resources/views/rs-prefixes/view.foil.php
@@ -114,6 +114,8 @@
             $( '.table' ).show();
 
             $( '.table' ).dataTable({
+                    stateSave: true,
+                    stateDuration : DATATABLE_STATE_DURATION,
                     responsive : true,
                     pageLength: 50
             });

--- a/resources/views/search/do.foil.php
+++ b/resources/views/search/do.foil.php
@@ -153,6 +153,8 @@
     $('.table').show();
 
     $('.table').DataTable( {
+        stateSave: true,
+        stateDuration : DATATABLE_STATE_DURATION,
         responsive: true,
         ordering: false,
         searching: false,

--- a/resources/views/services/lg/bgp-summary.foil.php
+++ b/resources/views/services/lg/bgp-summary.foil.php
@@ -178,6 +178,8 @@
     $(document).ready(function() {
 
         $('#bgpsummary').DataTable({
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             paging: false,
             order: [[ 2, "asc" ]],

--- a/resources/views/services/lg/routes.foil.php
+++ b/resources/views/services/lg/routes.foil.php
@@ -148,6 +148,8 @@
 
         $(document).ready(function() {
             $('#routes').DataTable({
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 paging: false,
                 order: [[ 0, "asc" ]],
                 columnDefs: [

--- a/resources/views/statistics/js/league-table.foil.php
+++ b/resources/views/statistics/js/league-table.foil.php
@@ -107,6 +107,8 @@
     let tableList = $( '#ixpDataTable' );
 
     tableList.dataTable({
+        stateSave: true,
+        stateDuration : DATATABLE_STATE_DURATION,
 
         "aLengthMenu": [[20, 50, 100, 500, -1], [20, 50, 100, 500, "All"]],
 

--- a/resources/views/switches/configuration.foil.php
+++ b/resources/views/switches/configuration.foil.php
@@ -222,6 +222,8 @@
     $( document ).ready( function() {
 
         $('#list-configuration').dataTable({
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive : true,
             "columnDefs": [
                 { "targets": [ 0 ], "visible": false, "searchable": false },

--- a/resources/views/switches/port-report.foil.php
+++ b/resources/views/switches/port-report.foil.php
@@ -108,6 +108,8 @@
 
             $('#list-port').dataTable({
                 responsive : true,
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 "columnDefs": [
                     { "targets": [ 0 ], "visible": false },
                     { "orderData": [ 0 ],    "targets": 1 },

--- a/resources/views/user/js/edit.foil.php
+++ b/resources/views/user/js/edit.foil.php
@@ -12,8 +12,8 @@
             tableList.show();
 
             tableList.dataTable({
-
-                responsive: true,
+                stateSave: true,
+                stateDuration : DATATABLE_STATE_DURATION,
                 responsive: true,
                 ordering: false,
                 searching: false,

--- a/resources/views/user/js/index.foil.php
+++ b/resources/views/user/js/index.foil.php
@@ -7,7 +7,8 @@
         tableList.show();
 
         tableList.dataTable({
-
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             ordering: false,
             searching: false,
@@ -33,7 +34,8 @@
         tableList.show();
 
         tableList.dataTable({
-
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
 
             "aLengthMenu": [ [ 20, 50, 100, 500, -1 ], [ 20, 50, 100, 500, "All" ] ],

--- a/resources/views/user/js/list.foil.php
+++ b/resources/views/user/js/list.foil.php
@@ -7,8 +7,8 @@
         tableList.show();
 
         tableList.dataTable({
-
-            responsive: true,
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             ordering: false,
             searching: false,
@@ -60,7 +60,8 @@
         tableList.show();
 
         tableList.dataTable({
-
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
 
             "aLengthMenu": [ [ 20, 50, 100, 500, -1 ], [ 20, 50, 100, 500, "All" ] ],

--- a/resources/views/vlan/private.foil.php
+++ b/resources/views/vlan/private.foil.php
@@ -123,6 +123,8 @@ $this->layout( 'layouts/ixpv4' );
 
     $(document).ready( function() {
         $('#table-list').DataTable( {
+            stateSave: true,
+            stateDuration : DATATABLE_STATE_DURATION,
             responsive: true,
             ordering: false,
             searching: false,


### PR DESCRIPTION
[IM] - Persistent Value in 'Show XY entries' - fixes inex/IXP-Manager#496

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
