### PR TITLE
[BF] Weird time format for created_at column.

### DIFF
--- a/resources/views/user-remember-token/list-row-override.foil.php
+++ b/resources/views/user-remember-token/list-row-override.foil.php
@@ -16,7 +16,7 @@ $row = $t->row;
         <?= $t->ee( $row['ip'] ) ?>
     </td>
     <td>
-        <?= $t->ee( $row['created_at'] ? \Carbon\Carbon::parse( $t->ee( $row['created_at'] ) )->format( 'Y:m:d H:i:s' ) : '' ) ?>
+        <?= $t->ee( $row['created_at'] ? \Carbon\Carbon::parse( $t->ee( $row['created_at'] ) )->format( 'Y-m-d H:i:s' ) : '' ) ?>
     </td>
     <td>
         <?= $t->ee( $row['expires'] ) ?>


### PR DESCRIPTION
Replaced with hyphens for YYYY-MM-DD instead of YYYY:MM:DD

[BF] Weird time format for created_at column.

*Longer description*

Fixes output like `2021:11:11 15:20:46` to `2021-11-11 15:20:46`

  