### PR TITLE
[IM] Improvements to Rs api-reconfigure-example-birdv2.sh

### DIFF
--- a/tools/vagrant/scripts/ixpm-reconfigure-routers-bird2.sh
+++ b/tools/vagrant/scripts/ixpm-reconfigure-routers-bird2.sh
@@ -323,7 +323,7 @@ if [[ $? -ne 0 ]]; then
 
     else
 
-      cmd="${BIRDBIN} -c ${cfile} -s $socket"
+      cmd="${BIRDBIN} -c ${cfile} -s $socket -u ${BIRD_RUN_USER} -g ${BIRD_RUN_GROUP}"
 
     fi
 


### PR DESCRIPTION
Various enhancements to the new unified api-reconfigure-example-birdv2.sh:

- -i option - If set, start BIRD via systemd if that's how you've got it set up (as per deb package)
- `BIRD_RUN_USER` / `BIRD_RUN_GROUP`: Set BIRD user/group to run as (to match BIRD's default/systemd)
- Check bird user/group exists. Bail if not.
- Start BIRD as correct user/group (pass -u and -g)
- Create missing dirs with correct ownership and permissions
- Add a few new sanity checks for required vars
- Default `RUNPATH` is now `/run/bird`
- If `URL_RELEASE` is commented out, don't get stuck in endless "sleeping 60 secs and trying again" loop. (So I can still use/test this script on older version of IXPM)

(Basically.. We're running the [BIRD deb package from nic.cz repo](https://pkg.labs.nic.cz/doc/?project=bird) so we don't need to build the .deb ourselves anymore. By default it runs from systemd and as user/group bird. Seems easier to update this script not to break all this stuff, rather than fight with the default BIRD setup every time it upgrades/installs)