### PR TITLE
[BF] Treat PeeringDB "Restrictive" as "selective"

### DIFF
--- a/resources/views/customer/js/edit.foil.php
+++ b/resources/views/customer/js/edit.foil.php
@@ -128,6 +128,7 @@
                             case "Open":
                                 peering_policy = "open";
                                 break;
+                            case "Restrictive":
                             case "Selective":
                                 peering_policy = "selective";
                                 break;


### PR DESCRIPTION
PeeringDB supports a "General Policy" named "Restrictive". IXP Manager has no direct equivalent.  But it means essentially the same thing as "selective".  The difference is (arguably) that Selective means "yes if..." and Restrictive means "no unless..." Those are close enough that IXP Manager can treat them the same.

Closes #858

In addition to the above, I have verified that these are not applicable:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
