### PR TITLE
Implement prepareForValidation method for NGINX

### DIFF
--- a/app/Http/Requests/StatisticsRequest.php
+++ b/app/Http/Requests/StatisticsRequest.php
@@ -50,7 +50,20 @@ class StatisticsRequest extends FormRequest
         // authorisation done on a per action basis using Grapher::Graph->authorise() in the controller
         return true;
     }
-
+    
+    /**
+     * Prepare the data for validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->period   = $this->query('period');
+        $this->category = $this->query('category');
+        $this->protocol = $this->query('protocol');
+        $this->type     = $this->query('type');
+    }
+    
     /**
      * Get the validation rules that apply to the request.
      *


### PR DESCRIPTION
Under NGINX, the customer statistics would always return to "bits" and "day" regardless of menu selections.  I don't know if this problem exists under Apache.  Note that I was led to this fix by claude.ai.

*PR template - remove this line and edit below*

[BF] Summary of fix - fixes [inex|islandbridgenetworks]/IXP-Manager#x

[NF] New feature summary - closes [inex|islandbridgenetworks]/IXP-Manager#x

*Longer description*
 

In addition to the above, I have:

 - [ ] ensure unit tests all run without error
 - [ ] ran pslam and corrected any static analysis issues
 - [ ] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent.
 - [ ] ensured appropriate checks against user privilege / resources accessed
 - [ ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
