### PR TITLE
[IM] Validate as-set on input

### DIFF
--- a/app/Http/Requests/Customer/Store.php
+++ b/app/Http/Requests/Customer/Store.php
@@ -78,8 +78,8 @@ class Store extends FormRequest
             'autsys'                => 'int|min:1',
             'maxprefixes'           => 'nullable|int|min:0',
             'peeringemail'          => 'email',
-            'peeringmacro'          => 'nullable|string|max:255',
-            'peeringmacrov6'        => 'nullable|string|max:255',
+            'peeringmacro'          => [ 'nullable', 'string', 'max:255', 'regex:/^(AS-[A-Z0-9]+(?:-[A-Z0-9]+)*|AS[1-9]\d*(?::AS-[A-Z0-9]+(?:-[A-Z0-9]+)*)?)$/i' ],
+            'peeringmacrov6'        => [ 'nullable', 'string', 'max:255', 'regex:/^(AS-[A-Z0-9]+(?:-[A-Z0-9]+)*|AS[1-9]\d*(?::AS-[A-Z0-9]+(?:-[A-Z0-9]+)*)?)$/i' ],
             'peeringpolicy'         => 'string|in:' . implode( ',', array_keys( Customer::$PEERING_POLICIES ) ),
             'irrdb'                 => 'nullable|integer|exists:irrdbconfig,id',
             'nocphone'              => 'nullable|string|max:255',
@@ -89,6 +89,7 @@ class Store extends FormRequest
             'nocwww'                => 'nullable|url|max:255',
             'reseller'              => 'nullable|integer|exists:cust,id',
         ];
+
 
         return $this->type == Customer::TYPE_ASSOCIATE  ? $validateCommonDetails : array_merge( $validateCommonDetails, $validateOtherDetails ) ;
     }

--- a/resources/views/customer/edit.foil.php
+++ b/resources/views/customer/edit.foil.php
@@ -173,15 +173,16 @@
                     ->label( 'IPv4 Peering Macro' )
                     ->placeholder( "AS-ACME-EXAMPLE" )
                     ->blockHelp( "The IPv4 Peering Macro is used instead of the AS number when set to generate inbound prefix filters for the "
-                        . "route servers based on the member's published IRR records." );
+                        . "route servers based on the member's published IRR records. Must be a valid as-macro. One of:<br><code>ASNNNNN,  AS-MACRONAME, ASNNNNN:AS-MACRONAME</code><br>");
                 ?>
-
+                
                 <?= Former::text( 'peeringmacrov6' )
                     ->label( 'IPv6 Peering Macro' )
                     ->placeholder( "AS-ACME-V6-EXAMPLE" )
                     ->blockHelp( "In the event that IPv6 Peering Macro is set, this will be used to generate IPv6 inbound prefix filters, "
                         . "otherwise the IPv4 Peering Macro will be used for both. If neither is set, the IRR policy of the AS number will "
-                        . "be used. Use <code>AS-NULL</code> to disable one or the other protocol peering macro if only one is required." );
+                        . "be used. Use <code>AS-NULL</code> to disable one or the other protocol peering macro if only one is required. "
+                        . "Must be a valid as-macro. One of:<br><code>ASNNNNN,  AS-MACRONAME, ASNNNNN:AS-MACRONAME</code><br>" );
                 ?>
 
                 <?= Former::select( 'peeringpolicy' )


### PR DESCRIPTION

[BF] Validate peeringmacro and peeringmacrov6 on input.

Related to https://github.com/inex/IXP-Manager/issues/877

Looks there has been some fixes to the scheduled job in the pipeline, but if we can stop bum data from getting into it in the first place, this would also be good.

The scheduled job to update the ASN/prefix list was silently crashing out (again!) when it encountered an invalid entry.

Seems it has not been running properly for some time.

Often when populating from PeeringDB, it contains other spurious text in the as-macro field, like:

`RIPE::AS-FOO  RIPE::AS-FOO-THING`.

This PR adds validation to the fields on input, and only accepts the following:-

- `AS<number>`
- `AS-<name>`
- `AS<number>:AS-NAME`

It does **not** accept:-

-  AS with leading zero - `AS01234`
-  More than one consecutive colon - `RIPE::AS-FOO`
- More than one consecutive hyphen `--`  - `AS--FOO-BAR`
- Leading or trailing `-` - `AS-FOO-BAR-`
- Leading or trailing `:` - `AS12345:`
- Any spaces, dots etc. (Anything not `0-9, A-Z, a-z, -`)

I've applied this as a local patch to our install to prevent this issue happening again.

R.

In addition to the above, I have:

 - [X] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [X] ensured appropriate checks against user privilege / resources accessed
 - [X] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
