### PR TITLE
[IM] Make allowed MAC address editing more intuitive

### DIFF
--- a/resources/views/layer2-address/vlan-interface-cust.foil.php
+++ b/resources/views/layer2-address/vlan-interface-cust.foil.php
@@ -8,13 +8,6 @@
 <?php $this->append() ?>
 
 <?php $this->section( 'page-header-postamble' ) ?>
-    <?php if( $t->vli->layer2Addresses()->count() < config( 'ixp_fe.layer2-addresses.customer_params.max_addresses' ) ): ?>
-        <div class="btn-group btn-group-sm" id="add-btn" role="group">
-            <a class="btn btn-white" id="add-l2a">
-                <span class="fa fa-plus"></span>
-            </a>
-        </div>
-    <?php endif; ?>
 <?php $this->append() ?>
 
 <?php $this->section( 'content' ) ?>
@@ -26,22 +19,47 @@
                 <?= $t->insert( 'layer2-address/customer-edit-msg.foil.php' ) ?>
             <?php endif; ?>
 
+            <?php if( $t->vli->layer2Addresses()->count() >= config( 'ixp_fe.layer2-addresses.customer_params.max_addresses' ) ): ?>
+               <div class="alert alert-warning" role="alert">
+                <div class="d-flex align-items-center">
+                 <div class="text-center">
+                 <i class="fa fa-exclamation-circle fa-2x "></i>
+                 </div>
+                <div class="col-sm-12">
+                 You have reached the maximum number of allowed MAC addresses for this port.
+                 Delete a MAC address to enable adding new MAC addresses.
+                </div>
+               </div>
+             </div>
+            <?php endif; ?>
+
             <div id="list-area" class="collapse">
-                <table id='layer-2-interface-list' class="table table-striped" width="100%">
+                <table id='layer-2-interface-list' class="table table-striped w-100" data-searching="false" data-paging="false" data-ordering="false" data-info="false">
                     <thead class="thead-dark">
                         <tr>
-                            <th>
+                            <th style="vertical-align: middle;">
                                 MAC Address
                             </th>
-                            <th>
+                            <th style="vertical-align: middle;">
                                 Created At
                             </th>
-                            <th>
+                            <th style="vertical-align: middle;">
                                 Action
+                                <?php if( $t->vli->layer2Addresses()->count() < config( 'ixp_fe.layer2-addresses.customer_params.max_addresses' ) ): ?>
+                                    &nbsp;<div class="btn-group btn-group-sm" id="add-btn" role="group">
+                                     <a class="btn btn-white" id="add-l2a" title="Add a new MAC address">
+                                    <span class="fa fa-plus"></span>
+                                   </a>
+                                  </div>
+                                <?php else: ?>
+                                    &nbsp;<div class="btn-group btn-group-sm" id="add-btn" role="group">
+                                    <span class="btn btn-white disabled fa fa-plus" title="Maximum allowed MACs. Delete a MAC address first."></span>
+                                  </div>
+                                <?php endif; ?>
                             </th>
                         </tr>
-                    <thead>
-                    <tbody >
+                    </thead>
+                    <tbody>
                         <?php foreach( $t->vli->layer2Addresses as $l2a ):?>
                             <tr>
                                 <td>
@@ -56,7 +74,7 @@
                                             <i class="fa fa-eye"></i>
                                         </a>
                                         <?php if( $t->vli->layer2Addresses()->count() > config( 'ixp_fe.layer2-addresses.customer_params.min_addresses' ) ): ?>
-                                            <a class="btn btn-white btn-delete" id='d2f-list-delete-<?= $l2a->id ?>' data-object-id="<?= $l2a->id ?>" href="<?= route( 'l2-address@delete' , [ 'l2a' => $l2a->id, 'showFeMessage' => true  ]  )  ?>"  title="Delete">
+                                           <a class="btn btn-white btn-delete" id='d2f-list-delete-<?= $l2a->id ?>' data-object-id="<?= $l2a->id ?>" href="<?= route( 'l2-address@delete' , [ 'l2a' => $l2a->id, 'showFeMessage' => true  ]  )  ?>"  title="Delete">
                                                 <i class="fa fa-trash"></i>
                                             </a>
                                         <?php endif; ?>
