### PR TITLE
Fix: Peering Matrix view displays empty orgname in help text

### DIFF
--- a/resources/views/peering-matrix/index.foil.php
+++ b/resources/views/peering-matrix/index.foil.php
@@ -243,17 +243,17 @@
                         cells in the body will freeze the dynamic highlighting.
                     </li>
                     <li>
-                        Where a <?= config( "options.identity.orgname" ) ?> member is not listed on this peering matrix, it is because they are
-                        currently not actively peering at <?= config( "options.identity.orgname" ) ?> , or because they have opted out of presenting
+                        Where a <?= config( "identity.orgname" ) ?> member is not listed on this peering matrix, it is because they are
+                        currently not actively peering at <?= config( "identity.orgname" ) ?> , or because they have opted out of presenting
                         their peering information in this database.
                     </li>
                     <li>
-                        This peering matrix is based on sflow traffic accounting data from the <?= config( "options.identity.orgname" ) ?> peering
+                        This peering matrix is based on sflow traffic accounting data from the <?= config( "identity.orgname" ) ?> peering
                         LANs and route server BGP peerings.
                     </li>
                     <li>
                         This peering matrix only detects if there is bidirectional TCP flow between routers at
-                        <?= config( "options.identity.orgname" ) ?>. It cannot detect whether there are actually prefixes swapped between routers.
+                        <?= config( "identity.orgname" ) ?>. It cannot detect whether there are actually prefixes swapped between routers.
                     </li>
                 </ul>
 

--- a/resources/views/peering-matrix/index.foil.php
+++ b/resources/views/peering-matrix/index.foil.php
@@ -244,7 +244,7 @@
                     </li>
                     <li>
                         Where a <?= config( "identity.orgname" ) ?> member is not listed on this peering matrix, it is because they are
-                        currently not actively peering at <?= config( "identity.orgname" ) ?> , or because they have opted out of presenting
+                        currently not actively peering at <?= config( "identity.orgname" ) ?>, or because they have opted out of presenting
                         their peering information in this database.
                     </li>
                     <li>


### PR DESCRIPTION
[BF] Summary of fix - fixes IXP-Manager

Fixed by not prefixing config items with "options.".

In addition to the above, I have:
 - [?] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [X] ensured appropriate checks against user privilege / resources accessed
 - [X] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
