### PR TITLE
Add missing "-" in example

### DIFF
--- a/tools/runtime/route-servers/crontab
+++ b/tools/runtime/route-servers/crontab
@@ -5,7 +5,7 @@ MAILTO=ops-auto@example.com
 # servers will no be taken out at the same time.
 
 47 11,15,19	* * *	root	/usr/local/sbin/api-reconfigure-rs2.sh -h rs1-lan1-ipv4 -q
-47 12,16,20	* * *	root	/usr/local/sbin/api-reconfigure-rs2.sh -h rs1-lan1-ipv6 q
+47 12,16,20	* * *	root	/usr/local/sbin/api-reconfigure-rs2.sh -h rs1-lan1-ipv6 -q
 47 13,17,21	* * *	root	/usr/local/sbin/api-reconfigure-rs2.sh -h rs1-lan2-ipv4 -q
 47 14,18,22	* * *	root	/usr/local/sbin/api-reconfigure-rs2.sh -h rs1-lan2-ipv6 -q
 


### PR DESCRIPTION
[BF] Add missing "-" in example - fixes IXP-Manager

In addition to the above, I have:
 - [X] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [X] ensured appropriate checks against user privilege / resources accessed
 - [X] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks