### PR TITLE
[BF] - switch configuration generate error 500

### DIFF
--- a/resources/views/switches/configuration.foil.php
+++ b/resources/views/switches/configuration.foil.php
@@ -176,17 +176,21 @@
                         <?= $conf[ "switchid" ] ?>
                     </td>
                     <td>
-                        <?php if( Auth::getUser()->isSuperUser() ): ?>
-                            <a href="<?= route( "customer@overview" , [ "id" => $conf[ "custid" ] ] ) ?>"><?= $conf[ "customer" ] ?></a>
-                        <?php else: ?>
-                            <a href="<?= route( "customer@detail"   , [ "id" => $conf[ "custid" ] ] ) ?>"><?= $conf[ "customer" ] ?></a>
+                        <?php if( $conf[ "custid" ] ): ?>
+                            <?php if( Auth::getUser()->isSuperUser() ): ?>
+                                <a href="<?= route( "customer@overview" , [ "id" => $conf[ "custid" ] ] ) ?>"><?= $conf[ "customer" ] ?></a>
+                            <?php else: ?>
+                                <a href="<?= route( "customer@detail"   , [ "id" => $conf[ "custid" ] ] ) ?>"><?= $conf[ "customer" ] ?></a>
+                            <?php endif; ?>
                         <?php endif; ?>
                     </td>
                     <td>
-                        <?php if( Auth::getUser()->isSuperUser() ): ?>
-                            <a href="<?= route( "switch@port-report"    , [ "id" => $conf[ "switchid" ] ] ) ?>"><?= $conf[ "switchname" ] ?></a>
-                        <?php else: ?>
-                            <a href="<?= route( "switch@configuration"  , [ "id" => $conf[ "switchid" ] ] ) ?>"><?= $conf[ "switchname" ] ?></a>
+                        <?php if( $conf[ "switchid" ] ): ?>
+                            <?php if( Auth::getUser()->isSuperUser() ): ?>
+                                <a href="<?= route( "switch@port-report"    , [ "id" => $conf[ "switchid" ] ] ) ?>"><?= $conf[ "switchname" ] ?></a>
+                            <?php else: ?>
+                                <a href="<?= route( "switch@configuration"  , [ "id" => $conf[ "switchid" ] ] ) ?>"><?= $conf[ "switchname" ] ?></a>
+                            <?php endif; ?>
                         <?php endif; ?>
                     </td>
                     <td>


### PR DESCRIPTION
switch configuration generate error 500
 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
