### PR TITLE
[BF] Fixes #646 - Small display fix for customers of type 'routeserver'

### DIFF
--- a/database/Entities/Customer.php
+++ b/database/Entities/Customer.php
@@ -1463,6 +1463,15 @@ class Customer
         return $this->getType() == self::TYPE_PROBONO;
     }
 
+    /**
+     * Check if this customer is of the named type
+     * @return boolean
+     */
+    public function isTypeRouteServer()
+    {
+        return $this->getType() == self::TYPE_ROUTESERVER;
+    }
+
 
     /**
      * Turn the database integer representation of the type into text as

--- a/resources/views/customer/cust-type.foil.php
+++ b/resources/views/customer/cust-type.foil.php
@@ -5,6 +5,8 @@
     <span class="badge badge-warning tw-p-1">ASSOCIATE MEMBER</span>
 <?php elseif( $t->cust->isTypeProBono() ): ?>
     <span class="badge badge-info">PROBONO MEMBER</span>
+<?php elseif( $t->cust->isTypeRouteServer() ): ?>
+    <span class="badge badge-primary">ROUTE SERVER</span>
 <?php elseif( $t->cust->isTypeInternal() ): ?>
     <span class="badge  badge-primary">INTERNAL INFRASTRUCTURE</span>
 <?php elseif( $t->cust->isTypeFull() == \Entities\Customer::TYPE_FULL ): ?>

--- a/resources/views/customer/list-type.foil.php
+++ b/resources/views/customer/list-type.foil.php
@@ -2,6 +2,8 @@
     <span class="badge badge-warning">ASSOCIATE MEMBER</span>
 <?php elseif( $t->cust->isTypeProBono() ): ?>
     <span class="badge badge-info">PROBONO MEMBER</span>
+<?php elseif( $t->cust->isTypeRouteServer() ): ?>
+    <span class="badge badge-primary">ROUTE SERVER</span>
 <?php elseif( $t->cust->isTypeInternal() ): ?>
     <span class="badge badge-primary">INTERNAL INFRASTRUCTURE</span>
 <?php elseif( $t->cust->isTypeFull() ): ?>


### PR DESCRIPTION
[BF] Fixes #646 - Small display fix for customers of type 'routeserver' 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
