### PR TITLE
mrtg - Use getPollable() instead of getActive()

### DIFF
--- a/app/Services/Grapher/Backend/Mrtg.php
+++ b/app/Services/Grapher/Backend/Mrtg.php
@@ -179,7 +179,7 @@ class Mrtg extends GrapherBackend implements GrapherBackendContract {
                         break 2;
                     }
 
-                    if( !$pi->statusIsConnectedOrQuarantine() || !$pi->getSwitchPort()->getSwitcher()->getActive() ) {
+                    if( !$pi->statusIsConnectedOrQuarantine() || !$pi->getSwitchPort()->getSwitcher()->getPollable() ) {
                         continue;
                     }
 
@@ -222,7 +222,7 @@ class Mrtg extends GrapherBackend implements GrapherBackendContract {
             foreach( $infra->getSwitchers() as $switch ) {
                 /** @var SwitcherEntity $switch */
 
-                if( !$switch->getActive() ) {
+                if( !$switch->getPollable() ) {
                     continue;
                 }
 


### PR DESCRIPTION
Use getPollable() instead of getActive() to avoid polling switches which are active but are not SNMP pollable.

