### PR TITLE
[BF] - fix issue : last logins -> login history ->  view -> generate 404

### DIFF
--- a/database/Repositories/User.php
+++ b/database/Repositories/User.php
@@ -126,7 +126,8 @@ class User extends EntityRepository
                         u.email AS email, 
                         c.name AS cust_name, 
                         c.id AS cust_id, 
-                        c2u.id AS id
+                        c2u.id AS c2u_id,
+                        u.id AS id
                     FROM Entities\\CustomerToUser c2u
                         JOIN c2u.user u
                         JOIN c2u.customer c";


### PR DESCRIPTION
Fix the 404 error when trying to view a login history via last logins entry menu
 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
