### PR TITLE
[BF] - Insufficient permissions error from IRRDB prefixes page - fixe…

### DIFF
--- a/app/Http/Middleware/AssertUserPrivilege.php
+++ b/app/Http/Middleware/AssertUserPrivilege.php
@@ -24,10 +24,9 @@ namespace IXP\Http\Middleware;
  */
 
 
-use Auth;
-use Closure;
+use Auth, Closure;
 
-use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Http\Request;
 
 /**
  * Middleware: Assert an authentcated user is of a given privilege
@@ -46,14 +45,14 @@ class AssertUserPrivilege
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
+     * @param  Request  $request
+     * @param  Closure  $next
      * @return mixed
      */
     public function handle($request, Closure $next, $privilege)
     {
         if( Auth::user()->getPrivs() != $privilege ) {
-            return response( 'Insufficent permissions', 403 );
+            return response( 'Insufficient permissions', 403 );
         }
 
         return $next($request);

--- a/app/Http/Middleware/Services/LookingGlass.php
+++ b/app/Http/Middleware/Services/LookingGlass.php
@@ -100,7 +100,7 @@ class LookingGlass
             return true;
         }
 
-        abort( 401, "Insufficent permissions to access this looking glass" );
+        abort( 401, "Insufficient permissions to access this looking glass" );
     }
 
 

--- a/resources/views/irrdb/list.foil.php
+++ b/resources/views/irrdb/list.foil.php
@@ -6,8 +6,12 @@ $this->layout( 'layouts/ixpv4' );
 ?>
 
 <?php $this->section( 'page-header-preamble' ) ?>
-    <a href="<?= route( "customer@overview" , [ "id" => $t->customer->id ] ) ?>"><?= $t->customer->name ?></a>
-    /
+    <?php if(  Auth::user()->isSuperUser()  ): ?>
+        <a href="<?= route( "customer@overview" , [ "id" => $t->customer->id ] ) ?>">
+            <?= $t->customer->name ?>
+        </a>
+        /
+    <?php endif; ?>
     IRRDB <?= $t->type == "asn" ? 'ASNs' : 'Prefixes' ?> IPv<?= $t->protocol ?> Entries (<?= count($t->irrdbList) ?>)
 <?php $this->append() ?>
 


### PR DESCRIPTION
 Insufficient permissions error from IRRDB prefixes page

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
