### PR TITLE
[IM] allow override broken mail defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,13 +46,7 @@ DB_PASSWORD="password"
 # MAIL_HOST="localhost"
 # MAIL_PORT=25
 # MAIL_ENCRYPTION=false
-#
-#
-# Use sendmail emulation (useful for dev or to override defaults)
-#
-# MAIL_MAILER="sendmail"
-# MAIL_SENDMAIL_PATH="/usr/sbin/sendmail -t"
-# MAIL_SENDMAIL_PATH="/usr/bin/msmtp -t --tls=off --from=${IDENTITY_EMAIL} --auto-from=off"
+
 
 
 #######################################################################################

--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,13 @@ DB_PASSWORD="password"
 # MAIL_HOST="localhost"
 # MAIL_PORT=25
 # MAIL_ENCRYPTION=false
-
-
+#
+#
+# Use sendmail emulation (useful for dev or to override defaults)
+#
+# MAIL_MAILER="sendmail"
+# MAIL_SENDMAIL_PATH="/usr/sbin/sendmail -t"
+# MAIL_SENDMAIL_PATH="/usr/bin/msmtp -t --tls=off --from=${IDENTITY_EMAIL} --auto-from=off"
 
 
 #######################################################################################

--- a/config/mail.php
+++ b/config/mail.php
@@ -80,7 +80,7 @@ return [
 
         'sendmail' => [
             'transport' => 'sendmail',
-            'path' => '/usr/sbin/sendmail -bs',
+            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -t'),
         ],
 
         'log' => [


### PR DESCRIPTION
*Longer description*

- Add new option MAIL_SENDMAIL_PATH to override sendmail path where the defaults are not appropriate
- sendmail -bs is the wrong option for this (crashes with error) should be sendmail -t 

This is useful for dev, or where you just need it to do the right thing, for example msmtp/msmtpd replaces the envelope sender
for non-existent users with something inappropriate.
