### PR TITLE
[NF] Decode BGP well-known communities

### DIFF
--- a/app/Utils/Foil/Extensions/Bird.php
+++ b/app/Utils/Foil/Extensions/Bird.php
@@ -142,10 +142,8 @@ class Bird implements ExtensionInterface
      */
     public function translateBgpFilteringLargeCommunity( string $lc ): ?array
     {
-        foreach( self::$BGPLCS as $k => $v ) {
-            if( $k === $lc ) {
-                return $v;
-            }
+        if( isset( self::$BGPLCS[$lc] ) ) {
+            return self::$BGPLCS[$lc];
         }
 
         foreach( self::$BGPLCS_REGEX as $re => $v ) {

--- a/app/Utils/Foil/Extensions/Bird.php
+++ b/app/Utils/Foil/Extensions/Bird.php
@@ -93,6 +93,17 @@ class Bird implements ExtensionInterface
         return $prefixes;
     }
 
+    # https://www.iana.org/assignments/bgp-well-known-communities/bgp-well-known-communities.xhtml
+    public static $BGPCS = [
+        '65535:0' => ['GRACEFUL_SHUTDOWN', 'warning'],
+        '65535:1' => ['ACCEPT_OWN', 'info'],
+        '65535:9' => ['STANDBY_PE', 'info'],
+        '65535:666' => ['BLACKHOLE', 'warning'],
+        '65535:65281' => ['NO_EXPORT', 'info'],
+        '65535:65282' => ['NO_ADVERTISE', 'info'],
+        '65535:65283' => ['NO_EXPORT_SUBCONFED', 'info'],
+        '65535:65284' => ['NOPEER', 'info'],
+    ];
 
     // FIXME: need to find a place for this that allows end users to customise it
     public static $BGPLCS = [
@@ -136,6 +147,14 @@ class Bird implements ExtensionInterface
         ':102:\d+'  => [ 'PREPEND TO PEERAS - TWICE', 'info' ],
         ':103:\d+'  => [ 'PREPEND TO PEERAS - THREE TIMES', 'info' ],
     ];
+
+    /**
+     * Get information on a BGP well-known community
+     */
+    public function translateBgpCommunity( string $c ): ?array
+    {
+        return self::$BGPCS[$c] ?? null;
+    }
 
     /**
      * Get information on a BGP large community used for filtering / info by IXP Manager

--- a/resources/views/services/lg/route.foil.php
+++ b/resources/views/services/lg/route.foil.php
@@ -138,7 +138,12 @@
                       </td>
                       <td>
                           <?php foreach( $r->bgp->communities as $c ): ?>
-                              <tt><?= implode(':',$c) ?></tt><br>
+                              <tt><?= implode(':',$c) ?></tt>
+
+                              <?php if( $cinfo = $t->bird()->translateBgpCommunity( implode(':',$c) ) ): ?>
+                                  <span class="badge badge-<?= $cinfo[1] ?>"><?= $cinfo[0] ?></span>
+                              <?php endif; ?>
+                              <br>
                           <?php endforeach; ?>
                       </td>
                   </tr>


### PR DESCRIPTION
[NF] Decode BGP well-known communities

*Longer description*

This decodes BGP well-known communities in the looking glass.

Design decisions to review:
* ~~This follows the same patterns as the existing code. I'm not entirely sure why the existing code prepends the ":" when calling the matching function nor why it uses a `foreach` + `if` instead of an array index. But PHP is not my strong suit.~~
* I only included well-known communities that made it to a standard. There are ones allocated for Internet drafts. If you want to add those (or want me to), that's fine.
* I marked them all "info" except BLACKHOLE (because that likely indicates a DDoS is happening) and GRACEFUL_SHUTDOWN (because someone is about to do maintenance), which I marked as "warning".

In addition to the above, I have reviewed the following:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks