### PR TITLE
Fix to #829

### DIFF
--- a/tools/runtime/sflow/sflow-to-rrd-handler
+++ b/tools/runtime/sflow/sflow-to-rrd-handler
@@ -210,7 +210,6 @@ while (<SFLOWTOOL>) {
 		my $newmactable = reload_mactable($client, $macdbrest);
 		if ($newmactable) {
 			$mactable = $newmactable;
-			$matrix = matrix_init($mactable, $infraid);
 			$mactablereloadfails = 0;
 		} else {
 			$mactablereloadfails++;
@@ -221,6 +220,7 @@ while (<SFLOWTOOL>) {
 				die "FATAL: could not reload mactable after $mactabletimeout seconds. Aborting.\n";
 			}
 		}
+		$matrix = matrix_init($mactable, $infraid);
 		$debug && print STDERR "DEBUG: flush completed at ".time()."\n";
 	}
 }


### PR DESCRIPTION
[BF] Unconditionally re-initialize sFlow collector counters - fixes inex/IXP-Manager#829

Previously the counters were not reset in case the API was unreachable. After writing data to RRDs new counters need to be initialized unconditionally.

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks