### PR TITLE
[BF] Phone number in user profile doesn't update

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -147,6 +147,7 @@ class ProfileController extends Controller
         $user->setName(             $r->input( "name") );
         $user->setUsername(         $r->input( "username") );
         $user->setEmail(            $r->input( "email") );
+        $user->setAuthorisedMobile( $r->input( "authorisedMobile") );        
         $user->setLastUpdated(      new DateTime() );
         $user->setLastUpdatedBy(    $user->getId() );
 


### PR DESCRIPTION
Add line to updateProfile() so that the phone number field authorisedMobile gets updated when the user changes it.

[BF] Summary of fix - fixes inex/IXP-Manager

We received a support ticket from a user that they were unable to change the phone number in their user
profile, even though they get the message "Your profile has been updated successfully", the old phone number
reappears in their profile.

I was able to reproduce this problem locally. It appears that updateProfile was not calling anything to do setAuthorisedMobile.

Added this line to app/Http/Controllers/ProfileController.php and tested. Now the phone number updates as expected when a user changes it.

In addition to the above, I have:

 - [ x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [ x] ensured appropriate checks against user privilege / resources accessed
 - [ x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
