### PR TITLE
robots.txt also disallow index.php/lg/*

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,7 @@
 # Crawlers should not search the looking glasses
 User-agent: *
 Disallow: /lg/
+Disallow: *index.php/lg/*
 
 User-agent: *
 Allow: /


### PR DESCRIPTION
Dotbot and others still accessing via /index.php/lg/rs1-ipv6/route/...
