### PR TITLE
Update p2p-single.foil.php

### DIFF
--- a/resources/views/statistics/p2p-single.foil.php
+++ b/resources/views/statistics/p2p-single.foil.php
@@ -36,14 +36,15 @@
 
             <a href="<?= route( 'statistics@member', [ 'id' => $t->c->getId() ] ) ?>" >
                 Traffic Exchanged with
-                <a href="<?= route( 'statistics@p2p', [ 'cid' => $dstVli->getVirtualInterface()->getCustomer()->getId() ] )
-                    . '?svli='     . $dstVli->getId()
-                    . '&dvli='     . $srcVli->getId()
-                    . '&category=' . $t->category
-                    . '&period='   . $t->period
-                    . '&protocol=' . $t->protocol
-                ?>">
-                    <?= $dstVli->getVirtualInterface()->getCustomer()->getFormattedName() ?>
+            </a>
+            <a href="<?= route( 'statistics@p2p', [ 'cid' => $dstVli->getVirtualInterface()->getCustomer()->getId() ] )
+                . '?svli='     . $dstVli->getId()
+                . '&dvli='     . $srcVli->getId()
+                . '&category=' . $t->category
+                . '&period='   . $t->period
+                . '&protocol=' . $t->protocol
+            ?>">
+                <?= $dstVli->getVirtualInterface()->getCustomer()->getFormattedName() ?>
             </a>
 
 


### PR DESCRIPTION
This nesting of \<a href=...\>\<a href=...\>\</a\> is definitely incorrect.  I'm not sure I reconstructed it to what was originally intended, but every one \<a href=...\> should have one associated \</a\> with it, and they should not be nested into each other.

Came across it because as a superuser I see

CustomerA (AS65001) / Statistics / Peer to Peer Graphs / Traffic Exchanged withCustomerB (AS65002) 

(note the missing space in "withCustomerB").