### PR TITLE
Remove 6461 from bird2 transit filter

### DIFF
--- a/resources/views/api/v4/router/collector/bird2/filter-transit-networks.foil.php
+++ b/resources/views/api/v4/router/collector/bird2/filter-transit-networks.foil.php
@@ -26,7 +26,6 @@ define TRANSIT_ASNS = [ 174,                  # Cogent
                         4134,                 # Chinanet
                         5511,                 # Orange opentransit
                         6453,                 # Tata Communications
-                        6461,                 # Zayo Bandwidth
                         6762,                 # Seabone / Telecom Italia
                         7018 ];               # AT&T
 

--- a/resources/views/api/v4/router/server/bird2/filter-transit-networks.foil.php
+++ b/resources/views/api/v4/router/server/bird2/filter-transit-networks.foil.php
@@ -26,7 +26,6 @@ define TRANSIT_ASNS = [ 174,                  # Cogent
                         4134,                 # Chinanet
                         5511,                 # Orange opentransit
                         6453,                 # Tata Communications
-                        6461,                 # Zayo Bandwidth
                         6762,                 # Seabone / Telecom Italia
                         7018 ];               # AT&T
 


### PR DESCRIPTION
AS6461 does have sessions on some route servers so we should remove it from the transit filter list?