### PR TITLE
fixing vlan id

### DIFF
--- a/resources/views/customer/emails/welcome-email.blade.php
+++ b/resources/views/customer/emails/welcome-email.blade.php
@@ -42,7 +42,7 @@ Speed:           {{$pi->speed()}} ({{$pi->duplex}} duplex)
 ```
 
 @foreach( $vi->vlanInterfaces as $vli )
-@php ($vlanid = $vli->vlan_id)
+@php ($vlanid = $vli->vlanid)
 
 **{{$vli->vlan->name}}**
 


### PR DESCRIPTION
variable $vlanid is assigned incorrectly, because of it the netmask of IP addresses is empty

[BF] Summary of fix - fixes [inex|islandbridgenetworks]/IXP-Manager#x

[NF] New feature summary - closes [inex|islandbridgenetworks]/IXP-Manager#x

*Longer description*
 

In addition to the above, I have:

 - [ x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [ x] ensured appropriate checks against user privilege / resources accessed
 - [ x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
