### PR TITLE
make a less confusing description for panel ports in LoA

### DIFF
--- a/app/Models/PatchPanelPort.php
+++ b/app/Models/PatchPanelPort.php
@@ -380,19 +380,45 @@ class PatchPanelPort extends Model
         return $query->where('duplex_master_id', null );
     }
 
+
+    /**
+     * Get better description for LoA:
+     *
+     * @return string
+     */
+    public function loaname(): string
+    {
+
+        if( $duplex = $this->duplexSlavePorts->first() ) {
+
+            $name = ( $this->number % 2 ? ( floor( $this->number / 2 ) ) + 1 : $this->number / 2 );
+            $name .=  ' (Fibre Pair, Positions ' . $name = $this->patchPanel->port_prefix . $this->number;
+            $name .= '/' . $duplex->name() . ')';
+
+        } else {
+
+             $name = $this->patchPanel->port_prefix . $this->number;
+
+        }
+
+        return $name;
+    }
+
+
     /**
      * Get name
      *
-     * @return integer
+     * @return string
      */
-    public function name()
+    public function name(): string
     {
         $name = $this->patchPanel->port_prefix . $this->number;
 
-        if( $this->duplexSlavePorts->isNotEmpty() ) {
-            $name .= '/' . $this->duplexSlavePorts[ 0 ]->name() . ' ';
+        if( $duplex = $this->duplexSlavePorts->first() ) {
+            $name .= '/' . $duplex->name() . ' ';
             $name .= '(' . ( $this->number % 2 ? ( floor( $this->number / 2 ) ) + 1 : $this->number / 2 ) . ')';
         }
+
         return $name;
     }
 


### PR DESCRIPTION
**Longer description**

Putting back my tweak to make the port / position less confusing for the colocation facilities in the LoA.
The colos are not understanding what we mean on the LoA by:  `"Port: 17/18 (9)"`

Changed output like  `"17/18 (9)"` to something more descriptive, so it reads:
`Port: 2 (Fibre Pair, Positions 3/4) (duplex port)`

So with any luck the colo will patch it to the correct port on the panel (we can but try!)

This is still not perfect because different colos expect different things.
(Some require the number to refer to a pair, others want the individual fibre positions in a pair. Sending both can cause confusion, but this would need some other mod per rack/site (yes, Equinix LD8 want individual positions "N+N", while Equinix LD6 expect a duplex port: "N") so even different facilities in the same company are't doing the same thing even for each individual panel (e.g. SC panels numbered N+N while LC panels numbered only in duplex pairs N. Sigh.)

Perhaps each panel could have an "override default name" option?
  
