### PR TITLE
Update templates to use bgp_path.last instead of last_nonaggregated

### DIFF
--- a/data/travis-ci/known-good/ci-apiv4-b2-rc1-lan1-ipv4.conf
+++ b/data/travis-ci/known-good/ci-apiv4-b2-rc1-lan1-ipv4.conf
@@ -294,7 +294,7 @@ int set allas;
 
         
     # Ensure origin ASN is in the neighbors AS-SET
-    if !(bgp_path.last_nonaggregated ~ allas) then {
+    if !(bgp_path.last ~ allas) then {
         bgp_large_community.add( IXP_LC_FILTERED_IRRDB_ORIGIN_AS_FILTERED );
     }
 
@@ -303,9 +303,9 @@ int set allas;
 
 
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         bgp_large_community.add( IXP_LC_FILTERED_RPKI_INVALID );
-    } else if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    } else if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         bgp_large_community.add( IXP_LC_INFO_RPKI_VALID );
     } else {
         # RPKI unknown, keep checking and mark as unknown for info
@@ -549,9 +549,9 @@ int set allas;
 
 
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         bgp_large_community.add( IXP_LC_FILTERED_RPKI_INVALID );
-    } else if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    } else if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         bgp_large_community.add( IXP_LC_INFO_RPKI_VALID );
     } else {
         # RPKI unknown, keep checking and mark as unknown for info
@@ -690,9 +690,9 @@ int set allas;
 
 
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         bgp_large_community.add( IXP_LC_FILTERED_RPKI_INVALID );
-    } else if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    } else if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         bgp_large_community.add( IXP_LC_INFO_RPKI_VALID );
     } else {
         # RPKI unknown, keep checking and mark as unknown for info

--- a/data/travis-ci/known-good/ci-apiv4-b2-rc1-lan1-ipv6.conf
+++ b/data/travis-ci/known-good/ci-apiv4-b2-rc1-lan1-ipv6.conf
@@ -308,9 +308,9 @@ int set allas;
 
 
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         bgp_large_community.add( IXP_LC_FILTERED_RPKI_INVALID );
-    } else if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    } else if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         bgp_large_community.add( IXP_LC_INFO_RPKI_VALID );
     } else {
         # RPKI unknown, keep checking and mark as unknown for info
@@ -452,9 +452,9 @@ int set allas;
 
 
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         bgp_large_community.add( IXP_LC_FILTERED_RPKI_INVALID );
-    } else if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    } else if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         bgp_large_community.add( IXP_LC_INFO_RPKI_VALID );
     } else {
         # RPKI unknown, keep checking and mark as unknown for info

--- a/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv4.conf
+++ b/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv4.conf
@@ -234,13 +234,13 @@ protocol rpki rpki2 {
 function filter_rpki()
 {
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         print "Tagging invalid ROA ", net, " for ASN ", bgp_path.last;
         bgp_large_community.add( IXP_LC_FILTERED_RPKI_INVALID );
         return true;
     }
 
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         bgp_large_community.add( IXP_LC_INFO_RPKI_VALID );
         return true;
     }

--- a/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv6.conf
+++ b/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv6.conf
@@ -243,13 +243,13 @@ protocol rpki rpki2 {
 function filter_rpki()
 {
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         print "Tagging invalid ROA ", net, " for ASN ", bgp_path.last;
         bgp_large_community.add( IXP_LC_FILTERED_RPKI_INVALID );
         return true;
     }
 
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         bgp_large_community.add( IXP_LC_INFO_RPKI_VALID );
         return true;
     }

--- a/resources/views/api/v4/router/as112/bird2/neighbors.foil.php
+++ b/resources/views/api/v4/router/as112/bird2/neighbors.foil.php
@@ -29,9 +29,9 @@ function fn_import ( int remote_as )
     <?php if( $t->router->rpki() ): ?>
 
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         return false;
-    } else if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    } else if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         return true;
     }
 

--- a/resources/views/api/v4/router/collector/bird2/neighbors.foil.php
+++ b/resources/views/api/v4/router/collector/bird2/neighbors.foil.php
@@ -144,7 +144,7 @@ int set allas;
         <?php   endif; ?>
 
     # Ensure origin ASN is in the neighbors AS-SET
-    if !(bgp_path.last_nonaggregated ~ allas) then {
+    if !(bgp_path.last ~ allas) then {
         bgp_large_community.add( IXP_LC_FILTERED_IRRDB_ORIGIN_AS_FILTERED );
     }
 
@@ -155,9 +155,9 @@ int set allas;
 <?php if( $t->router->rpki() && config( 'ixp.rpki.rtr1.host' ) ): ?>
 
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         bgp_large_community.add( IXP_LC_FILTERED_RPKI_INVALID );
-    } else if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    } else if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         bgp_large_community.add( IXP_LC_INFO_RPKI_VALID );
     } else {
         # RPKI unknown, keep checking and mark as unknown for info

--- a/resources/views/api/v4/router/server/bird2/rpki.foil.php
+++ b/resources/views/api/v4/router/server/bird2/rpki.foil.php
@@ -46,13 +46,13 @@ protocol rpki rpki2 {
 function filter_rpki()
 {
     # RPKI check
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_INVALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_INVALID ) then {
         print "Tagging invalid ROA ", net, " for ASN ", bgp_path.last;
         bgp_large_community.add( IXP_LC_FILTERED_RPKI_INVALID );
         return true;
     }
 
-    if( roa_check( t_roa, net, bgp_path.last_nonaggregated ) = ROA_VALID ) then {
+    if( roa_check( t_roa, net, bgp_path.last ) = ROA_VALID ) then {
         bgp_large_community.add( IXP_LC_INFO_RPKI_VALID );
         return true;
     }


### PR DESCRIPTION
As per https://bird.network.cz/pipermail/bird-users/2021-February/015199.html
using `roa_check(roa_v4, net, bgp_path.last);` is recommended.