### PR TITLE
[BF] Fix crash in switch config list if array_sum contains non-integer

### DIFF
--- a/resources/views/switches/configuration.foil.php
+++ b/resources/views/switches/configuration.foil.php
@@ -175,11 +175,16 @@
                             <td>
                                 <?= str_replace( ",", "<br>", $conf[ "ifName" ] ) ?>
                             </td>
-                            <td>
-                                <?= $t->scaleBits( array_sum( explode( "," , $conf[ "rate_limit" ] ?: $conf[ "speed" ]) )*1000*1000, 0 ) ?>
-                            </td>
-                            <td>
-                                <?= array_sum( explode( ',' , $conf[ "rate_limit" ] ?: $conf[ 'speed' ] ) ) ?>
+                <td>
+               <?php $sp_scale = '' ?>
+               <?php $sp_total = array_sum( explode( "," , $conf["rate_limit" ] ?? $conf[ "speed" ] ?? 0 ) ); ?>
+                <?php if( $sp_total > 0 ): ?>
+                <?php $sp_scale = $t->scaleBits( $sp_total *1000*1000, 0 ) ?>
+                <?php endif; ?>
+                <?= $sp_scale ?>
+                </td>
+                <td>
+                <?= array_sum( explode( ',' , $conf[ "rate_limit" ] ?? $conf[ 'speed' ] ?? 0 ) ) ?>
                             </td>
                             <td>
                                 <?= $conf[ "vlan" ] ?>


### PR DESCRIPTION

Fix crash in php8.3 if array_sum contains non-integers from scaleBits()

```
[2025-02-20 16:24:49] production.ERROR: array_sum(): Addition is not supported on type string {"userId":725,"exception":"[object] (ErrorException(code: 0): array_sum(): Addition is not supported on type string at /srv/ixpmanager/resources/views/switches/configuration.foil.php:179)
``` 
Downgraded to php8.1 for now, but while I was on 8.3, fixed this error.

In addition to the above, I have:

 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
