### PR TITLE
Fixes template of MRTG Backend Config

### DIFF
--- a/resources/views/services/grapher/mrtg/target.foil.php
+++ b/resources/views/services/grapher/mrtg/target.foil.php
@@ -12,6 +12,9 @@ Target[<?=$mrtglabel?>]:    <?php
         $cnt = 0;
         $numports = count( $this->portIds );
         foreach( $this->portIds as $piid ):
+            if(!$this->data['pis'][$piid]->switchPort->ifnameToSNMPIdentifier()){
+                continue;
+            }
 
             if( $numports > 1 && $cnt === 0 ):
                 echo "\n          ";


### PR DESCRIPTION
[BF] Summary of fix - fixes template of MRTG Backend Config

The original template will cause the backend can't proper generate the graph for switch aggregated / infra / overall after manually adding interface (for example dummy interface).

The MRTG config of the original template will be like
<img width="822" alt="截圖 2021-11-01 下午5 29 45" src="https://user-images.githubusercontent.com/5138409/139651348-c5d6fb85-501c-40c8-baf7-7eb3670e3282.png">
It contains some invalid reference which can't retrieve from the SNMP, eventually cause the graph fail to render.

The quick fix is to check whether or not the interface can be retrieved from the SNMP, to achieve that, the simply way is to check the existence of the return value of ifnameToSNMPIdentifier().

The final MRTG config will be like 
 
<img width="833" alt="截圖 2021-11-01 下午5 29 54" src="https://user-images.githubusercontent.com/5138409/139651898-f41b72db-d885-4922-a062-5dbc5cac742f.png">

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
