### PR TITLE
Fix typos in a VirtualInterface comment

### DIFF
--- a/app/Models/VirtualInterface.php
+++ b/app/Models/VirtualInterface.php
@@ -199,9 +199,8 @@ class VirtualInterface extends Model
     }
 
     /**
-     * Get peerring PhysicalInterfaces
+     * Get peering PhysicalInterfaces
      *
-
      */
     public function peeringPhysicalInterface(): array
     {


### PR DESCRIPTION
This fixes a couple typos in a comment.