### PR TITLE
[BF] group by virtualinterface id

### DIFF
--- a/app/Models/Aggregators/SwitcherAggregator.php
+++ b/app/Models/Aggregators/SwitcherAggregator.php
@@ -212,7 +212,7 @@ class SwitcherAggregator extends Switcher
             ->when( $ipv6enabled , function( Builder $q ) {
                 return $q->where( 'vli.ipv6enabled', true );
             })
-            ->groupBy( 'customer', 'custid', 'asn', 'switchname', 'switchid', 'vlan' )
+            ->groupBy( 'customer', 'custid', 'asn', 'switchname', 'switchid', 'vlan', 'vi.id' )
             ->orderBy( 'customer', 'ASC' )
             ->get()->toArray();
     }


### PR DESCRIPTION
*Longer description*

See also #757

correctly group also by virtual interface id (was erroneously grouping interfaces together regardless of virtual interface id, so port in one VI rate_limit causes ports in other VI to also be listed a rate_limt.

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
