### PR TITLE
[IM] Change column heading "reseller" to "resold"

### DIFF
--- a/resources/views/customer/list.foil.php
+++ b/resources/views/customer/list.foil.php
@@ -91,7 +91,7 @@
                         Peering Policy
                     </th>
                     <th>
-                        Reseller
+                        Resold
                     </th>
                     <th>
                         Type


### PR DESCRIPTION
Small tweak in customer/member list. This column indicates a **Resold** customer, not a Reseller. (Despite the name of the field.)
  
