### PR TITLE
Cisco / Huawei use ifType l2vlan for subinterfaces

### DIFF
--- a/database/Entities/Switcher.php
+++ b/database/Entities/Switcher.php
@@ -768,7 +768,9 @@ class Switcher
         foreach( $host->useIface()->indexes() as $index ) {
 
             // we're only interested in Ethernet ports here (right?)
-            if( $host->useIface()->types()[ $index ] != SNMPIface::IF_TYPE_ETHERNETCSMACD && $host->useIface()->types()[ $index ] != SNMPIface::IF_TYPE_L3IPVLAN ) {
+            if( $host->useIface()->types()[ $index ] != SNMPIface::IF_TYPE_ETHERNETCSMACD
+                && $host->useIface()->types()[ $index ] != SNMPIface::IF_TYPE_L2VLAN
+                && $host->useIface()->types()[ $index ] != SNMPIface::IF_TYPE_L3IPVLAN ) {
                 continue;
             }
 


### PR DESCRIPTION
[NF] Cisco / Huawei use ifType l2vlan for subinterfaces

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  