### PR TITLE
[NF] Implements #642 - Logging for failed auth events

### DIFF
--- a/app/Listeners/Auth/LoginFailed.php
+++ b/app/Listeners/Auth/LoginFailed.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace IXP\Listeners\Auth;
+
+/*
+ * Copyright (C) 2009 - 2020 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GpNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Auth, Log;
+use Illuminate\Auth\Events\Failed as FailedEvent;
+
+class LoginFailed {
+
+    /**
+     * Handle a failed login event.
+     *
+     *
+     * @param  FailedEvent  $e
+     * @return void
+     */
+    public function handle( FailedEvent $e )
+    {
+        // TODO: Maybe we should persist failed logs into the DB instead and create a view in the backend
+        Log::warning( 'Login failed for user "' . $e->credentials['username'] . '" from IP ' . ixp_get_client_ip() . '.' );
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -49,6 +49,10 @@ class EventServiceProvider extends ServiceProvider {
             \IXP\Listeners\Auth\LoginSuccessful::class
         ],
 
+        \Illuminate\Auth\Events\Failed::class => [
+            \IXP\Listeners\Auth\LoginFailed::class
+        ],
+
         'IXP\Events\Customer\BillingDetailsChanged' => [
             'IXP\Listeners\Customer\BillingDetailsChanged'
         ],


### PR DESCRIPTION
[NF] Logging for failed auth events - implements inex/IXP-Manager #642 

This PR dedicated to our friends at @swissix implements logging for failed auth events into `laravel.log` like in prior versions of IXP manager. We probably should create a proper migration and persist failed logon events into the database with a dedicated backend view in the future, but for the moment this should be enough. Honestly I even like this method because this way we can use fail2ban on laravel.log to automatically block offending IPs.

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
