### PR TITLE
Router edit: Suggested format for `handle` matching examples

### DIFF
--- a/resources/views/router/edit.foil.php
+++ b/resources/views/router/edit.foil.php
@@ -53,7 +53,7 @@
                     <?= Former::text( 'handle' )
                         ->label( 'Handle' )
                         ->placeholder( 'rs1-lan1-ipv4' )
-                        ->blockHelp( "The handle is like the router's name. It is suggested you use something like: <code>purpose-proto-lan</code>. A
+                        ->blockHelp( "The handle is like the router's name. It is suggested you use something like: <code>purpose-lan-proto</code>. A
                     good example of this is <code>rs1-lan1-ipv4</code> for <em>route server #1</em> on <em>lan1</em> using <em>IPv4</em>.
                     These handles are used in API calls and other areas such as Nagios configuration generation." );
                     ?>


### PR DESCRIPTION
[BF] Fix help text when adding/editing router: Suggested format for handle should match format used in later examples.

Suggestion says to use format `purpose-proto-lan`, but handles used in examples use format `purpose-lan-proto`.

In addition to the above, I have:
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks