### PR TITLE
restrict customer list on patch-panel-port/edit to current customers only

### DIFF
--- a/app/Http/Controllers/PatchPanel/Port/PortController.php
+++ b/app/Http/Controllers/PatchPanel/Port/PortController.php
@@ -210,7 +210,7 @@ class PortController extends Controller
 
         return view( 'patch-panel-port/edit' )->with([
             'states'                => $states,
-            'customers'             => Customer::select( [ 'id', 'name' ] )->orderBy( 'name' )->get(),
+            'customers'             => Customer::select( [ 'id', 'name' ] )->current()->orderBy( 'name' )->get(),
             'switches'              => Switcher::select( [ 'switch.id', 'switch.name' ] )
                                         ->leftJoin( 'cabinet AS cab', 'cab.id', 'switch.cabinetid' )
                                         ->where( 'active', true )


### PR DESCRIPTION
[BF] restrict customer list on patch-panel-port/edit to current customers only

Currently the `Member`/`Customer` field on `patch-panel-port/edit` shows non-current members. This patch alters the datasource call to select only current members.
 
In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
