### PR TITLE
shortname should be ->getShortName

### DIFF
--- a/app/Utils/Export/JsonSchema.php
+++ b/app/Utils/Export/JsonSchema.php
@@ -131,7 +131,7 @@ class JsonSchema
 
             $i = [];
             /** @var Infrastructure $infra */
-            $i['shortname'] = $infra->getName();
+            $i['shortname'] = $infra->getShortName();
             $i['name'] = config('identity.legalname');
             $i['country'] = $infra->getCountry() ?? config('identity.location.country');
             $i['url'] = config('identity.corporate_url');


### PR DESCRIPTION
[BF] Fixes shortname in IX-F export

*IX-F export is not getting the proper shortname from the json export as it is grabbing "name" from the infrastructure rather than "shortname".*
 

