### PR TITLE
[IM] move aggregate graph after port graphs for more consistent alignment

### DIFF
--- a/resources/views/customer/overview-tabs/ports/port.foil.php
+++ b/resources/views/customer/overview-tabs/ports/port.foil.php
@@ -342,6 +342,31 @@
     </div>
 
     <div class="col-lg-6 col-md-12">
+
+    <?php foreach( $pis as $pi ): ?>
+
+            <?php if( !$pi->isGraphable() ) { continue; } ?>
+
+            <div class="card mb-4">
+                <div class="card-header d-flex">
+                    <div class="mr-auto">
+                        <h5>
+                            Day Graph for <?= $t->ee( $pi->switchPort->switcher->name ) ?> / <?= $t->ee( $pi->switchPort->name ) ?>
+                        </h5>
+                    </div>
+
+                    <div class="my-auto">
+                        <a class="btn btn-white btn-sm" href="<?= route( "statistics@member-drilldown", [ 'type' => 'pi', 'typeid' => $pi->id ] ) ?>">
+                            <i class="fa fa-search"></i>
+                        </a>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <?= $t->grapher->physint( $pi )->renderer()->boxLegacy() ?>
+                </div>
+            </div>
+        <?php endforeach; ?>
+
         <?php if( $isLAG ): ?>
             <?php if( $t->vi->isGraphable() ): ?>
                 <div class="card mb-4">
@@ -364,27 +389,5 @@
             <?php endif; ?>
         <?php endif; ?>
 
-        <?php foreach( $pis as $pi ): ?>
-            <?php if( !$pi->isGraphable() ) { continue; } ?>
-
-            <div class="card mb-4">
-                <div class="card-header d-flex">
-                    <div class="mr-auto">
-                        <h5>
-                            Day Graph for <?= $t->ee( $pi->switchPort->switcher->name ) ?> / <?= $t->ee( $pi->switchPort->name ) ?>
-                        </h5>
-                    </div>
-
-                    <div class="my-auto">
-                        <a class="btn btn-white btn-sm" href="<?= route( "statistics@member-drilldown", [ 'type' => 'pi', 'typeid' => $pi->id ] ) ?>">
-                            <i class="fa fa-search"></i>
-                        </a>
-                    </div>
-                </div>
-                <div class="card-body">
-                    <?= $t->grapher->physint( $pi )->renderer()->boxLegacy() ?>
-                </div>
-            </div>
-        <?php endforeach; ?>
     </div>
 </div>


### PR DESCRIPTION
Move aggregate graph so it's **_after_** the individual port graphs.

This is to make it more consistent

- **For non-LAG ports**: the graph related to the port always appears to the right of the physical port.
- **For LAG ports**: The LAG aggregate graph was appearing first, which shuffles down the physical port graphs making it harder to read which graph belongs to which physical port.

i.e., The graphs are aligned with the associated physical port, except **_sometimes_** they aren't.

**Mistakes have occurred because of this,** for example:

- Reading the wrong graph for a port.
- Looking for the port which traffic has dropped off, moving eyes left and then changing or unplugging the wrong crossconnect. 

**Before**: Here you can see I accidentally clicked the crossconnect for the port adjacent to the graph Ethernet8/2, which on closer inspection is actually Ethernet13/1. Then unplugged the crossconnect  Ethernet13/1 instead of Ethernet8/2. One outage later, I realised what I'd done.
 
![s1](https://github.com/user-attachments/assets/1beda9e6-1690-4a9e-a2de-833c5411377d)

**After**: Graphs **always** in the same order and align with the associated physical port. (LAG or not) This reduces the chance of similar "read-out" errors in future.

![s2](https://github.com/user-attachments/assets/03272d47-769b-4cd4-8086-ca6155f09b25)

There may be a nicer way to do this, for example moving the "Connection" (virtual interface) and LAG aggregate graphs first, so they're always first and together, with a blank space if there's no LAG graph.

Or hiding the LAG graph by default and only expanding it if needed. (I don't think we really look at it that often.)

