### PR TITLE
Fix: Guard against null in router->last-updated on /lg page

### DIFF
--- a/resources/views/services/lg/router-tab.foil.php
+++ b/resources/views/services/lg/router-tab.foil.php
@@ -35,7 +35,7 @@
                                                     <?= $t->ee( $router[ 'name' ] ) ?>
                                                 </td>
                                                 <td class="align-middle">
-                                                    <?= $router[ 'last-updated' ]->format( "Y-m-d H:i:s" ) ?>
+                                                    <?= $router[ 'last-updated' ] ? $router[ 'last-updated' ]->format( "Y-m-d H:i:s" ) : '(unknown)' ?>
                                                 </td>
                                                 <td>
                                                     <a class="btn btn-primary" href="<?= url('/lg/' . $t->ee( $router[ 'handle' ] ) ) ?>">Looking Glass</a>


### PR DESCRIPTION
[BF] Guard against null in router->last-updated - fixes IXP-Manager

The /lg page renders the error "500 Server Error :: Call to a member function format() on null" if router->last-updated is null.

Fixed by rendering "(unknown)" if null.

In addition to the above, I have:
 - [X] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [X] ensured appropriate checks against user privilege / resources accessed
 - [X] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
