### PR TITLE
rir update - remove another unused arg left over from refactoring

### DIFF
--- a/app/Console/Commands/Rir/GenerateObject.php
+++ b/app/Console/Commands/Rir/GenerateObject.php
@@ -85,9 +85,9 @@ class GenerateObject extends Command
         if( !$this->isVerbosityQuiet() && !$this->option( "force" ) && $obj === $cobj ) {
             $this->warn( "Generated RIR object is identical to cached version, use --force to update anyway." );
         }
-        
+
         if( $this->option( "send-email" ) && ( $this->option( "force" ) || $obj !== $cobj ) ) {
-            $this->sendEmail( $key, $obj );
+            $this->sendEmail( $obj );
         } else if( $this->option( "update-ripe-db" ) && ( $this->option( "force" ) || $obj !== $cobj ) ) {
             $this->updateRipeDb( $gen->generateJson() );
         } else if( !$this->option( "send-email" ) && !$this->option( "update-ripe-db" ) ) {
@@ -134,11 +134,11 @@ class GenerateObject extends Command
     
     /**
      * Send an email with the generated object
-     * @param string $key
      * @param string $obj
      * @return void
      */
-    private function sendEmail( string $key, string $obj ): void {
+    private function sendEmail( string $obj ): void
+    {
         if( !$this->option( "to" ) && !config( 'ixp_api.rir.email.to' )   ){
             $this->fail( "Please specify the TO email address" );
         }
@@ -153,7 +153,6 @@ class GenerateObject extends Command
         if( !$this->isVerbosityQuiet() ) {
             $this->info( "Email sent." );
         }
-        
     }
     
     


### PR DESCRIPTION
$key is unused in sendEmail and should have been removed last time I removed an unused arg