### PR TITLE
[BF] update-dns-from-ixp-manager: Fix sed -i.bup

### DIFF
--- a/tools/runtime/dns-arpa/update-dns-from-ixp-manager.sh
+++ b/tools/runtime/dns-arpa/update-dns-from-ixp-manager.sh
@@ -99,7 +99,7 @@ done
 
 for f in $SOAFILES; do
     calculate_serial $SOAPATH/$f
-    sed -E -i '.bup' "s/[0-9]{10}[[:space:]]+;[[:space:]]+Serial/${SERIAL}      ; Serial/" $SOAPATH/$f
+    sed -E -i'.bup' "s/[0-9]{10}[[:space:]]+;[[:space:]]+Serial/${SERIAL}      ; Serial/" $SOAPATH/$f
 done
 
 checkzone=0


### PR DESCRIPTION
With (at least GNU) sed, you cannot have a space between the -i and the SUFFIX.

An alternative would be `--in-place=.bup`, but `--in-place` might be a GNUism, and I'm not sure if that's acceptable.