### PR TITLE
Allow memcached host and port to be configured via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,6 +239,9 @@ GRAPHER_BACKEND_MRTG_DBTYPE=rrd
 # See config/cache.php
 CACHE_DRIVER=array
 
+# MEMCACHED_HOST=127.0.0.1
+# MEMCACHED_PORT=11211
+
 #######################################################################################
 # Session Lifetimes - standard and remember me.
 #

--- a/config/cache.php
+++ b/config/cache.php
@@ -79,7 +79,7 @@ return [
 			'driver'  => 'memcached',
 			'servers' => [
 				[
-					'host' => '127.0.0.1', 'port' => 11211, 'weight' => 100
+					'host' => env('MEMCACHED_HOST', '127.0.0.1'), 'port' => env('MEMCACHED_PORT', 11211), 'weight' => 100
 				],
 			],
 		],


### PR DESCRIPTION
[BF] Summary of fix - fixes [inex]/IXP-Manager#968

Problem Statement: Memcached is currently hard coded to 127.0.0.1:11211.
Change: Add env value (with defaults matching existing behaviour), this allows the ability to move it either inside a docker container, or another box / cluster
Risk/Reward: Low risk, as default values that match existing behaviour can be passed. 
  
