### PR TITLE
[IM] Add option to use a db query to map sFLOW VLAN to peering VLAN

### DIFF
--- a/tools/perl-lib/IXPManager/ixpmanager.conf.dist
+++ b/tools/perl-lib/IXPManager/ixpmanager.conf.dist
@@ -34,4 +34,29 @@
 #	debug = 1
 	apikey = VeryLongAPIKeyFromIXPManager
 	apibaseurl = http://www.example.com/ixp/api/v4
+
+	# use configured MAC table instead of learned MAC table?
+	# macdbtype = configured
+
+	# If resold VLANs are not in IXP Manager, do we map VLANs for translations/resold customers?
+
+	map_vlans = 0
+
+	# If map_vlans is enabled, query to translate VLANs.
+ 	# query should return two fields: pvlan (resold vlan) and vlan (peering vlan)
+ 	#
+ 	# Example: Extract VLAN id from subinterface names e.g. Ethernet15/1.501
+ 	# for all resold customers. Map to actual peering VLAN as configured in IXPM.
+	# 
+ 	map_vlan_query = SELECT DISTINCT SUBSTRING_INDEX(sp.name, '.', -1) AS pvlan, v.number as vlan \
+		FROM switchport sp \
+		INNER JOIN physicalinterface pi ON pi.switchportid = sp.id \
+		INNER JOIN virtualinterface vi ON pi.virtualinterfaceid = vi.id \
+		INNER JOIN cust c ON vi.custid = c.id \
+		INNER JOIN vlaninterface vli ON vli.virtualinterfaceid = vi.id \
+		INNER JOIN vlan v ON vli.vlanid = v.id \
+		WHERE c.reseller > 0 AND \
+		v.peering_matrix = 1 AND \
+		sp.name LIKE '%.%'
+
 </ixp>

--- a/tools/runtime/sflow/sflow-detect-ixp-bgp-sessions
+++ b/tools/runtime/sflow/sflow-detect-ixp-bgp-sessions
@@ -2,7 +2,7 @@
 #
 # sflow-detect-ixp-bgp-sessions
 #
-# Copyright (C) 2009 - 2019 Internet Neutral Exchange Association Company Limited By Guarantee.
+# Copyright (C) 2009 - 2025 Internet Neutral Exchange Association Company Limited By Guarantee.
 # All Rights Reserved.
 #
 # This file is part of IXP Manager.
@@ -47,6 +47,8 @@ my $dbh = $ixp->{db};
 
 my $debug = defined($ixp->{ixp}->{debug}) ? $ixp->{ixp}->{debug} : 0;
 my $insanedebug = 0;
+my $map_vlans = defined($ixp->{ixp}->{map_vlans}) ? $ixp->{ixp}->{map_vlans} : 0;
+my $map_vlan_query = $ixp->{ixp}->{map_vlan_query};
 my $sflowtool = defined($ixp->{ixp}->{sflowtool}) ? $ixp->{ixp}->{sflowtool} : '/usr/bin/sflowtool';
 my $sflowtool_opts = defined($ixp->{ixp}->{sflowtool_bgp_opts}) ? $ixp->{ixp}->{sflowtool_bgp_opts} : '-l';
 my $timer_period = 600;
@@ -68,6 +70,13 @@ if ($insanedebug) {
 }
 
 my $ipmappings = reload_ipmappings($dbh);
+
+my $vlan_mappings;
+
+if ($map_vlans) {
+	$vlan_mappings = reload_vlan_mappings($dbh,$map_vlan_query);
+	$debug && print Dumper ($vlan_mappings);
+}
 
 my $execute_periodic = 0;
 my $quit_after_periodic = 0;
