### PR TITLE
[BF] - Wrong login history displayed for user - fixes inex/IXP-Manager#594

### DIFF
--- a/app/Http/Controllers/LoginHistoryController.php
+++ b/app/Http/Controllers/LoginHistoryController.php
@@ -141,14 +141,14 @@ class LoginHistoryController extends Doctrine2Frontend
      */
     public function view( Request $r, $id ): View
     {
-        /** @var $c2u CustomerToUserEntity */
-        if( !( $c2u = D2EM::getRepository( CustomerToUserEntity::class )->find( $id ) ) ) {
+        /** @var $u UserEntity */
+        if( !( $u = D2EM::getRepository( UserEntity::class )->find( $id ) ) ) {
             abort(404 );
         }
 
         return view( 'login-history/view' )->with([
-            'histories'                 => D2EM::getRepository( UserLoginHistoryEntity::class)->getAllForFeList( $c2u->getUser()->getId(), $r->input( 'limit', 0 ) ),
-            'user'                      => $c2u->getUser(),
+            'histories'                 => D2EM::getRepository( UserLoginHistoryEntity::class)->getAllForFeList( $u->getId(), $r->input( 'limit', 0 ) ),
+            'user'                      => $u,
         ]);
     }
 }

--- a/resources/views/customer/overview-tabs/users.foil.php
+++ b/resources/views/customer/overview-tabs/users.foil.php
@@ -72,7 +72,7 @@
                                     Resend welcome email
                                 </button>
                             </form>
-                            <a class="dropdown-item" href="<?= route( "login-history@view", [ 'id' => $c2u->getId() ] ) ?>">
+                            <a class="dropdown-item" href="<?= route( "login-history@view", [ 'id' => $c2u->getUser()->getId() ] ) ?>">
                                 Login history
                             </a>
                         </ul>


### PR DESCRIPTION
Wrong login history displayed for user

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
