### PR TITLE
[BF] 404 error when clicking contact name in email search result

### DIFF
--- a/resources/views/search/contacts.foil.php
+++ b/resources/views/search/contacts.foil.php
@@ -23,7 +23,7 @@
             <?php foreach( $t->results[ 'contacts' ] as $contact ): ?>
                 <tr>
                     <td>
-                        <a href="<?= url( "contact/edit/id/" . $contact->getId() . "/cid/".$contact->getCustomer()->getId()) ?>">
+                        <a href="<?= url( "contact/edit/" . $contact->getId() ) ?>">
                             <?= $t->ee(  $contact->getName() ) ?>
                         </a>
                     </td>


### PR DESCRIPTION
[BF] Summary of fix - fixes inex/IXP-Manager

*Longer description*

Fix contact edit link 404 error when clicking contact name in search by email results.

In addition to the above, I have:

 - [x ] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [ ] ensured appropriate checks against user privilege / resources accessed
 - [x ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  