### PR TITLE
Issue configured mac address management display 1 after the IP address

### DIFF
--- a/resources/views/layer2-address/vlan-interface.foil.php
+++ b/resources/views/layer2-address/vlan-interface.foil.php
@@ -50,8 +50,8 @@ Vlan Interface / Configured MAC Address Management
                         Addresses
                     </dt>
                     <dd class="col-sm-9">
-                        <?= !$t->vli->getIPv4Address() ?: $t->vli->getIPv4Address()->getAddress() . ( !$t->vli->getIPv6Address() ?: ' / ' ) ?>
-                        <?= !$t->vli->getIPv6Address() ?: $t->vli->getIPv6Address()->getAddress() ?>
+                        <?= $t->vli->getIPv4Address() ? $t->vli->getIPv4Address()->getAddress() . ( $t->vli->getIPv6Address() ? ' / ': '' ) : ''  ?>
+                        <?= $t->vli->getIPv6Address() ? $t->vli->getIPv6Address()->getAddress() : '' ?>
                     </dd>
                 </dl>
             </div>


### PR DESCRIPTION
Issue configured mac address management display 1 after the IP address
 
In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
