### PR TITLE
Error500 on User Mgmt - fixes inex/IXP-Manager#579

### DIFF
--- a/resources/views/user/edit.foil.php
+++ b/resources/views/user/edit.foil.php
@@ -107,7 +107,7 @@ Users  / <?= $t->isAdd ? 'Add' : 'Edit' ?>
                                         <th>
                                             Action
 
-                                            <a class="btn btn-white btn-sm ml-2" href="<?= route( "customer-to-user@add" , [ "email" => $t->user->getEmail() ] ) ?>">
+                                            <a id="add-c2u-btn" class="btn btn-white btn-sm ml-2" href="<?= route( "customer-to-user@add" , [ "email" => $t->user->getEmail() ] ) ?>">
                                                 <i class="fa fa-plus"></i>
                                             </a>
                                         </th>

--- a/resources/views/user/edit.foil.php
+++ b/resources/views/user/edit.foil.php
@@ -107,7 +107,7 @@ Users  / <?= $t->isAdd ? 'Add' : 'Edit' ?>
                                         <th>
                                             Action
 
-                                            <a class="btn btn-white btn-sm ml-2" href="<?= route( "customer-to-user@add" , [ "id" => $t->user->getEmail() ] ) ?>">
+                                            <a class="btn btn-white btn-sm ml-2" href="<?= route( "customer-to-user@add" , [ "email" => $t->user->getEmail() ] ) ?>">
                                                 <i class="fa fa-plus"></i>
                                             </a>
                                         </th>

--- a/tests/Browser/UserControllerTest.php
+++ b/tests/Browser/UserControllerTest.php
@@ -297,6 +297,31 @@ class UserControllerTest extends DuskTestCase
             $this->assertFalse(     $u->getDisabled()       );
 
 
+
+            /**
+             *
+             * Add customer to a user
+             *
+             */
+            $browser->click( "#d2f-list-edit-" . $u->getId() )
+                    ->click( "#add-c2u-btn")
+                    ->click( "#user-" . $u->getId() )
+                    ->select(   "#privs",   UserEntity::AUTH_CUSTADMIN )
+                    ->select(   "#cust",    3 )
+                    ->click( ".btn-primary" );
+
+
+            /** @var CustomerToUserEntity $c2u3 */
+            $c2u3 = D2EM::getRepository( CustomerToUserEntity::class )->findOneBy( [ 'user' => $u , "customer" => 3 ] );
+
+            // test the values:
+            $this->assertInstanceOf(CustomerToUserEntity::class   , $c2u3 );
+            $this->assertEquals(    3                             , $c2u3->getCustomer()->getId() );
+            $this->assertEquals(             $u->getId()                   , $c2u3->getUser()->getId() );
+            $this->assertEquals(    UserEntity::AUTH_CUSTADMIN    , $c2u3->getPrivs() );
+            $this->assertNotNull(           $c2u3->getCreatedAt() );
+
+
             /**
              *
              * Delete customer/user link
@@ -329,7 +354,7 @@ class UserControllerTest extends DuskTestCase
 
 
             $this->assertEquals( null   , D2EM::getRepository( CustomerToUserEntity::class )->findOneBy( [ 'user' => $u , "customer" => 2 ] ) );
-            $this->assertEquals( 1      , count( $u->getCustomers2User() ) );
+            $this->assertEquals( 2      , count( $u->getCustomers2User() ) );
 
 
             /**
@@ -340,7 +365,7 @@ class UserControllerTest extends DuskTestCase
 
             $browser->click(    "#d2f-list-delete-" . $u->getId() )
                     ->waitForText( "Delete User" )
-                    ->assertSee(   "Are you sure you want to delete this user and its 1 " . config( 'ixp_fe.lang.customer.one' ) . " links" )
+                    ->assertSee(   "Are you sure you want to delete this user and its 2 " . config( 'ixp_fe.lang.customer.one' ) . " links" )
                     ->press(     'Delete' );
 
             $browser->assertPathIs("/user/list" )


### PR DESCRIPTION
Error500 on User Mgmt

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
