### PR TITLE
[BF] correct IXPM-OBJECT/IXPM-KEY in default rir templates

### DIFF
--- a/resources/views/api/v4/rir/as-set-ixp-connected.foil.php
+++ b/resources/views/api/v4/rir/as-set-ixp-connected.foil.php
@@ -1,6 +1,6 @@
 <?php if( $t->forJson ): ?>
-IXPM-OBJECT:    aut-num
-IXPM-KEY:       AS66500<?php else: ?>
+IXPM-OBJECT:    as-set
+IXPM-KEY:       AS-SET-IXP-CONNECTED<?php else: ?>
 password:       <?= config('ixp_api.rir.password') ?>
 <?php endif; ?>
 

--- a/resources/views/api/v4/rir/as-set-ixp-rs-v4.foil.php
+++ b/resources/views/api/v4/rir/as-set-ixp-rs-v4.foil.php
@@ -1,6 +1,6 @@
 <?php if( $t->forJson ): ?>
-IXPM-OBJECT:    aut-num
-IXPM-KEY:       AS66500<?php else: ?>
+IXPM-OBJECT:    as-set
+IXPM-KEY:       AS-SET-IXP-RS-V4<?php else: ?>
 password:       <?= config('ixp_api.rir.password') ?>
 <?php endif; ?>
 

--- a/resources/views/api/v4/rir/as-set-ixp-rs-v6.foil.php
+++ b/resources/views/api/v4/rir/as-set-ixp-rs-v6.foil.php
@@ -1,6 +1,6 @@
 <?php if( $t->forJson ): ?>
-IXPM-OBJECT:    aut-num
-IXPM-KEY:       AS66500<?php else: ?>
+IXPM-OBJECT:    as-set
+IXPM-KEY:       AS-SET-IXP-RS-V6<?php else: ?>
 password:       <?= config('ixp_api.rir.password') ?>
 <?php endif; ?>
 

--- a/resources/views/api/v4/rir/as-set-ixp-rs.foil.php
+++ b/resources/views/api/v4/rir/as-set-ixp-rs.foil.php
@@ -1,6 +1,6 @@
 <?php if( $t->forJson ): ?>
-IXPM-OBJECT:    aut-num
-IXPM-KEY:       AS66500<?php else: ?>
+IXPM-OBJECT:    as-set
+IXPM-KEY:       AS-SET-IXP-RS<?php else: ?>
 password:       <?= config('ixp_api.rir.password') ?>
 <?php endif; ?>
 

--- a/tests/Console/Rir/GenerateObjectTest.php
+++ b/tests/Console/Rir/GenerateObjectTest.php
@@ -165,7 +165,7 @@ class GenerateObjectTest extends TestCase
     {
         config()->set('ixp_api.rir.ripe_api_key', 'fakeapikey' );
         \Http::fake(
-            ['https://rest.db.ripe.net/RIPE/aut-num/AS66500' => \Http::response('[]', 200)]
+            ['https://rest.db.ripe.net/RIPE/as-set/AS-SET-IXP-RS' => \Http::response('[]', 200)]
         );
 
         $rirObject = 'as-set-ixp-rs';
@@ -183,7 +183,7 @@ class GenerateObjectTest extends TestCase
     {
         config()->set('ixp_api.rir.ripe_api_key', 'fakeapikey' );
         \Http::fake(
-            ['https://rest.db.ripe.net/RIPE/aut-num/AS66500' => \Http::response('[]', 200)]
+            ['https://rest.db.ripe.net/RIPE/as-set/AS-SET-IXP-RS' => \Http::response('[]', 200)]
         );
 
         $rirObject = 'as-set-ixp-rs';
@@ -210,7 +210,7 @@ class GenerateObjectTest extends TestCase
     {
         config()->set('ixp_api.rir.ripe_api_key', 'fakeapikey' );
         \Http::fake( [
-            'https://rest.db.ripe.net/RIPE/aut-num/AS66500' => \Http::response(file_get_contents("data/ci/known-good/ripedb-api-error.json"), 401 )
+            'https://rest.db.ripe.net/RIPE/as-set/AS-SET-IXP-RS' => \Http::response(file_get_contents("data/ci/known-good/ripedb-api-error.json"), 401 )
         ] );
 
         $rirObject = 'as-set-ixp-rs';


### PR DESCRIPTION
[BF] correct IXPM-OBJECT/IXPM-KEY in default rir templates

Small tweak to default rir templates. as-set: objects should have:

```
IXPM-OBJECT:    as-set
IXPM-KEY:       AS-SET-....
```