### PR TITLE
move rfc1997 communities config to neighbour template

### DIFF
--- a/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv6.conf
+++ b/data/travis-ci/known-good/ci-apiv4-b2-rs1-lan1-ipv6.conf
@@ -324,6 +324,8 @@ template bgp tb_rsclient {
     # (RPKI is /really/ quick)
     connect delay time 30;
 
+    interpret communities off;  # enable rfc1997 well-known community pass through
+
     ipv6 {
         export all;
         missing lladdr ignore;
@@ -490,7 +492,6 @@ protocol bgp pb_0001_as1213 from tb_rsclient {
             table t_0001_as1213;
             export filter f_export_as1213;
         };
-        interpret communities off;  # enable rfc1997 well-known community pass through
         password "N7rX2SdfbRsyBLTm";
 }
 
@@ -640,7 +641,6 @@ protocol bgp pb_0006_as25441 from tb_rsclient {
             table t_0006_as25441;
             export filter f_export_as25441;
         };
-        interpret communities off;  # enable rfc1997 well-known community pass through
         password "X8Ks9QnbER9cyzU3";
 }
 

--- a/resources/views/api/v4/router/server/bird2/neighbor-template.foil.php
+++ b/resources/views/api/v4/router/server/bird2/neighbor-template.foil.php
@@ -54,6 +54,6 @@ template bgp tb_rsclient {
         missing lladdr ignore;
 <?php endif; ?>
     };
-
+<?php if( $t->router->rfc1997_passthru ): ?>        interpret communities off;  # enable rfc1997 well-known community pass through
     rs client;
 }

--- a/resources/views/api/v4/router/server/bird2/neighbor-template.foil.php
+++ b/resources/views/api/v4/router/server/bird2/neighbor-template.foil.php
@@ -48,12 +48,15 @@ template bgp tb_rsclient {
     # (RPKI is /really/ quick)
     connect delay time 30;
 
+<?php if( $t->router->rfc1997_passthru ): ?>    interpret communities off;  # enable rfc1997 well-known community pass through
+<?php endif; ?>
+
     <?= $t->ipproto ?> {
         export all;
 <?php if( $t->router->protocol == 6 ): ?>
         missing lladdr ignore;
 <?php endif; ?>
     };
-<?php if( $t->router->rfc1997_passthru ): ?>        interpret communities off;  # enable rfc1997 well-known community pass through
+
     rs client;
 }

--- a/resources/views/api/v4/router/server/bird2/neighbors.foil.php
+++ b/resources/views/api/v4/router/server/bird2/neighbors.foil.php
@@ -271,7 +271,6 @@ protocol bgp pb_<?= $int['fvliid'] ?>_as<?= $int['autsys'] ?> from tb_rsclient {
             table t_<?= $int['fvliid'] ?>_as<?= $int['autsys'] ?>;
             export filter f_export_as<?= $int['autsys'] ?>;
         };
-<?php endif; ?>
         <?php if( $int['bgpmd5secret'] && !$t->router->skip_md5 ): ?>password "<?= $int['bgpmd5secret'] ?>";<?php endif; ?>
 
 }

--- a/resources/views/api/v4/router/server/bird2/neighbors.foil.php
+++ b/resources/views/api/v4/router/server/bird2/neighbors.foil.php
@@ -271,7 +271,6 @@ protocol bgp pb_<?= $int['fvliid'] ?>_as<?= $int['autsys'] ?> from tb_rsclient {
             table t_<?= $int['fvliid'] ?>_as<?= $int['autsys'] ?>;
             export filter f_export_as<?= $int['autsys'] ?>;
         };
-<?php if( $t->router->rfc1997_passthru ): ?>        interpret communities off;  # enable rfc1997 well-known community pass through
 <?php endif; ?>
         <?php if( $int['bgpmd5secret'] && !$t->router->skip_md5 ): ?>password "<?= $int['bgpmd5secret'] ?>";<?php endif; ?>
 


### PR DESCRIPTION
Move the "`interpret communities off`" option to the neighbor template, rather than repeating this config for every neighbor.