### PR TITLE
[BF] IP Addresses not shown

### DIFF
--- a/resources/views/layer2-address/vlan-interface.foil.php
+++ b/resources/views/layer2-address/vlan-interface.foil.php
@@ -38,11 +38,11 @@
                             <?= $t->ee( $t->vli->vlan->name ) ?>
                         </dd>
                         <dt class="col-sm-2">
-                            Addresses
+                            IP Addresses
                         </dt>
                         <dd class="col-sm-9">
-                            <?= $t->vli->ipvv4Address ? $t->vli->ipvv4Address->address . ( $t->vli->ipvv6Address ? ' / ': '' ) : ''  ?>
-                            <?= $t->vli->ipvv6Address->address ?? '' ?>
+                            <?= $t->vli->ipv4Address ? $t->vli->ipv4Address->address . ( $t->vli->ipv6Address ? ' / ': '' ) : ''  ?>
+                            <?= $t->vli->ipv6Address->address ?? '' ?>
                         </dd>
                     </dl>
                 </div>


### PR DESCRIPTION
Fix typo so IP addresses display. Better description: "IP Addresses" as opposed to MAC Addresses (sometimes there are no IP addresses, so this will be blank)