### PR TITLE
[BF] - remove comma that was making php error

### DIFF
--- a/app/Http/Controllers/Switches/SwitchController.php
+++ b/app/Http/Controllers/Switches/SwitchController.php
@@ -775,7 +775,7 @@ class SwitchController extends Doctrine2Frontend
             $speed,
             $vlan ? $vlan->getId() : null,
             $r->input( 'rs-client' )    ? true : false,
-            $r->input( 'ipv6-enabled' ) ? true : false,
+            $r->input( 'ipv6-enabled' ) ? true : false
         );
 
         return view( 'switches/configuration' )->with([


### PR DESCRIPTION
Remove one comma that was breaking switch controller

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
