### PR TITLE
[BF/IM] Allow reseller uplink ports to be updated

### DIFF
--- a/resources/views/interfaces/common/js/interface-functions.foil.php
+++ b/resources/views/interfaces/common/js/interface-functions.foil.php
@@ -172,7 +172,7 @@ function updateSwitchPort( e ) {
         selectedPort = $( "#original-switch-port-fanout" ).val();
     } else {
         dd_sp     = $( "#switchportid" );
-        arrayType = [ <?= \IXP\Models\SwitchPort::TYPE_UNSET ?>,  <?= \IXP\Models\SwitchPort::TYPE_PEERING ?>, <?= \IXP\Models\SwitchPort::TYPE_CORE ?> ];
+        arrayType = [ <?= \IXP\Models\SwitchPort::TYPE_UNSET ?>, <?= \IXP\Models\SwitchPort::TYPE_RESELLER ?>, <?= \IXP\Models\SwitchPort::TYPE_PEERING ?>, <?= \IXP\Models\SwitchPort::TYPE_CORE ?> ];
         selectedPort = $( "#original-switch-port" ).val();
     }
 


### PR DESCRIPTION
This PR fixes a bug/limitation which meant it was not possible to update physical interfaces of type "Reseller" (reseller uplink ports) without first having to change them back to "Peering" via Switches -> Switch Ports -> (Edit), then make the changes, then set it back to type "Reseller" in Switches -> Switch Ports -> (Edit).

It will also set a new port being added to a VirtualInterface to "Reseller" if existing port in VI is already set to "Reseller".

In addition to the above, I have:

 - [X] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [X] ensured appropriate checks against user privilege / resources accessed
 - [X] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
