### PR TITLE
landingpage: fix svg logos are too big

### DIFF
--- a/resources/views/auth/forgot-password.foil.php
+++ b/resources/views/auth/forgot-password.foil.php
@@ -10,7 +10,7 @@
             <?= $t->alerts() ?>
             <div class="tw-text-center tw-my-6">
                 <?php if( config( "identity.biglogo" ) ) :?>
-                    <img class="tw-inline img-fluid" src="<?= config( "identity.biglogo" ) ?>" />
+                    <img class="tw-inline img-fluid tw-w-full tw-max-w-sm tw-mx-auto" src="<?= config( "identity.biglogo" ) ?>" />
                 <?php else: ?>
                     <h2>
                         [Your Logo Here]

--- a/resources/views/auth/forgot-username.foil.php
+++ b/resources/views/auth/forgot-username.foil.php
@@ -10,7 +10,7 @@
             <?= $t->alerts() ?>
             <div class="tw-text-center tw-my-6">
                 <?php if( config( "identity.biglogo" ) ) :?>
-                    <img class="tw-inline img-fluid" src="<?= config( "identity.biglogo" ) ?>" />
+                    <img class="tw-inline img-fluid tw-w-full tw-max-w-sm tw-mx-auto" src="<?= config( "identity.biglogo" ) ?>" />
                 <?php else: ?>
                     <h2>
                         [Your Logo Here]

--- a/resources/views/auth/login.foil.php
+++ b/resources/views/auth/login.foil.php
@@ -10,7 +10,7 @@
             <?= $t->alerts() ?>
             <div class="tw-text-center tw-my-6">
                 <?php if( config( "identity.biglogo" ) ) :?>
-                    <img class="tw-inline img-fluid" src="<?= config( "identity.biglogo" ) ?>" />
+                    <img class="tw-inline img-fluid tw-w-full tw-max-w-sm tw-mx-auto" src="<?= config( "identity.biglogo" ) ?>" />
                 <?php else: ?>
                     <h2>
                         [Your Logo Here]

--- a/resources/views/auth/reset-password.foil.php
+++ b/resources/views/auth/reset-password.foil.php
@@ -10,7 +10,7 @@
             <?= $t->alerts() ?>
             <div class="tw-text-center tw-my-6">
                 <?php if( config( "identity.biglogo" ) ) :?>
-                    <img class="tw-inline img-fluid" src="<?= config( "identity.biglogo" ) ?>" />
+                    <img class="tw-inline img-fluid tw-w-full tw-max-w-sm tw-mx-auto" src="<?= config( "identity.biglogo" ) ?>" />
                 <?php else: ?>
                     <h2>
                         [Your Logo Here]


### PR DESCRIPTION
[BF] Summary of fix - fixes [inex|islandbridgenetworks]/IXP-Manager#x
Configures a maximum size for the logo on the login page (and other pages) as svg logos are growing infinite in size
 
In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
BEFORE:
![Screenshot 2024-04-18 at 18-22-58 DD-IX Portal](https://github.com/inex/IXP-Manager/assets/34819524/af0729c8-29e3-4405-93c9-8582b5bda986)

AFTER:
![Screenshot 2024-04-18 at 18-31-58 DD-IX Portal](https://github.com/inex/IXP-Manager/assets/34819524/c574481e-fa3f-4cee-ae13-0b51db3b076b)
