### PR TITLE
[NF] Switch to bgpq4

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -50,7 +50,7 @@ class Kernel extends ConsoleKernel {
             ->skip( function() { return env( 'TASK_SCHEDULER_SKIP_UPDATE_IN_MANRS', false ); } );
 
         // IRRDB - https://docs.ixpmanager.org/features/irrdb/
-        if( config( 'ixp.irrdb.bgpq3.path' ) && is_executable( config( 'ixp.irrdb.bgpq3.path' ) ) ) {
+        if( config( 'ixp.irrdb.bgpq4.path' ) && is_executable( config( 'ixp.irrdb.bgpq4.path' ) ) ) {
             $schedule->command( 'irrdb:update-prefix-db' )->cron( '7 */6 * * *' )
                 ->skip( function() { return env( 'TASK_SCHEDULER_SKIP_IRRDB_UPDATE_PREFIX_DB', false ); } );
 

--- a/app/Tasks/Irrdb/UpdateAsnDb.php
+++ b/app/Tasks/Irrdb/UpdateAsnDb.php
@@ -47,11 +47,11 @@ class UpdateAsnDb extends UpdateDb
     public function update(): array
     {
         if( $this->customer()->isRouteServerClient() && $this->customer()->isIrrdbFiltered() ) {
-            $this->bgpq3()->setSources( $this->customer()->getIRRDB()->getSource() );
+            $this->bgpq4()->setSources( $this->customer()->getIRRDB()->getSource() );
 
             foreach( $this->protocols() as $protocol ) {
                 $this->startTimer();
-                $asns = $this->bgpq3()->getAsnList( $this->customer()->resolveAsMacro( $protocol, 'as' ), $protocol );
+                $asns = $this->bgpq4()->getAsnList( $this->customer()->resolveAsMacro( $protocol, 'as' ), $protocol );
                 $this->result[ 'netTime' ] += $this->timeElapsed();
 
                 $this->result[ 'v' . $protocol ][ 'count' ] = count( $asns );

--- a/app/Tasks/Irrdb/UpdateDb.php
+++ b/app/Tasks/Irrdb/UpdateDb.php
@@ -29,7 +29,7 @@ use Entities\Customer;
 use Exception;
 use IXP\Exceptions\ConfigurationException;
 use IXP\Exceptions\GeneralException;
-use IXP\Utils\Bgpq3;
+use IXP\Utils\Bgpq4;
 use Log;
 
 /**
@@ -44,11 +44,11 @@ use Log;
 abstract class UpdateDb
 {
     /**
-     * BGPQ3 Utility Interface details object.
+     * BGPQ4 Utility Interface details object.
      *
-     * @var Bgpq3
+     * @var Bgpq4
      */
-    private $bgpq3 = null;
+    private $bgpq4 = null;
 
     /**
      * Customer to update prefixes of
@@ -111,7 +111,7 @@ abstract class UpdateDb
             $this->protocols = $protocols;
         }
 
-        $this->setBgpq3( new Bgpq3( config( 'ixp.irrdb.bgpq3.path' ) ) );
+        $this->setBgpq4( new Bgpq4( config( 'ixp.irrdb.bgpq4.path' ) ) );
     }
 
     /**
@@ -146,24 +146,24 @@ abstract class UpdateDb
 
 
     /**
-     * Set the Bgpq3 utility
+     * Set the Bgpq4 utility
      *
-     * @param Bgpq3 $bgpq3
+     * @param Bgpq4 $bgpq4
      * @return UpdateDb
      * @throws ConfigurationException
      */
-    public function setBgpq3( Bgpq3 $bgpq3 ): UpdateDb {
-        $this->bgpq3 = $bgpq3;
+    public function setBgpq4( Bgpq4 $bgpq4 ): UpdateDb {
+        $this->bgpq4 = $bgpq4;
         return $this;
     }
 
     /**
-     * Get the Bgpq3 utility
+     * Get the Bgpq4 utility
      *
-     * @return Bgpq3
+     * @return Bgpq4
      */
-    public function bgpq3(): Bgpq3 {
-        return $this->bgpq3;
+    public function bgpq4(): Bgpq4 {
+        return $this->bgpq4;
     }
 
     /**
@@ -218,7 +218,7 @@ abstract class UpdateDb
         $fromDb = D2EM::getRepository( $entity )->getForCustomerAndProtocol( $this->customer(), $protocol );
         $this->result['dbTime'] += $this->timeElapsed();
 
-        // The calling function and the Bgpq3 class does a lot of validation and error
+        // The calling function and the Bgpq4 class does a lot of validation and error
         // checking. But the last thing we need to do is start filtering all prefixes/ASNs if
         // something falls through to here. So, as a basic check, make sure we do not accept
         // an empty array of prefixes/ASNs for a customer that has a lot.
@@ -227,7 +227,7 @@ abstract class UpdateDb
             // make sure the customer doesn't have a non-empty prefix/ASN set that we're about to delete
             if( count( $fromDb ) != 0 ) {
                 $msg = "IRRDB {$type}: {$this->customer()->getName()} has a non-zero {$type} count for IPv{$protocol} in the database but "
-                    . "BGPQ3 returned none. Please examine manually. No databases changes made for this customer.";
+                    . "BGPQ4 returned none. Please examine manually. No databases changes made for this customer.";
                 Log::alert( $msg );
                 $result['msg'] = $msg;
             }

--- a/app/Tasks/Irrdb/UpdatePrefixDb.php
+++ b/app/Tasks/Irrdb/UpdatePrefixDb.php
@@ -48,11 +48,11 @@ class UpdatePrefixDb extends UpdateDb
      */
     public function update(): array {
         if( $this->customer()->isRouteServerClient() && $this->customer()->isIrrdbFiltered() ) {
-            $this->bgpq3()->setSources($this->customer()->getIRRDB()->getSource());
+            $this->bgpq4()->setSources($this->customer()->getIRRDB()->getSource());
 
             foreach( $this->protocols() as $protocol ) {
                 $this->startTimer();
-                $prefixes = $this->bgpq3()->getPrefixList($this->customer()->resolveAsMacro($protocol, 'as'), $protocol);
+                $prefixes = $this->bgpq4()->getPrefixList($this->customer()->resolveAsMacro($protocol, 'as'), $protocol);
                 $this->result['netTime'] += $this->timeElapsed();
 
                 $this->result['v' . $protocol]['count'] = count($prefixes);

--- a/app/Utils/Bgpq4.php
+++ b/app/Utils/Bgpq4.php
@@ -27,17 +27,17 @@ use IXP\Exceptions\GeneralException as Exception;
 use IXP\Exceptions\ConfigurationException;
 
 /**
- * Interface for the BQPQ3 command line utility
+ * Interface for the BGPQ4 command line utility
  *
- * @see http://snar.spb.ru/prog/bgpq3/
+ * @see https://github.com/bgp/bgpq4/
  *
  * @author Barry O'Donovan <barry@opensolutions.ie>
  */
-class Bgpq3
+class Bgpq4
 {
     /**
-     * Full executable path of the BGPQ3 utility
-     * @var string Full executable path of the BGPQ3 utility
+     * Full executable path of the BGPQ4 utility
+     * @var string Full executable path of the BGPQ4 utility
      */
     private $path = null;
 
@@ -57,7 +57,7 @@ class Bgpq3
     /**
      * Constructor
      *
-     * @param string $path The full executable path of the BGPQ3 utility
+     * @param string $path The full executable path of the BGPQ4 utility
      * @param string $whois Whois server - defaults to BGPQ's own default
      * @param string $sources Whois server sources - defaults to BGPQ's own default
      * @throws ConfigurationException
@@ -65,7 +65,7 @@ class Bgpq3
     public function __construct( $path, $whois = null, $sources = null )
     {
         if( !$path || !is_file( $path ) || !is_executable( $path ) ) {
-            throw new ConfigurationException('You must set the configuration option IXP_IRRDB_BGPQ3_PATH and it must be the absolute path to the executable bgpq3 utility.');
+            throw new ConfigurationException('You must set the configuration option IXP_IRRDB_BGPQ4_PATH and it must be the absolute path to the executable bgpq4 utility.');
         }
 
 
@@ -124,7 +124,7 @@ class Bgpq3
      */
     public function getAsnList( $asmacro, $proto = 4 )
     {
-        $json = $this->execute( '-3j -l pl -f 999 ' . escapeshellarg( $asmacro ), false );
+        $json = $this->execute( '-j -l pl -f 999 ' . escapeshellarg( $asmacro ), false );
         $array = json_decode( $json, true );
 
         if( $array === null )
@@ -147,7 +147,7 @@ class Bgpq3
      *
      * @param string $cmd The query part ot the BGPQ command. I.e. other switches besides -6, -h, -S.
      * @param int $proto The protocol. If 6, adds the -6 switch
-     * @throws Exception If return code from BGPQ3 is != 0
+     * @throws Exception If return code from BGPQ4 is != 0
      * @return string The output from the shell command.
      */
     private function execute( $cmd, $proto = 4 )
@@ -169,7 +169,7 @@ class Bgpq3
         exec( $cmd, $output, $return_var );
 
         if( $return_var != 0 )
-            throw new Exception( 'Error executing BGPQ3 with: ' . $cmd );
+            throw new Exception( 'Error executing BGPQ4 with: ' . $cmd );
 
         return implode( "\n", $output );
     }
@@ -179,7 +179,7 @@ class Bgpq3
      * The whois server to query
      *
      * @param string $whois The whois server to query
-     * @return Bgpq3 For fluent interfaces
+     * @return Bgpq4 For fluent interfaces
      */
     public function setWhois( $whois )
     {
@@ -191,7 +191,7 @@ class Bgpq3
      * The whois server sources
      *
      * @param string $sources The whois server sources
-     * @return Bgpq3 For fluent interfaces
+     * @return Bgpq4 For fluent interfaces
      */
     public function setSources( $sources )
     {
@@ -203,7 +203,7 @@ class Bgpq3
      * The executable path to the BGPQ executable
      *
      * @param string $path The executable path to the BGPQ executable
-     * @return Bgpq3 For fluent interfaces
+     * @return Bgpq4 For fluent interfaces
      */
     public function setPath( $path )
     {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,15 +42,22 @@ apt-get update
 apt full-upgrade -y
 apt autoremove -y
 
-apt-get install -y apache2 php7.3 php7.3-intl php7.3-mysql php-rrd php7.3-cgi php7.3-cli php7.3-snmp php7.3-curl               \
-    php-memcached libapache2-mod-php7.3 mysql-server mysql-client php-mysql memcached snmp                                     \
-    php7.3-mbstring php7.3-xml php7.3-gd php-gettext bgpq3 php-memcache unzip php-zip git php-yaml php-ds php7.3-bcmath        \
-    libconfig-general-perl libnetaddr-ip-perl mrtg  libconfig-general-perl libnetaddr-ip-perl rrdtool librrds-perl
+apt-get install -y \
+	apache2 autoconf automake build-essential libapache2-mod-php7.3		\
+	libconfig-general-perl libconfig-general-perl libnetaddr-ip-perl	\
+	libnetaddr-ip-perl librrds-perl memcached mrtg mysql-client		\
+	mysql-server php-ds php-gettext php-memcache php-memcached php-mysql	\
+	php-rrd php-yaml php-zip php7.3 php7.3-bcmath php7.3-cgi php7.3-cli	\
+	php7.3-curl php7.3-gd php7.3-intl php7.3-mbstring php7.3-mysql		\
+	php7.3-snmp php7.3-xml rrdtool snmp unzip
 
 if ! [ -L /var/www ]; then
   rm -rf /var/www
   ln -fs /vagrant/public /var/www
 fi
+
+cd /tmp && git clone https://github.com/bgp/bgpq4
+cd bgpq4 && ./bootstrap && ./configure && make && make install
 
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/config/ixp.php
+++ b/config/ixp.php
@@ -105,15 +105,15 @@ return [
        ;; */
 
     'irrdb' => [
-        'bgpq3' => [
-            'path' => env( 'IXP_IRRDB_BGPQ3_PATH', false ),
+        'bgpq4' => [
+            'path' => env( 'IXP_IRRDB_BGPQ4_PATH', false ),
         ],
 
         // ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
         // Minimum subnet sizes
         //
         // Used by the route server/collector/as112 templates and
-        // the bgpq3 command line.
+        // the bgpq4 command line.
         // Templates:
         //   - resources/views/api/v4/router/as112/bird/header.foil.php
         //   - resources/views/api/v4/router/collector/bird/header.foil.php

--- a/database/Entities/Customer.php
+++ b/database/Entities/Customer.php
@@ -2201,7 +2201,7 @@ class Customer
      * Useful function to get the appropriate AS macro or ASN for a customer
      * for a given protocol.
      *
-     * One example usage is in IrrdbCli for bgpq3. bgpq3 requires ASNs to
+     * One example usage is in IrrdbCli for bgpq4. bgpq4 requires ASNs to
      * be formatted as `asxxxx` so we set `$asnPrefix = 'as'` in this case.
      *
      * By default, the function will return some format of the ASN if no macro is

--- a/resources/views/irrdb-config/edit-form.foil.php
+++ b/resources/views/irrdb-config/edit-form.foil.php
@@ -23,13 +23,13 @@
 
             <?= Former::text( 'protocol' )
                 ->label( 'Protocol' )
-                ->blockHelp( "This is no longer used as bgpq3 does not require this parameter and we will most likely deprecate this in time.<br><br>"
+                ->blockHelp( "This is no longer used as bgpq4 does not require this parameter and we will most likely deprecate this in time.<br><br>"
                     . "For now, if querying RADB, set it to <code>irrd</code>; otherwise use <code>ripe</code>." );
             ?>
 
             <?= Former::text( 'source' )
                 ->label( 'Source' )
-                ->blockHelp( "Which IRRDB dataset source(s) to use as a comma separated list. E.g. bgpq3 recommend <code>RADB,RIPE,APNIC</code>.<br><br>"
+                ->blockHelp( "Which IRRDB dataset source(s) to use as a comma separated list. E.g. bgpq4 recommend <code>RADB,RIPE,APNIC</code>.<br><br>"
                     . "A set of supported datasets supported by RADB <a href='http://www.radb.net/query/?advanced_query=1'>can be found here</a>." );
             ?>
 

--- a/resources/views/irrdb-config/list-postamble.foil.php
+++ b/resources/views/irrdb-config/list-postamble.foil.php
@@ -11,7 +11,7 @@
                 from which IXP Manager pulls a member's configured IRRDB entries.
             </p>
 
-            IXP Manager uses <a href="https://github.com/snar/bgpq3" target="_blank">bgpq3</a> to pull this detail. We have
+            IXP Manager uses <a href="https://github.com/bgp/bgpq4" target="_blank">bgpq4</a> to pull this detail. We have
             <a href="http://docs.ixpmanager.org/features/irrdb/" target="_blank">further official IXP Manager documentation here</a>.
         </div>
     </div>

--- a/tools/installers/ubuntu-lts-1604-ixp-manager-v4.sh
+++ b/tools/installers/ubuntu-lts-1604-ixp-manager-v4.sh
@@ -314,10 +314,13 @@ echo -n "Installing PHP, Apache, MySQL, etc. Please be very patient..."
 # Prevent mrtg from prompting
 echo mrtg mrtg/conf_mods boolean true | debconf-set-selections
 
-log_break && apt-get install -qy apache2 php7.0 php7.0-intl php-rrd php7.0-cgi php7.0-cli php7.0-snmp php7.0-curl php7.0-mcrypt  \
-    php-memcached libapache2-mod-php7.0 mysql-server mysql-client php7.0-mysql memcached snmp nodejs nodejs-legacy npm           \
-    php7.0-mbstring php7.0-xml php7.0-gd php7.0-bcmath php-gettext bgpq3 php-memcache unzip php7.0-zip git php-yaml php-ds       \
-    libconfig-general-perl libnetaddr-ip-perl mrtg  libconfig-general-perl libnetaddr-ip-perl rrdtool librrds-perl curl          \
+log_break && apt-get install -qy \
+    apache2 autoconf automake build-essential curl git libapache2-mod-php7.0    \
+    libconfig-general-perl libnetaddr-ip-perl librrds-perl memcached mrtg       \
+    mysql-client mysql-server nodejs nodejs-legacy npm php-ds php-gettext       \
+    php-memcache php-memcached php-rrd php-yaml php7.0 php7.0-bcmath php7.0-cgi \
+    php7.0-cli php7.0-curl php7.0-gd php7.0-intl php7.0-mbstring php7.0-mcrypt  \
+    php7.0-mysql php7.0-snmp php7.0-xml php7.0-zip rrdtool snmp unzip           \
         &>> /tmp/ixp-manager-install.log
 echo '[done]'
 
@@ -503,7 +506,7 @@ DOCTRINE_CACHE=memcached
 DOCTRINE_CACHE_NAMESPACE=IXPMANAGERNAMESPACE
 
 
-IXP_IRRDB_BGPQ3_PATH="/usr/bin/bgpq3"
+IXP_IRRDB_BGPQ4_PATH="/usr/local/bin/bgpq4"
 
 END_ENV
 

--- a/tools/installers/ubuntu-lts-1804-ixp-manager-v5.sh
+++ b/tools/installers/ubuntu-lts-1804-ixp-manager-v5.sh
@@ -316,7 +316,7 @@ echo mrtg mrtg/conf_mods boolean true | debconf-set-selections
 
 log_break && apt-get install -qy apache2 php7.3 php7.3-intl php-rrd php7.3-cgi php7.3-cli php7.3-snmp php7.3-curl                \
     php-memcached libapache2-mod-php7.3 mysql-server mysql-client php7.3-mysql memcached snmp                                    \
-    php7.3-mbstring php7.3-xml php7.3-gd php7.3-bcmath php-gettext bgpq3 php-memcache unzip php7.3-zip git php-yaml php-ds       \
+    php7.3-mbstring php7.3-xml php7.3-gd php7.3-bcmath php-gettext bgpq4 php-memcache unzip php7.3-zip git php-yaml php-ds       \
     libconfig-general-perl libnetaddr-ip-perl mrtg  libconfig-general-perl libnetaddr-ip-perl rrdtool librrds-perl curl          \
         &>> /tmp/ixp-manager-install.log
 echo '[done]'
@@ -503,7 +503,7 @@ DOCTRINE_CACHE=memcached
 DOCTRINE_CACHE_NAMESPACE=IXPMANAGERNAMESPACE
 
 
-IXP_IRRDB_BGPQ3_PATH="/usr/bin/bgpq3"
+IXP_IRRDB_BGPQ4_PATH="/usr/local/bin/bgpq4"
 
 END_ENV
 


### PR DESCRIPTION
bgpq4 is a fork of bgpq3, aiming to be faster & better.

*Longer description*

- bgpq4 supports the new `IRRd v4` `!a` query, offering some speedup
- there is no `bgpq4` debian package yet, so paths probably are `/usr/local/bin`
- bgpq4 deprecated the '-3' command line option (32-bit ASN support is now enabled by default) 
  
