### PR TITLE
[DUSK] - remember me session management

### DIFF
--- a/resources/views/auth/login.foil.php
+++ b/resources/views/auth/login.foil.php
@@ -62,7 +62,7 @@
 
             <div class="tw-mb-6">
                 <label class="tw-block tw-text-grey-dark tw-font-bold">
-                    <input class="tw-mr-2 tw-leading-tight" type="checkbox" name="remember" value="1">
+                    <input class="tw-mr-2 tw-leading-tight" type="checkbox" name="remember" id="remember-me" value="1">
                     <span class="tw-text-sm">
                         Remember me
                     </span>

--- a/resources/views/layouts/menus/associate.foil.php
+++ b/resources/views/layouts/menus/associate.foil.php
@@ -128,7 +128,7 @@
                         Profile
                     </a>
 
-                    <a class="dropdown-item <?= !request()->is( 'active-sessions/list' ) ?: 'active' ?>" href="<?= route('active-sessions@list' )?>">
+                    <a id="active-sessions" class="dropdown-item <?= !request()->is( 'active-sessions/list' ) ?: 'active' ?>" href="<?= route('active-sessions@list' )?>">
                         Active Sessions
                     </a>
 

--- a/resources/views/layouts/menus/custadmin.foil.php
+++ b/resources/views/layouts/menus/custadmin.foil.php
@@ -179,7 +179,7 @@
                         API Keys
                     </a>
 
-                    <a class="dropdown-item <?= !request()->is( 'active-sessions/list' ) ?: 'active' ?>" href="<?= route('active-sessions@list' )?>">
+                    <a id="active-sessions" class="dropdown-item <?= !request()->is( 'active-sessions/list' ) ?: 'active' ?>" href="<?= route('active-sessions@list' )?>">
                         Active Sessions
                     </a>
 

--- a/resources/views/layouts/menus/custuser.foil.php
+++ b/resources/views/layouts/menus/custuser.foil.php
@@ -171,7 +171,7 @@
                         API Keys
                     </a>
 
-                    <a class="dropdown-item <?= !request()->is( 'active-sessions/list' ) ?: 'active' ?>" href="<?= route('active-sessions@list' )?>">
+                    <a id="active-sessions" class="dropdown-item <?= !request()->is( 'active-sessions/list' ) ?: 'active' ?>" href="<?= route('active-sessions@list' )?>">
                         Active Sessions
                     </a>
 

--- a/resources/views/layouts/menus/superuser.foil.php
+++ b/resources/views/layouts/menus/superuser.foil.php
@@ -138,7 +138,7 @@
 
                     <a class="dropdown-item <?= !request()->is( 'api-key/list' ) ?: 'active' ?>" href="<?= route('api-key@list' )?>">API Keys</a>
 
-                    <a class="dropdown-item <?= !request()->is( 'active-sessions/list' ) ?: 'active' ?>" href="<?= route('active-sessions@list' )?>">
+                    <a id="active-sessions" class="dropdown-item <?= !request()->is( 'active-sessions/list' ) ?: 'active' ?>" href="<?= route('active-sessions@list' )?>">
                         Active Sessions
                     </a>
 

