### PR TITLE
Reorder admin tabs to more logical order

### DIFF
--- a/resources/views/customer/overview.foil.php
+++ b/resources/views/customer/overview.foil.php
@@ -248,6 +248,13 @@
                         </li>
                     <?php endif; ?>
                 <?php endif; ?>
+
+                <li role="cross-connects" class="nav-item ">
+                    <a class="nav-link <?php if( $t->tab == 'cross-connects' ): ?> active <?php endif; ?>" data-toggle="tab" href="#cross-connects" data-toggle="tab">
+                        Cross Connects
+                    </a>
+                </li>
+
                 <li role="users" class="nav-item ">
                     <a class="nav-link <?php if( $t->tab == 'users' ): ?> active <?php endif; ?>" data-toggle="tab" href="#users" data-toggle="tab">
                         Users
@@ -266,28 +273,6 @@
                     </a>
                 </li>
 
-                <li role="notes" class="nav-item ">
-                    <a class="nav-link <?php if( $t->tab == 'notes' ): ?> active <?php endif; ?>" data-toggle="tab" href="#notes" id="tab-notes" data-toggle="tab">
-                        Notes
-                        <?php if( $t->notesInfo[ "unreadNotes"] > 0 ): ?>
-                            <span id="notes-unread-indicator" class="badge badge-success"><?= $t->notesInfo[ "unreadNotes"] ?></span>
-                        <?php endif ?>
-                    </a>
-                </li>
-                <li role="cross-connects" class="nav-item ">
-                    <a class="nav-link <?php if( $t->tab == 'cross-connects' ): ?> active <?php endif; ?>" data-toggle="tab" href="#cross-connects" data-toggle="tab">
-                        Cross Connects
-                    </a>
-                </li>
-
-                <?php if( $t->peers ): ?>
-                    <li role="peers" class="nav-item">
-                        <a class="nav-link <?php if( $t->tab == 'peers' ): ?> active <?php endif; ?>" data-toggle="tab" href="#peers" data-toggle="tab">
-                            Peers
-                        </a>
-                    </li>
-                <?php endif; ?>
-
                 <?php if( count( $c->getConsoleServerConnections() ) ): ?>
                     <li role="console-server-connections" class="nav-item ">
                         <a class="nav-link <?php if( $t->tab == 'console-server-connections' ): ?>active<?php endif; ?>" data-toggle="tab" href="#console-server-connections" data-toggle="tab">
@@ -296,11 +281,28 @@
                     </li>
                 <?php endif ?>
 
+                <li role="notes" class="nav-item ">
+                    <a class="nav-link <?php if( $t->tab == 'notes' ): ?> active <?php endif; ?>" data-toggle="tab" href="#notes" id="tab-notes" data-toggle="tab">
+                        Notes
+                        <?php if( $t->notesInfo[ "unreadNotes"] > 0 ): ?>
+                            <span id="notes-unread-indicator" class="badge badge-success"><?= $t->notesInfo[ "unreadNotes"] ?></span>
+                        <?php endif ?>
+                    </a>
+                </li>
+
 
                 <?php if( !config( 'ixp_fe.frontend.disabled.docstore_customer' ) ): ?>
                     <li class="nav-item" onclick="window.location.href = '<?= route( 'docstore-c-dir@list', [ 'cust' => $c->getId() ] ) ?>'">
                         <a class="nav-link" data-toggle="tab" href="">
                             Documents &raquo;
+                        </a>
+                    </li>
+                <?php endif; ?>
+
+                <?php if( $t->peers ): ?>
+                    <li role="peers" class="nav-item">
+                        <a class="nav-link <?php if( $t->tab == 'peers' ): ?> active <?php endif; ?>" data-toggle="tab" href="#peers" data-toggle="tab">
+                            Peers
                         </a>
                     </li>
                 <?php endif; ?>


### PR DESCRIPTION
Put together similar categories of tabs: 

 * Ports/VLANS/Cross Connects
 * Notes and Documents
 * Peers / Filtered Prefixes / P2P

*PR template - remove this line and edit below*

[BF] Summary of fix - fixes [inex|islandbridgenetworks]/IXP-Manager#x

[NF] New feature summary - closes [inex|islandbridgenetworks]/IXP-Manager#x

*Longer description*
 

In addition to the above, I have:

 - [ ] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [ ] ensured appropriate checks against user privilege / resources accessed
 - [ ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
