### PR TITLE
Allow a customer to add an inital MAC address. Resolves #643

### DIFF
--- a/resources/views/customer/overview-tabs/ports/port.foil.php
+++ b/resources/views/customer/overview-tabs/ports/port.foil.php
@@ -306,7 +306,7 @@
                                         <?php foreach( $vli->getLayer2AddressesAsArray() as $l2a ): ?>
                                             <?= $l2a ?><br />
                                         <?php endforeach; ?>
-                                        <?php if( count( $vli->getLayer2AddressesAsArray() ) > 0 && config( 'ixp_fe.layer2-addresses.customer_can_edit' ) ): ?>
+                                        <?php if( config( 'ixp_fe.layer2-addresses.customer_can_edit' ) ): ?>
                                             <a href="<?= route( "layer2-address@forVlanInterface", [ "vliid" => $vli->getId() ] ) ?>">Edit</a>
                                         <?php endif; ?>
                                     </td>


### PR DESCRIPTION
Resolves issue #643 - allows a customer to add an initial MAC address by removing the check for >0 MACs.