### PR TITLE
[BF] Fix a doc comment

### DIFF
--- a/app/Http/Controllers/Api/V4/MemberExportController.php
+++ b/app/Http/Controllers/Api/V4/MemberExportController.php
@@ -45,7 +45,7 @@ use IXP\Utils\Export\JsonSchema as JsonSchemaExporter;
 class MemberExportController extends Controller
 {
     /**
-     * API call to generate DNS ARPA records in a given format
+     * API call to generate IX-F export in a given version
      *
      * @param Request   $r
      * @param string    $version Version of schema to export


### PR DESCRIPTION
[BF] Fix a doc comment

The MemberExportController doc comment says it outputs "DNS ARPA records.

This looks like a copy-and-paste from another Controller that was never updated.

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
