### PR TITLE
[BF] Rack field in patch panel LoA verification page is blank

### DIFF
--- a/resources/views/patch-panel-port/verify-loa.foil.php
+++ b/resources/views/patch-panel-port/verify-loa.foil.php
@@ -60,7 +60,7 @@
                 <tr>
                     <td width="10%"></td>
                     <td><b>Rack:</b></td>
-                    <td><?= $t->ee( $t->ppp->getPatchPanel()->getCabinet()->getColocation() ) ?></td>
+                    <td><?= $t->ee( $t->ppp->getPatchPanel()->getCabinet()->getCololocation() ) ?></td>
                 </tr>
                 <tr>
                     <td></td>


### PR DESCRIPTION
ppp->getPatchPanel()->getCabinet()->getCololocation()


