### PR TITLE
Allow unauthenticated users to view inter-switch / POP graphs

### DIFF
--- a/resources/views/statistics/core-bundle.foil.php
+++ b/resources/views/statistics/core-bundle.foil.php
@@ -2,7 +2,7 @@
     /** @var Foil\Template\Template $t */
     $this->layout( 'layouts/ixpv4' );
     $cb = $t->cb;/** @var \IXP\Models\CoreBundle $cb */
-    $isSuperUser = Auth::getUser()->isSuperUser();
+    $isSuperUser = Auth::check() ? Auth::getUser()->isSuperUser() : false;
 ?>
 
 <?php $this->section( 'page-header-preamble' ) ?>


### PR DESCRIPTION
[BF] Summary of fix - fixes [inex/IXP-Manager#775](https://github.com/inex/IXP-Manager/issues/775)

*Longer description*

fix: Allow unauthenticated users to view inter-switch / POP graphs when using core bundles

Check if user is authenticated following style used in other foils.

[Issue 775](https://github.com/inex/IXP-Manager/issues/775)
 

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
