### PR TITLE
[BF] - Bug in Switches List Live Port State section - fixes inex/IXP-Manager#621

### DIFF
--- a/app/Http/Controllers/Switches/SwitchPortController.php
+++ b/app/Http/Controllers/Switches/SwitchPortController.php
@@ -515,7 +515,8 @@ class SwitchPortController extends Doctrine2Frontend
         $this->feParams->pagetitlepostamble             = 'MAU Interface Detail for ' . $s->getName() ;
 
         $this->data[ 'params' ][ 'switches' ]           = $switches;
-        $this->data[ 'params' ][ 'switch' ]             = $s->getId();
+        $this->data[ 'params' ][ 'switch' ]             = $s;
+        $this->data[ 'params' ][ 'switchid' ]           = $s->getId();
 
         $this->setUpViews();
         $this->data[ 'view' ][ 'pageBreadcrumbs']       = $this->resolveTemplate( 'page-bread-crumbs',          false );
@@ -617,7 +618,8 @@ class SwitchPortController extends Doctrine2Frontend
         $this->setUpOpStatus();
 
         $this->data[ 'params' ][ 'portStates' ]     = Iface::$IF_OPER_STATES;
-        $this->data[ 'params' ][ 'switch' ]         = $s->getId();
+        $this->data[ 'params' ][ 'switch' ]         = $s;
+        $this->data[ 'params' ][ 'switchid' ]       = $s->getId();
         $this->data[ 'params' ][ 'switches']        = D2EM::getRepository( SwitcherEntity::class  )->getNames();
 
         $this->data[ 'rows' ] =  $this->listGetData();


### PR DESCRIPTION
Quick fix
 
In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
