### PR TITLE
Enable RFC 9234 route leak prevention in backwards compatible ('non-strict' mode)

### DIFF
--- a/resources/views/api/v4/router/server/bird/neighbor-template.foil.php
+++ b/resources/views/api/v4/router/server/bird/neighbor-template.foil.php
@@ -47,6 +47,7 @@ template bgp tb_rsclient {
 
         export all;
         rs client;
+        local role rs_server;
 <?php if( $t->router->protocol == 6 ): ?>
         missing lladdr ignore;
 <?php endif; ?>


### PR DESCRIPTION
* Requires BIRD 2.0.15 or higher

[NF] New feature summary 

Enable RFC 9234 support on IXP-manager-managed route servers. See https://mailman.nanog.org/pipermail/nanog/2024-September/226204.html

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks