### PR TITLE
Update IEEE OUI URL

### DIFF
--- a/app/Utils/OUI.php
+++ b/app/Utils/OUI.php
@@ -38,7 +38,7 @@ class OUI
      * Where to get the OUI list from
      * @var string Where to get the OUI list from
      */
-    public $file = 'http://standards.ieee.org/develop/regauth/oui/oui.txt';
+    public $file = 'https://standards-oui.ieee.org/oui/oui.txt';
 
     /**
      * Raw OUI data


### PR DESCRIPTION
Update IEEE OUI URL

The URL referenced on line 41 points to an outdated link, which results in a 403, as identified by nishal@inx.net.za