### PR TITLE
Link to reseller. Use more commonly displayed abbreviatedName.

### DIFF
--- a/resources/views/customer/overview.foil.php
+++ b/resources/views/customer/overview.foil.php
@@ -137,8 +137,7 @@
                     <span class="tw-text-gray-600">
                          joined <?= \Carbon\Carbon::instance( $c->datejoin )->format('Y') ?>
                         <?php if( $r = $c->resellerObject ): ?>
-                           - resold via <a href="<?= route( "customer@overview" , [ 'cust' => $r->id ] ) ?>"><?= $t->ee($r->abbreviatedName)?>
-                         </a>
+                           - resold via <a href="<?= route( "customer@overview" , [ 'cust' => $r->id ] ) ?>"><?= $t->ee($r->abbreviatedName)?></a>
                         <?php endif; ?>
                     </span>
                 </p>

--- a/resources/views/customer/overview.foil.php
+++ b/resources/views/customer/overview.foil.php
@@ -137,7 +137,8 @@
                     <span class="tw-text-gray-600">
                          joined <?= \Carbon\Carbon::instance( $c->datejoin )->format('Y') ?>
                         <?php if( $r = $c->resellerObject ): ?>
-                            - resold via <?= $r->name ?>
+                           - resold via <a href="<?= route( "customer@overview" , [ 'cust' => $r->id ] ) ?>"><?= $t->ee($r->abbreviatedName)?>
+                         </a>
                         <?php endif; ?>
                     </span>
                 </p>


### PR DESCRIPTION
*Longer description*

Link to reseller. Use more commonly displayed abbreviatedName.

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