@@ -64,7 +82,7 @@
                                 </td>
                             </tr>
                         <?php endforeach;?>
-                    <tbody>
+                   </tbody>
                 </table>
             </div>
             <?= $t->insert( 'layer2-address/modal-mac' ); ?>

--- a/resources/views/layer2-address/vlan-interface.foil.php
+++ b/resources/views/layer2-address/vlan-interface.foil.php
@@ -38,11 +38,11 @@
                             <?= $t->ee( $t->vli->vlan->name ) ?>
                         </dd>
                         <dt class="col-sm-2">
-                            Addresses
+                            IP Addresses
                         </dt>
                         <dd class="col-sm-9">
-                            <?= $t->vli->ipvv4Address ? $t->vli->ipvv4Address->address . ( $t->vli->ipvv6Address ? ' / ': '' ) : ''  ?>
-                            <?= $t->vli->ipvv6Address->address ?? '' ?>
+                            <?= $t->vli->ipv4Address ? $t->vli->ipv4Address->address . ( $t->vli->ipv6Address ? ' / ': '' ) : ''  ?>
+                            <?= $t->vli->ipv6Address->address ?? '' ?>
                         </dd>
                     </dl>
                 </div>

--- a/resources/views/layer2-address/vlan-interface.foil.php
+++ b/resources/views/layer2-address/vlan-interface.foil.php
@@ -12,9 +12,6 @@
         <a href="<?= route( 'virtual-interface@edit' , [ "vi" => $t->vli->virtualInterface->id ] ) ?>" class="btn btn-sm btn-white">
             Virtual Interface Details
         </a>
-        <a class="btn btn-sm btn-white" href="#" id="add-l2a">
-            <i class="fa fa-plus"></i>
-        </a>
     </div>
 <?php $this->append() ?>
 
@@ -64,11 +61,11 @@
                                 Updated
                             </th>
                             <th>
-                                Action
+                                Action <a class="btn btn-sm btn-white" href="#" id="add-l2a"><i class="fa fa-plus"></i></a>
                             </th>
-                        </tr>
-                    <thead>
-                    <tbody >
+                            </tr>
+                    </thead>
+                    <tbody>
                         <?php foreach( $t->vli->layer2Addresses as $l2a ):?>
                             <tr>
                                 <td>
@@ -92,7 +89,7 @@
                                 </td>
                             </tr>
                         <?php endforeach;?>
-                    <tbody>
+                    </tbody>
                 </table>
             </div>
             <?= $t->insert( 'layer2-address/modal-mac' ); ?>


### PR DESCRIPTION
- Move the "+" button to the MAC address table heading.
- customer page: Don't hide the "+" button. If maximum MACs reached, grey out.
- customer page: Add message explaining what to do when maximum MACs reached.
- reduce table clutter on customer mac edit page.

*Longer description*

Fixes https://github.com/inex/IXP-Manager/issues/799

We have implemented this to make it easier for members to understand how to manage their allowed MAC addresses.

It wasn't super obvious how to add MAC addresses, and sometimes the "+" button was hidden.

Before:
![image](https://user-images.githubusercontent.com/3037635/212392448-c6b42fee-eb45-4687-a61c-6cfa316ec03e.png)

After:
- Plus button is in a more obvious place.
- Table clutter removed.

![image](https://user-images.githubusercontent.com/3037635/212392658-225d3cc2-74b3-4fc2-a943-3a00a229d882.png)

When maximum allowed MAC addresses reached:
- Plus button is in a more obvious place, but greyed out.  Hover message explains what it is/why it's disbled
- More obvious message.

![image](https://user-images.githubusercontent.com/3037635/212393475-2afa2277-8bf1-4c55-b9f9-b641c8cc701d.png)


In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
