### PR TITLE
Fix issue #558

### DIFF
--- a/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv4.conf
+++ b/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv4.conf
@@ -171,16 +171,12 @@ function ixp_community_filter(int peerasn)
     if (routeserverasn, 1, 0) ~ bgp_large_community then
             return true;
 
-    # it's unwise to conduct a 32-bit check on a 16-bit value
-    if peerasn > 65535 then
-            return true;
-
     # Implement widely used community filtering schema.
-    if (0, peerasn) ~ bgp_community then
+    if ((peerasn < 65536) && ((0, peerasn) ~ bgp_community)) || (ro, 0, peerasn) ~ bgp_ext_community then
             return false;
-    if (routeserverasn, peerasn) ~ bgp_community then
+    if ((peerasn < 65536) && ((routeserverasn, peerasn) ~ bgp_community)) || (ro, routeserverasn, peerasn) ~ bgp_ext_community then
             return true;
-    if (0, routeserverasn) ~ bgp_community then
+    if (0, routeserverasn) ~ bgp_community || (ro, 0, routeserverasn) ~ bgp_ext_community then
             return false;
 
     return true;

--- a/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv6.conf
+++ b/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv6.conf
@@ -182,16 +182,12 @@ function ixp_community_filter(int peerasn)
     if (routeserverasn, 1, 0) ~ bgp_large_community then
             return true;
 
-    # it's unwise to conduct a 32-bit check on a 16-bit value
-    if peerasn > 65535 then
-            return true;
-
     # Implement widely used community filtering schema.
-    if (0, peerasn) ~ bgp_community then
+    if ((peerasn < 65536) && ((0, peerasn) ~ bgp_community)) || (ro, 0, peerasn) ~ bgp_ext_community then
             return false;
-    if (routeserverasn, peerasn) ~ bgp_community then
+    if ((peerasn < 65536) && ((routeserverasn, peerasn) ~ bgp_community)) || (ro, routeserverasn, peerasn) ~ bgp_ext_community then
             return true;
-    if (0, routeserverasn) ~ bgp_community then
+    if (0, routeserverasn) ~ bgp_community || (ro, 0, routeserverasn) ~ bgp_ext_community then
             return false;
 
     return true;

--- a/data/travis-ci/known-good/ci-apiv4-rs1-lan1-ipv4.conf
+++ b/data/travis-ci/known-good/ci-apiv4-rs1-lan1-ipv4.conf
@@ -71,16 +71,12 @@ function ixp_community_filter(int peerasn)
         if !(source = RTS_BGP) then
                 return false;
 
-        # it's unwise to conduct a 32-bit check on a 16-bit value
-        if peerasn > 65535 then
-                return true;
-
         # Implement widely used community filtering schema.
-        if (0, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((0, peerasn) ~ bgp_community)) || (ro, 0, peerasn) ~ bgp_ext_community then
                 return false;
-        if (routeserverasn, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((routeserverasn, peerasn) ~ bgp_community)) || (ro, routeserverasn, peerasn) ~ bgp_ext_community then
                 return true;
-        if (0, routeserverasn) ~ bgp_community then
+        if (0, routeserverasn) ~ bgp_community || (ro, 0, routeserverasn) ~ bgp_ext_community then
                 return false;
 
         return true;

--- a/data/travis-ci/known-good/ci-apiv4-rs1-lan1-ipv6.conf
+++ b/data/travis-ci/known-good/ci-apiv4-rs1-lan1-ipv6.conf
@@ -82,16 +82,12 @@ function ixp_community_filter(int peerasn)
         if !(source = RTS_BGP) then
                 return false;
 
-        # it's unwise to conduct a 32-bit check on a 16-bit value
-        if peerasn > 65535 then
-                return true;
-
         # Implement widely used community filtering schema.
-        if (0, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((0, peerasn) ~ bgp_community)) || (ro, 0, peerasn) ~ bgp_ext_community then
                 return false;
-        if (routeserverasn, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((routeserverasn, peerasn) ~ bgp_community)) || (ro, routeserverasn, peerasn) ~ bgp_ext_community then
                 return true;
-        if (0, routeserverasn) ~ bgp_community then
+        if (0, routeserverasn) ~ bgp_community || (ro, 0, routeserverasn) ~ bgp_ext_community then
                 return false;
 
         return true;

