### PR TITLE
Check filename has extension. Make more obvious.

### DIFF
--- a/resources/views/docstore-customer/file/upload.foil.php
+++ b/resources/views/docstore-customer/file/upload.foil.php
@@ -21,13 +21,23 @@
             ->actionButtonsCustomClass( "grey-box")
             ->class('col-8')
             ->rules([
-                'name' => 'required|max:100'
+                'name' => ['required', 'max:100', 'match:"/^(?:^..*)\.\w{1,5}$/"']
             ])
+        ?>
+        
+        <?= Former::file( 'uploadedFile' )
+            ->id( 'uploadedFile' )
+            ->label( ( $t->file ? 'Replace' : 'Upload' ) . ' File' )
+            ->class( 'form-control border-0 shadow-none' )
+            ->multiple( false )
+            ->blockHelp( $t->file ? "You only need to choose a file here if you wish to replace the existing one. Do not select a file to edit other details but leave the current file in place."
+                : "Select the file you wish to upload." );
         ?>
 
         <?= Former::text( 'name' )
             ->id('name')
-            ->label( 'Name' )
+            ->label( 'File Name' )
+            ->title( 'File name including extension' )
             ->blockHelp( "The name of the file (this is as it appears on listings in the web interface rather than on the filesystem). "
                 . "<b>This is also the name the downloaded file will have - so use the appropriate extension.</b>");
         ?>
@@ -53,15 +63,6 @@
             ->fromQuery( \IXP\Models\User::$PRIVILEGES_TEXT , 'name' )
             ->addClass( 'chzn-select' )
             ->blockHelp( "The minimum privilege a user is required to have to view and download the file." );
-        ?>
-
-        <?= Former::file( 'uploadedFile' )
-            ->id( 'uploadedFile' )
-            ->label( ( $t->file ? 'Replace' : 'Upload' ) . ' File' )
-            ->class( 'form-control border-0 shadow-none' )
-            ->multiple( false )
-            ->blockHelp( $t->file ? "You only need to choose a file here if you wish to replace the existing one. Do not select a file to edit other details but leave the current file in place."
-                : "Select the file you wish to upload." );
         ?>
 
         <div class="form-group">


### PR DESCRIPTION
A follow up to: https://github.com/inex/IXP-Manager/issues/686

Users still seem to be uploading files without extensions, by typing something in the "Name" field, not realising this is used as the actual file name.

Possibly because this is the first field, and it's before the file upload button. 
If Name is not completed, the filename is completed automatically.

File then won't open when downloaded because it has no extension.

- This fix changes "Name" to "File Name" to make it more obvious.
- Validate the file name is "(something).extn"
- Move upload file button before File Name so the user does this bit first. (Then will see the name is filled in for them.)

Can't see a way to make the help text visible by default (it's hidden unless the user clicks the help button.)

In addition to the above, I have:

 - [X] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [X] ensured appropriate checks against user privilege / resources accessed
 - [X] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
