### PR TITLE
Fix  update:reset-mysql-views artisan command

### DIFF
--- a/resources/views/database/views.foil.sql
+++ b/resources/views/database/views.foil.sql
@@ -87,7 +87,7 @@ CREATE VIEW view_switch_details_by_custid AS
 		sw.snmppasswd,
 		sw.infrastructure,
 		ca.name AS cabinet,
-		ca.cololocation AS colocabinet,
+		ca.colocation AS colocabinet,
 		lo.name AS locationname,
 		lo.shortname AS locationshortname
 	FROM


### PR DESCRIPTION
[BF] Fixes the update:reset-mysql-views command

 [this migration](https://github.com/inex/IXP-Manager/blob/master/database/migrations/2021_06_11_141137_update_db_doctrine2eloquent.php) breaks the views reset due to [this view reference](https://github.com/inex/IXP-Manager/blob/master/resources/views/database/views.foil.sql#L90).

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
