### PR TITLE
[BF] - hide download/view LOA for patch panel port without customer assigned

### DIFF
--- a/resources/views/patch-panel-port/action-dd.foil.php
+++ b/resources/views/patch-panel-port/action-dd.foil.php
@@ -102,7 +102,7 @@
         <?php endif; ?>
 
         <?php if( $t->tpl == "index"):?>
-            <?php if( $t->ppp->isAllocated() ): ?>
+            <?php if( $t->ppp->isAllocated() && $t->ppp->getCustomer() ): ?>
 
                 <a class="dropdown-item" href="<?= route( 'patch-panel-port@download-loa' , [ 'id' => $t->ppp->getId() ] ) ?>">
                     Download LoA

--- a/resources/views/patch-panel-port/view.foil.php
+++ b/resources/views/patch-panel-port/view.foil.php
@@ -297,7 +297,7 @@
                                             </tr>
                                         <?php endif; ?>
 
-                                        <?php if( $current && ( Auth::user()->isSuperUser() || $p->isStateAwaitingXConnect() ) ): ?>
+                                        <?php if( $current && ( Auth::user()->isSuperUser() || $p->isStateAwaitingXConnect() ) && $t->ppp->getCustomer() ): ?>
                                             <tr>
                                                 <td>
                                                     <b>


### PR DESCRIPTION
hide download/view LOA for patch panel port without customer assigned


In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
