### PR TITLE
add patch_panel.colo_pp_type

### DIFF
--- a/app/Http/Controllers/PatchPanel/PatchPanelController.php
+++ b/app/Http/Controllers/PatchPanel/PatchPanelController.php
@@ -141,6 +141,7 @@ class PatchPanelController extends Controller
             'port_prefix'               => $r->old( 'port_prefix',         $pp->port_prefix         ),
             'location_notes'            => $r->old( 'location_notes',      $pp->location_notes      ),
             'u_position'                => $r->old( 'u_position',          $pp->u_position          ),
+            'colo_pp_type'              => $r->old( 'colo_pp_type',        $pp->colo_pp_type        ),
             'mounted_at'                => $r->old( 'mounted_at',          $pp->mounted_at          ),
             'numberOfPorts'             => $r->old( 'numberOfPorts',0                         ),
         ]);

--- a/app/Http/Requests/StorePatchPanel.php
+++ b/app/Http/Requests/StorePatchPanel.php
@@ -68,6 +68,7 @@ class StorePatchPanel extends FormRequest
             'installation_date' => 'date',
             'port_prefix'       => 'string|nullable',
             'u_position'        => 'numeric|nullable',
+            'colo_pp_type'      => 'numeric',
             'mounted_at'        => 'string|nullable|in:' . implode( ',', array_keys( PatchPanel::$MOUNTED_AT ) ),
             'numberOfPorts'     => 'required|integer',
         ];

--- a/app/Models/Aggregators/PatchPanelPortAggregator.php
+++ b/app/Models/Aggregators/PatchPanelPortAggregator.php
@@ -75,7 +75,11 @@ class PatchPanelPortAggregator extends PatchPanelPort
         return self::selectRaw( '
             ppp.*,
             count( pppf.id ) AS files, count( ppph.id ) AS histories,
-            pp.name as ppname, pp.port_prefix AS prefix,
+            pp.name as ppname,
+            pp.colo_reference as ppcolo_reference,
+            pp.port_prefix AS prefix,
+            pp.cable_type AS ppcable_type,
+            pp.colo_pp_type,
             sp.name AS spname,
             s.name AS sname, c.abbreviatedName AS cname,
             count( ppps.id ) AS nbslave, 

--- a/app/Models/PatchPanel.php
+++ b/app/Models/PatchPanel.php
@@ -49,6 +49,7 @@ use IXP\Traits\Observable;
  * @property string|null $installation_date
  * @property string $port_prefix
  * @property int $active
+ * @property int $colo_pp_type
  * @property int $chargeable
  * @property string $location_notes
  * @property int|null $u_position
@@ -104,6 +105,7 @@ class PatchPanel extends Model
         'installation_date',
         'port_prefix',
         'active',
+        'colo_pp_type',
         'chargeable',
         'location_notes',
         'u_position',
@@ -136,6 +138,19 @@ class PatchPanel extends Model
         self::CABLE_TYPE_MMF,
     ];
 
+    /**
+     * CONST Co-lo simplex/duplex specification
+     */
+    public const COLO_PP_TYPE_SIMPLEX   = 0;
+    public const COLO_PP_TYPE_DUPLEX    = 1;
+
+    /**
+     * Array Co-lo simplex/duplex specification
+     */
+    public static $COLO_PP_TYPES = [
+        self::COLO_PP_TYPE_SIMPLEX      => 'Simplex',
+        self::COLO_PP_TYPE_DUPLEX       => 'Duplex',
+    ];
 
     /**
      * CONST Connector types
@@ -226,6 +241,17 @@ class PatchPanel extends Model
     public function chargeable(): string
     {
         return PatchPanelPort::$CHARGEABLES[ $this->chargeable ] ?? 'Unknown';
+    }
+
+    /**
+     * Specifies whether the co-location provider uses simplex ("port 1") or
+     * duplex ("fibre 1 / fibre 2") notation in their cross-connect database.
+     *
+     * @return string
+     */
+    public function coloPpType(): string
+    {
+        return self::$COLO_PP_TYPES[ $this->colo_pp_type ] ?? 'Other';
     }
 
     /**

--- a/app/Models/PatchPanelPort.php
+++ b/app/Models/PatchPanelPort.php
@@ -253,6 +253,14 @@ class PatchPanelPort extends Model
     ];
 
     /**
+     * Array STATES for cross-connects where there may be a circuit installed by the colo
+     */
+    public static $COLO_ASSIGNED_STATES = [
+        self::STATE_CONNECTED,
+        self::STATE_AWAITING_CEASE,
+    ];
+
+    /**
      * Array $CHARGEABLES
      */
     public static $OWNED_BY = [

--- a/database/migrations/2022_02_12_183121_add_colo_pp_type_patch_panel.php
+++ b/database/migrations/2022_02_12_183121_add_colo_pp_type_patch_panel.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColoPPTypePatchPanel extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('patch_panel', function (Blueprint $table) {
+            $table->tinyInteger( 'colo_pp_type' )->after( 'active' )->nullable( false )->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('patch_panel', function (Blueprint $table) {
+            $table->dropColumn('colo_pp_type');
+        });
+
+    }
+}

--- a/resources/views/patch-panel/edit.foil.php
+++ b/resources/views/patch-panel/edit.foil.php
@@ -133,6 +133,16 @@
                         ->value( date( 'Y-m-d' ) );
                     ?>
 
+                    <?= Former::select( 'colo_pp_type' )
+                        ->label( 'Co-lo Patch Panel Port Type' )
+                        ->options( \IXP\Models\PatchPanel::$COLO_PP_TYPES )
+                        ->addClass( 'chzn-select' )
+                        ->blockHelp( 'Specify whether the co-location provider uses simplex ("Port 1") or duplex ("fibre 1 / fibre 2")'
+                            . 'notation in their cross-connect database.' )
+                        ;
+                    ?>
+
+
                     <div class="form-group row">
                         <div class="col-sm-8">
                             <div class="card mt-4">

--- a/resources/views/patch-panel/view.foil.php
+++ b/resources/views/patch-panel/view.foil.php
@@ -140,6 +140,16 @@
                             <tr>
                                 <td>
                                     <b>
+                                        Co-lo Patch Panel Type:
+                                    </b>
+                                </td>
+                                <td>
+                                    <?= $pp->coloPpType() ?>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <b>
                                         Created:
                                     </b>
                                 </td>


### PR DESCRIPTION
[NF] add add patch_panel.colo_pp_type field to mirror how colo providers track patch panels

needed for two reasons: 1. to be able to send colo providers LOAs which match the specification of their XC databases and 2. ultimately to be able to perform XC reconciliation between ixp-m and colo.
 
In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  