--- a/tests/Browser/UserRememberTokenControllerTest.php
+++ b/tests/Browser/UserRememberTokenControllerTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * Copyright (C) 2009 - 2020 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GpNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace Tests\Browser;
+
+use Auth, D2EM;
+
+use Entities\{
+    User                as UserEntity,
+    UserRememberToken   as UserRememberTokenEntity,
+};
+
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+
+class UserRememberTokenControllerTest extends DuskTestCase
+{
+
+    /**
+     * A Dusk test example.
+     *
+     * @return void
+     * @throws
+     */
+    public function testAdd()
+    {
+
+        $this->browse(function ( Browser $browser, Browser $browser2 ) {
+
+            /** @var UserEntity $user */
+            $user = D2EM::getRepository( UserEntity::class )->findOneBy( [ 'username' => 'travis'  ] );
+
+            $cookieName = Auth::getRecallerName();
+
+            $browser->resize( 1600,1200 )
+                    ->visit('/logout')
+                    ->visit('/login')
+                    ->type('username', $user->getUsername() )
+                    ->type('password', 'travisci' )
+                    ->press('#login-btn' )
+                    ->assertPathIs( '/admin' );
+
+            /**
+             * Check that the remember cookie and DB entry is not existing as we didnt checked the remember me checkbox
+             */
+            $browser->assertCookieMissing( $cookieName );
+
+            $listUrt = D2EM::getRepository( UserRememberTokenEntity::class )->findBy( [ 'User' => $user->getId()  ] );
+
+            $this->assertEquals( 0, count( $listUrt ) );
+
+            /**
+             * Login checking the checkbox remember me
+             */
+            $browser->resize( 1600,1200 )
+                    ->visit('/logout')
+                    ->visit('/login')
+                    ->type('username', 'travis' )
+                    ->type('password', 'travisci' )
+                    ->check( '#remember-me')
+                    ->press('#login-btn' )
+                    ->assertPathIs( '/admin' );
+
+            /**
+             * Check that the remember cookie and DB entry is existing as we checked the remember me checkbox
+             */
+            $browser->assertHasCookie( $cookieName );
+
+            $listUrt = D2EM::getRepository( UserRememberTokenEntity::class )->findBy( [ 'User' => $user->getId()  ] );
+
+            $this->assertEquals( 1, count( $listUrt ) );
+
+
+
+            /**
+             * Open a new browser and login
+             */
+            $browser2->resize( 1600,1200 )
+                ->visit('/logout')
+                ->visit('/login')
+                ->type('username', 'travis' )
+                ->type('password', 'travisci' )
+                ->check( '#remember-me')
+                ->press('#login-btn' )
+                ->assertPathIs( '/admin' );
+
+            /**
+             * Check that the remember cookie exist in the new browser
+             */
+            $browser2->assertHasCookie( $cookieName );
+
+            /**
+             * Check that the user has 2 active sessions
+             */
+            $listUrt = D2EM::getRepository( UserRememberTokenEntity::class )->findBy( [ 'User' => $user->getId()  ] );
+
+            $this->assertEquals( 2, count( $listUrt ) );
+
+            /**
+             * Delete an active session
+             */
+            $browser->click('#my-account')
+                    ->click("#active-sessions")
+                    ->assertPathIs('/active-sessions/list');
+
+            // Get the last user remember token for the user
+            $lastUrt = D2EM::getRepository( UserRememberTokenEntity::class )->findOneBy( [ 'User' => $user->getId() ], [ 'id' => 'DESC' ] );
+
+            $browser->press("#d2f-list-delete-" . $lastUrt->getId() )
+                ->waitForText( 'Do you really want to delete this active login session?' )
+                ->press('Delete')
+                ->assertPathIs('/active-sessions/list' )
+                ->assertSee( 'Active Login Session deleted.' );
+
+
+            D2EM::refresh( $lastUrt );
+
+            $listUrt = D2EM::getRepository( UserRememberTokenEntity::class )->findBy( [ 'User' => $user->getId()  ] );
+
+            $this->assertEquals( 1, count( $listUrt ) );
+
+            /**
+             * Refresh the second browser and check that we have been logged out
+             */
+            $browser2->refresh()
+                    ->assertPathIs( '/login' );
+
+            /**
+             * Refresh the first browser and check that we are still logged in
+             */
+            $browser->refresh()
+                ->assertPathIs( '/active-sessions/list' );
+
+
+            /**
+             * Delete the user remember token left for the user and check that the user is loggued out
+             */
+            // Get the user remember token left for the user
+            $urt = D2EM::getRepository( UserRememberTokenEntity::class )->findOneBy( [ 'User' => $user->getId() ] );
+
+            $browser->press("#d2f-list-delete-" . $urt->getId() )
+                ->waitForText( 'Do you really want to delete this active login session?' )
+                ->press('Delete')
+                ->assertPathIs('/login' )
+                ->assertSee( 'You have been logged out.' );
+        });
+
+
+    }
+
+}


### PR DESCRIPTION
Remember me session management

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
