### PR TITLE
Draft: [NF] Support BFD

### DIFF
--- a/data/ci/known-good/ci-apiv4-b2-rc1-lan1-ipv4.conf
+++ b/data/ci/known-good/ci-apiv4-b2-rc1-lan1-ipv4.conf
@@ -443,7 +443,6 @@ protocol bgp pb_as42_vli3_ipv4 {
         import where f_import_as42();
         export none;
     };
-
     password "mcWsqMdzGwTKt67g";
 }
 
@@ -583,7 +582,6 @@ protocol bgp pb_as112_vli4_ipv4 {
         import where f_import_as112();
         export none;
     };
-
     password "w83fmGpRDtaKomQo";
 }
 
@@ -729,7 +727,6 @@ protocol bgp pb_as1213_vli1_ipv4 {
         import where f_import_as1213();
         export none;
     };
-
     password "N7rX2SdfbRsyBLTm";
 }
 

--- a/data/ci/known-good/ci-apiv4-b2-rc1-lan1-ipv6.conf
+++ b/data/ci/known-good/ci-apiv4-b2-rc1-lan1-ipv6.conf
@@ -347,7 +347,6 @@ protocol bgp pb_as1213_vli1_ipv6 {
         import where f_import_as1213();
         export none;
     };
-
     password "N7rX2SdfbRsyBLTm";
 }
 
@@ -488,7 +487,6 @@ protocol bgp pb_as25441_vli6_ipv6 {
         import where f_import_as25441();
         export none;
     };
-
     password "X8Ks9QnbER9cyzU3";
 }
 

--- a/resources/views/api/v4/router/collector/bird2/neighbors.foil.php
+++ b/resources/views/api/v4/router/collector/bird2/neighbors.foil.php
@@ -239,9 +239,9 @@ protocol bgp pb_as<?= $int['autsys'] ?>_vli<?= $int['vliid'] ?>_ipv<?= $int['pro
         import where f_import_as<?= $int['autsys'] ?>();
         export none;
     };
-
-    <?php if( $int['bgpmd5secret'] && !$t->router->skip_md5 ): ?>password "<?= $int['bgpmd5secret'] ?>";<?php endif; ?>
-
+<?php if( $int['bgpmd5secret'] && !$t->router->skip_md5 ): ?>
+    password "<?= $int['bgpmd5secret'] ?>";
+<?php endif; ?>
 }
 
 <?php endforeach; ?>

--- a/resources/views/api/v4/router/server/bird2/header.foil.php
+++ b/resources/views/api/v4/router/server/bird2/header.foil.php
@@ -60,6 +60,17 @@ router id <?= $t->router->router_id ?>;
 # ignore interface up/down events
 protocol device { }
 
+protocol bfd
+{
+        accept ipv<?= $t->router->protocol ?> direct;
+        interface "*" {
+                passive on;
+                multiplier 3;
+                min rx interval 500ms;
+                min tx interval 500ms;
+        };
+}
+
 # This function excludes weird networks
 #  rfc1918, class D, class E, too long and too short prefixes
 function avoid_martians()

--- a/resources/views/api/v4/router/server/bird2/neighbors.foil.php
+++ b/resources/views/api/v4/router/server/bird2/neighbors.foil.php
@@ -281,8 +281,9 @@ protocol bgp pb_<?= $int['fvliid'] ?>_as<?= $int['autsys'] ?> from tb_rsclient {
             table t_<?= $int['fvliid'] ?>_as<?= $int['autsys'] ?>;
             export filter f_export_as<?= $int['autsys'] ?>;
         };
-        <?php if( $int['bgpmd5secret'] && !$t->router->skip_md5 ): ?>password "<?= $int['bgpmd5secret'] ?>";<?php endif; ?>
-
+<?php if( $int['bgpmd5secret'] && !$t->router->skip_md5 ): ?>
+        password "<?= $int['bgpmd5secret'] ?>";
+<?php endif; ?>
 }
 
 <?php endforeach; ?>

--- a/resources/views/api/v4/router/server/bird2/neighbors.foil.php
+++ b/resources/views/api/v4/router/server/bird2/neighbors.foil.php
@@ -284,6 +284,7 @@ protocol bgp pb_<?= $int['fvliid'] ?>_as<?= $int['autsys'] ?> from tb_rsclient {
 <?php if( $int['bgpmd5secret'] && !$t->router->skip_md5 ): ?>
         password "<?= $int['bgpmd5secret'] ?>";
 <?php endif; ?>
+        bfd on;
 }
 
 <?php endforeach; ?>


### PR DESCRIPTION
This enables BFD in passive mode in the bird2 route server templates. Passive mode means that the route server will only speak BFD if the participant initiates it.

At this point, this is just an example.  The following issues need to be resolved before this could be merged:

* Is BFD going to be enabled everywhere?  If not, it needs an option. Is that option on or off by default?  If on, should it be set to off for existing Routers on migration?
* Should the interval be customizable?  Should the multiplier?

This builds on top of the commit from PR #852, which is also included here.

To do:
 - [ ] Add a per-VLAN Interface (where "Route Server Client" is now) setting to enable BFD. Default to on.
 - [ ] Add per-Router (or global in .env, but I like per-Router because, among other reasons, it allows someone to step into it one route server at a time) settings for whether BFD is enabled. Default to off.
 - [ ] Add global in .env (or per-Router, but that seems unnecessary) settings for interval and multipler. Default the interval to 1s and the multiplier to 5, per Euro-IX recommendation.
 - [ ] Write tests
 - [ ] Write documentation

In addition to the above, I have reviewed the following:

 - [ ] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [ ] ensured appropriate checks against user privilege / resources accessed
 - [ ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