@@ -137,6 +146,13 @@ while (<SFLOWTOOL>) {
 
 		# we're also only interested in ip addresses that have a database match
 		if ($ipmappings->{$ipprotocol}->{$srcip} && $ipmappings->{$ipprotocol}->{$dstip}) {
+
+				# if enabled, correct VLAN if there are VLAN translations e.g. for resold customers:
+				if ($vlan_mappings->{$vlan}->{'vlan'}) {
+					print STDERR " [VLAN mapping: VLAN $vlan -> $vlan_mappings->{$vlan}->{'vlan'}]" if ($debug);
+					$vlan = $vlan_mappings->{$vlan}->{'vlan'};
+				}
+
 			print STDERR " database updated" if ($debug);
 			if (!$sth->execute($ipmappings->{$ipprotocol}->{$srcip}, $ipmappings->{$ipprotocol}->{$dstip}, $ipprotocol, $vlan, $agent)) {
 				print STDERR " unsuccessfully" if ($debug);
@@ -162,8 +178,14 @@ while (<SFLOWTOOL>) {
 		}
 		$execute_periodic = 0;
 		$ipmappings = reload_ipmappings($dbh);
+
+		if ($map_vlans) {
+			$vlan_mappings = reload_vlan_mappings($dbh,$map_vlan_query);
+		}
+
 		$debug && print STDERR "DEBUG: periodic reload completed at ".time()."\n";
 		$debug && print Dumper ($ipmappings);
+		$debug && print Dumper ($vlan_mappings);		
 
 		if (time() - $lastdailyrun > 86400) {
 			$lastdailyrun = time();
@@ -226,4 +248,26 @@ sub reload_ipmappings
 	}
 
 	return $mapping;
+}
+
+#
+# VLAN translation mappings
+#
+sub reload_vlan_mappings {
+
+        my ($d,$sql) = @_;
+
+	return undef unless ($sql);
+
+	my ($s, $mapping);
+
+	$debug && print STDERR "DEBUG: sql $sql\n";
+
+	$s = $d->prepare("$sql");
+	$s->execute();
+
+	$mapping = $s->fetchall_hashref('pvlan');
+
+	return $mapping;
+
 }


### PR DESCRIPTION
For our resold members, the **Peering Manager** view was not showing bilateral peering sessions existing, despite a BGP session being configured and up.

The BGP session was being correctly identified from sFLOW, and added to the database, however, IXPM only appears to show bilateral peering sessions where the VLAN is a peering LAN in its database.

For resellers, we use **Arista** port VLAN translation feature. Arista sends the **original** VLAN via sFLOW and not the translated VLAN. Therefore the VLAN which is received via sFLOW is not in IXP Manager's database / does not have peering matrix option enabled. [The portal excludes this](https://github.com/inex/IXP-Manager/blob/master/app/Models/Aggregators/BgpSessionDataAggregator.php#L81) when showing peering sessions in the Peering Manager view.

(It would be nice if Arista had a config option to send the translated VLAN via sFLOW, but I could not find such a thing. I suspect this may be non-trivial given it's usually done in hardware...)

This PR adds a config option for `sflow-detect-ixp-bgp-sessions` to use an sql query to map the resold customer VLANs back to the correct peering VLAN, as configured in IXP Manager.

Scenario:

Resold customer interface is:-

```
interface Ethernet15/1.501
   description P: Resold Customer Name
   load-interval 6
   encapsulation dot1q vlan 501
   vlan id 4
   mac access-group MAC-ACL-Ethernet15_1.501 in
   service-profile LONAP-1G
```

 * The VLAN id 501 is only significant for this port/reseller and is not in IXP Manager's database.
 * Ethernet15/1.501 is added to the **peering VLAN** (VLAN 4) in IXP Manager.
 * Arista sends us VLAN 501 via sFLOW, however.

If enabled, an sql query (also configurable) will be used to map the resold VLAN IDs back to the peering VLAN, and this VLAN will be added to the database instead.

The easiest thing to do[1] is a query which just extracts the VLAN ID from the interface name for all resold customers, together with the VLAN id for the peering VLAN as configured in IXP Manager. 

So we end up with a table like:-

```
+-------+------+
| pvlan | vlan |
+-------+------+
| 845   |    4 |
| 1503  |    4 |
| 101   |    4 |
| 509   |    4 |
| 551   |    4 |
| 502   |    4 |
| 515   |    4 |
| 646   |    4 |
| 516   |    4 |
| 519   |    4 |
| 520   |    4 |
| 608   |    4 |
...
```

[1] Actually, the _easiest/laziest_ thing to do in our case is: `if ($vlan >= 500) ... { $vlan = 4 } ` - but that is quite a "LONAP-specific" workaround.