### PR TITLE
[NF] Allow to exclude interface lists by ASNs inside IX-F feed

### DIFF
--- a/app/Utils/Export/JsonSchema.php
+++ b/app/Utils/Export/JsonSchema.php
@@ -328,6 +328,7 @@ class JsonSchema
 
         $cnt = 0;
         $exclude_asns = [];
+        $exclude_asns_if = [];
         $exclude_tags = [];
 
         if( $xas = config( 'ixp_api.json_export_schema.excludes.asnum' ) ) {
@@ -336,6 +337,10 @@ class JsonSchema
 
         if( $xt = config( 'ixp_api.json_export_schema.excludes.tags' ) ) {
             $exclude_tags = explode( '|', $xt );
+        }
+
+        if( $xas = config( 'ixp_api.json_export_schema.excludes.asnumif' ) ) {
+            $exclude_asns_if = explode( '|', $xas );
         }
 
         foreach( $customers as $c ) {
@@ -494,7 +499,9 @@ class JsonSchema
 
                 $conn['ixp_id']      = $vli->vlan->infrastructureid;
                 $conn['state']       = 'active';
-                $conn['if_list']     = $iflist;
+                if( ! (count( $exclude_asns_if ) && in_array( $c->autsys, $exclude_asns_if ) ) ) {
+                    $conn['if_list'] = $iflist;
+                }
                 $conn['vlan_list']   = $vlanentries;
 
                 $connlist[] = $conn;

--- a/config/ixp_api.php
+++ b/config/ixp_api.php
@@ -41,14 +41,15 @@ return [
 
         // some IXs want to exclude some information:
         'excludes' => [
-            'rfc5398'   => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_RFC5398', true    ),
-            'rfc6996'   => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_RFC6996', true    ),
-            'tags'      => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_TAGS',    false   ),
-            'asnum'     => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_ASNUM',   false   ),
-            'switch'    => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_SWITCH',  false   ),
-            'ixp'       => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_IXP',     false   ),
-            'member'    => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_MEMBER',  false   ),
-            'intinfo'   => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_INTINFO', false   ),
+            'rfc5398'   => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_RFC5398',  true    ),
+            'rfc6996'   => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_RFC6996',  true    ),
+            'tags'      => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_TAGS',     false   ),
+            'asnum'     => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_ASNUM',    false   ),
+            'asnumif'   => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_ASNUM_IF', false   ),
+            'switch'    => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_SWITCH',   false   ),
+            'ixp'       => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_IXP',      false   ),
+            'member'    => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_MEMBER',   false   ),
+            'intinfo'   => env( 'IXP_API_JSONEXPORTSCHEMA_EXCLUDE_INTINFO',  false   ),
         ],
     ],
 


### PR DESCRIPTION
[NF]  This allows to remove which specific PoPs a given member ASN is connected on.

*Longer description*

We have a need to mask where some peers are physically connected, which specifically for us means to remove the `switch_id` from the IX-F feed. However, removing just the `switch_id` results in a validation error on [IXPDB's validator](https://ixpdb.euro-ix.net/en/validator/) - thus we suggest omitting the whole `if_list` structure for a matching member.

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
*Example IX-F resource*

```json
{
  "asnum": 213113,
  "member_since": "2021-07-15T00:00:00Z",
  "url": "https://kamel.network",
  "name": "Kamel Networks",
  "peering_policy": "open",
  "member_type": "peering",
  "connection_list": [
    {
      "ixp_id": 1,
      "state": "active",
      "vlan_list": [
        {
          "vlan_id": 1,
          "ipv4": {
            "address": "185.1.215.11",
            "as_macro": "AS-KAMEL",
            "routeserver": true,
            "mac_addresses": [
              "00:1c:73:2c:6e:ca"
            ],
            "max_prefix": 12
          },
          "ipv6": {
            "address": "2001:7f8:117::21:3113:1",
            "as_macro": "AS-KAMEL",
            "routeserver": true,
            "mac_addresses": [
              "00:1c:73:2c:6e:ca"
            ],
            "max_prefix": 12
          }
        }
      ]
    }
  ]
}
```

*Example configuration*

```
IXP_API_JSONEXPORTSCHEMA_EXCLUDE_ASNUM_IF="213113|1234"
```