### PR TITLE
fix robots.txt syntax

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
Currently robots.txt fails to block anything due to invalid syntax, there is no pathspec in the Disallow: line
This patch fixes it to Disallow: / to stop things crawling the whole site and following every route server link etc.