### PR TITLE
Implements #629 - Port-Specific Custom VLAN Tag

### DIFF
--- a/app/Http/Controllers/Interfaces/VirtualInterfaceController.php
+++ b/app/Http/Controllers/Interfaces/VirtualInterfaceController.php
@@ -316,6 +316,7 @@ class VirtualInterfaceController extends Common
         $vli->setRsclient(          $request->input( 'rsclient',        false ) );
         $vli->setAs112client(       $request->input( 'as112client',     false ) );
         $vli->setBusyhost(          false );
+        $vli->setCustomvlantag(     $request->input( 'customvlantag',   false ) );
 
         if( !$this->setIp($request, $v, $vli, false ) || !$this->setIp($request, $v, $vli, true ) ) {
             return Redirect::to('virtualInterface/add-wizard' )->withInput( $request->all() );

--- a/app/Http/Controllers/Interfaces/VlanInterfaceController.php
+++ b/app/Http/Controllers/Interfaces/VlanInterfaceController.php
@@ -144,6 +144,7 @@ class VlanInterfaceController extends Common
                 'rsmorespecifics'           => $request->old( 'rsmorespecifics',         ( $vli->getRsMoreSpecifics()  ? 1 : 0 ) ),
                 'as112client'               => $request->old( 'as112client',             ( $vli->getAs112client()      ? 1 : 0 ) ),
                 'busyhost'                  => $request->old( 'busyhost',                ( $vli->getBusyhost()         ? 1 : 0 ) ),
+                'customvlantag'             => $request->old( 'customvlantag',           ( $vli->getCustomVlanTag()    ? 1 : 0 ) ),
 
                 'ipv6-enabled'              => $request->old( 'ipv6-enabled',            ( $vli->getIpv6enabled()      ? 1 : 0 ) ),
                 'ipv6-address'              => $request->old( 'ipv6-address',            ( $vli->getIPv6Address()      ? $vli->getIPv6Address()->getId() : null ) ),
@@ -215,6 +216,7 @@ class VlanInterfaceController extends Common
         $vli->setRsclient(          $request->input( 'rsclient',        false ) );
         $vli->setAs112client(       $request->input( 'as112client',     false ) );
         $vli->setBusyhost(          $request->input( 'busyhost',        false ) );
+        $vli->setCustomvlantag(     $request->input( 'customvlantag',   false ) );
         D2EM::flush();
 
         // add a warning if we're filtering on irrdb but have not configured one for the customer

--- a/app/Http/Requests/StoreVirtualInterfaceWizard.php
+++ b/app/Http/Requests/StoreVirtualInterfaceWizard.php
@@ -57,6 +57,7 @@ class StoreVirtualInterfaceWizard extends FormRequest
             'cust'                  => 'required|integer|exists:Entities\Customer,id',
             'vlan'                  => 'required|integer|exists:Entities\Vlan,id',
             'trunk'                 => 'boolean',
+            'customvlantag'         => 'integer',
 
             'switch'                => 'required|integer|exists:Entities\Switcher,id',
             'switch-port'           => 'required|integer|exists:Entities\SwitchPort,id',

--- a/app/Http/Requests/StoreVlanInterface.php
+++ b/app/Http/Requests/StoreVlanInterface.php
@@ -54,6 +54,7 @@ class StoreVlanInterface extends FormRequest
             'maxbgpprefix'          => 'integer|nullable',
             'mcastenabled'          => 'boolean',
             'busyhost'              => 'boolean',
+            'customvlantag'         => 'integer',
             'rsclient'              => 'boolean',
             'irrdbfilter'           => 'boolean',
             'rsmorespecifics'       => 'boolean',

--- a/app/Tasks/Yaml/SwitchConfigurationGenerator.php
+++ b/app/Tasks/Yaml/SwitchConfigurationGenerator.php
@@ -130,7 +130,7 @@ class SwitchConfigurationGenerator
             /** @var \Entities\VlanInterface $vli */
             $v = [];
             $v[ 'number' ] = $vli->getVlan()->getNumber();
-
+            $v[ 'customVlanTag' ] = $vli->getCustomvlantag();
             $v[ 'macaddresses' ] = [];
             foreach( $vli->getLayer2Addresses() as $mac ) {
                 $v[ 'macaddresses' ][] = $mac->getMacFormattedWithColons();

--- a/database/Entities/VlanInterface.php
+++ b/database/Entities/VlanInterface.php
@@ -123,6 +123,11 @@ class VlanInterface
     protected $busyhost = false;
 
     /**
+     *  @var integer $customvlantag
+     */
+    protected $customvlantag;
+
+    /**
      * @var string $notes
      */
     protected $notes;
@@ -570,6 +575,29 @@ class VlanInterface
     public function getBusyhost()
     {
         return $this->busyhost;
+    }
+
+    /**
+     * Set customvlantag
+     *
+     * @param integer $customvlantag
+     * @return VlanInterface
+     */
+    public function setCustomvlantag($customvlantag)
+    {
+        $this->customvlantag = $customvlantag;
+
+        return $this;
+    }
+
+    /**
+     * Get customvlantag
+     *
+     * @return integer $customvlantag
+     */
+    public function getCustomvlantag()
+    {
+        return $this->customvlantag;
     }
 
     /**

--- a/database/Repositories/VlanInterface.php
+++ b/database/Repositories/VlanInterface.php
@@ -120,6 +120,7 @@ class VlanInterface extends EntityRepository
                         vli.as112client             AS as112client,
                         vli.rsclient                AS rsclient, 
                         vli.busyhost                AS busyhost, 
+                        vli.customvlantag           AS customvlantag,
                         vli.irrdbfilter             AS irrdbfilter,
                         vli.rsmorespecifics         AS rsmorespecifics,
                         vli.ipv{$proto}canping      AS canping,

--- a/database/migrations/2020_04_06_205000_add_customvlantag_to_vlan_interface.php
+++ b/database/migrations/2020_04_06_205000_add_customvlantag_to_vlan_interface.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCustomvlantagToVlanInterface extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+      Schema::table('vlaninterface', function (Blueprint $table) {
+        $table->integer('customvlantag')->default(0)->nullable();
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('vlaninterface', function (Blueprint $table) {
+          $table->dropColumn('customvlantag');
+            //
+        });
+    }
+}

--- a/database/xml/Entities.VlanInterface.dcm.xml
+++ b/database/xml/Entities.VlanInterface.dcm.xml
@@ -42,6 +42,7 @@
     <field name="ipv6monitorrcbgp" type="boolean" nullable="true"/>
     <field name="as112client" type="boolean" nullable="true"/>
     <field name="busyhost" type="boolean" nullable="true"/>
+    <field name="customvlantag" type="integer" nullable="false"/>
     <field name="notes" type="text" nullable="true"/>
     <many-to-one field="VirtualInterface" target-entity="Entities\VirtualInterface" inversed-by="VlanInterfaces">
       <join-columns>

--- a/resources/views/interfaces/virtual/add/vli.foil.php
+++ b/resources/views/interfaces/virtual/add/vli.foil.php
@@ -36,6 +36,9 @@
                             VLAN Tag
                         </th>
                         <th>
+                            Custom VLAN Tag
+                        </th>
+                        <th>
                             Configured MAC Address(es)
                         </th>
                         <th>
@@ -62,6 +65,10 @@
 
                             <td>
                                 <?= $t->ee( $vli->getVlan()->getNumber() )?>
+                            </td>
+                            
+                            <td>
+                                <?= $t->ee( ($vli->getCustomvlantag() == 0) ? '(Untagged)' : "{$vli->getCustomvlantag()}" ) ?>
                             </td>
 
                             <td>

--- a/resources/views/interfaces/virtual/wizard.foil.php
+++ b/resources/views/interfaces/virtual/wizard.foil.php
@@ -83,6 +83,11 @@ $this->layout( 'layouts/ixpv4' );
                         ->inline()
                     ?>
 
+                    <?= Former::number( 'customvlantag' )
+                                ->label( 'Custom VLAN Tag' )
+                                ->blockHelp( 'The VLAN to translate to, if required. 0 signifies untagged ');
+                    ?>
+
                     <?= Former::checkbox( 'ipv6-enabled' )
                         ->label('&nbsp;')
                         ->text( 'IPv6 Enabled' )

--- a/resources/views/interfaces/vlan/edit.foil.php
+++ b/resources/views/interfaces/vlan/edit.foil.php
@@ -92,6 +92,11 @@
                                 ->blockHelp( 'Pick the VLAN for this VLAN interface. IP address dropdowns will automatically populate on change.' );
                             ?>
 
+                            <?= Former::number( 'customvlantag' )
+                                ->label( 'Custom VLAN Tag' )
+                                ->blockHelp( 'The VLAN to translate to, if required. 0 signifies untagged ');
+                            ?>
+
                             <?= Former::checkbox( 'mcastenabled' )
                                 ->label('&nbsp;')
                                 ->text( 'Multicast Enabled' )


### PR DESCRIPTION
[NF] New feature summary - closes inex/IXP-Manager#629

Adds a customVlanTag parameter to the vlanInterface model and plumbs that through to the UI. This allows a member to have a Peering VLAN handed off on a virtualInterface with a customer port-specific tag. This has also been implemented with the provisioning flow to add a customVlanTag field to the generated YAML file. 

I've also included a migration that works against previous versions of the installation.

In addition to the above, I have:

 - [X] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [X] ensured appropriate checks against user privilege / resources accessed
 - [X] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
