### PR TITLE
[BF] - Patch Panels Customer View: State 'Reserved' appears white text on white background 

### DIFF
--- a/database/Entities/PatchPanelPort.php
+++ b/database/Entities/PatchPanelPort.php
@@ -410,7 +410,7 @@ class PatchPanelPort
             elseif($this->isStateAwaitingXConnect()):
                 $class = 'danger';
             else:
-                $class = 'default';
+                $class = 'info';
             endif;
         }
 


### PR DESCRIPTION
Patch Panels Customer View: State 'Reserved' appears white text on white background - fixes inex/IXP-Manager#637

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