--- a/data/travis-ci/known-good/ci-apiv4-rs1-lan2-ipv4.conf
+++ b/data/travis-ci/known-good/ci-apiv4-rs1-lan2-ipv4.conf
@@ -81,16 +81,12 @@ function ixp_community_filter(int peerasn)
         if (routeserverasn, 1, 0) ~ bgp_large_community then
                 return true;
 
-        # it's unwise to conduct a 32-bit check on a 16-bit value
-        if peerasn > 65535 then
-                return true;
-
         # Implement widely used community filtering schema.
-        if (0, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((0, peerasn) ~ bgp_community)) || (ro, 0, peerasn) ~ bgp_ext_community then
                 return false;
-        if (routeserverasn, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((routeserverasn, peerasn) ~ bgp_community)) || (ro, routeserverasn, peerasn) ~ bgp_ext_community then
                 return true;
-        if (0, routeserverasn) ~ bgp_community then
+        if (0, routeserverasn) ~ bgp_community || (ro, 0, routeserverasn) ~ bgp_ext_community then
                 return false;
 
         return true;

--- a/data/travis-ci/known-good/ci-apiv4-rs1-lan2-ipv6.conf
+++ b/data/travis-ci/known-good/ci-apiv4-rs1-lan2-ipv6.conf
@@ -82,16 +82,12 @@ function ixp_community_filter(int peerasn)
         if !(source = RTS_BGP) then
                 return false;
 
-        # it's unwise to conduct a 32-bit check on a 16-bit value
-        if peerasn > 65535 then
-                return true;
-
         # Implement widely used community filtering schema.
-        if (0, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((0, peerasn) ~ bgp_community)) || (ro, 0, peerasn) ~ bgp_ext_community then
                 return false;
-        if (routeserverasn, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((routeserverasn, peerasn) ~ bgp_community)) || (ro, routeserverasn, peerasn) ~ bgp_ext_community then
                 return true;
-        if (0, routeserverasn) ~ bgp_community then
+        if (0, routeserverasn) ~ bgp_community || (ro, 0, routeserverasn) ~ bgp_ext_community then
                 return false;
 
         return true;

--- a/resources/views/api/v4/router/server/bird/community-filter.foil.php
+++ b/resources/views/api/v4/router/server/bird/community-filter.foil.php
@@ -51,16 +51,12 @@ function ixp_community_filter(int peerasn)
                 return true;
 
 <?php endif; ?>
-        # it's unwise to conduct a 32-bit check on a 16-bit value
-        if peerasn > 65535 then
-                return true;
-
         # Implement widely used community filtering schema.
-        if (0, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((0, peerasn) ~ bgp_community)) || (ro, 0, peerasn) ~ bgp_ext_community then
                 return false;
-        if (routeserverasn, peerasn) ~ bgp_community then
+        if ((peerasn < 65536) && ((routeserverasn, peerasn) ~ bgp_community)) || (ro, routeserverasn, peerasn) ~ bgp_ext_community then
                 return true;
-        if (0, routeserverasn) ~ bgp_community then
+        if (0, routeserverasn) ~ bgp_community || (ro, 0, routeserverasn) ~ bgp_ext_community then
                 return false;
 
         return true;

--- a/resources/views/api/v4/router/server/bird2/community-filter.foil.php
+++ b/resources/views/api/v4/router/server/bird2/community-filter.foil.php
@@ -69,16 +69,12 @@ function ixp_community_filter(int peerasn)
             return true;
 
 <?php endif; ?>
-    # it's unwise to conduct a 32-bit check on a 16-bit value
-    if peerasn > 65535 then
-            return true;
-
     # Implement widely used community filtering schema.
-    if (0, peerasn) ~ bgp_community then
+    if ((peerasn < 65536) && ((0, peerasn) ~ bgp_community)) || (ro, 0, peerasn) ~ bgp_ext_community then
             return false;
-    if (routeserverasn, peerasn) ~ bgp_community then
+    if ((peerasn < 65536) && ((routeserverasn, peerasn) ~ bgp_community)) || (ro, routeserverasn, peerasn) ~ bgp_ext_community then
             return true;
-    if (0, routeserverasn) ~ bgp_community then
+    if (0, routeserverasn) ~ bgp_community || (ro, 0, routeserverasn) ~ bgp_ext_community then
             return false;
 
     return true;


### PR DESCRIPTION
Currently, if you have route server peers with ASNs greater than 65535, the routes sent to those peers include routes which should be (and are for ASNs less than 65535) filtered by the standard community filtering.

This extends the config template with support for these larger ASNs.
