### PR TITLE
[BF] Fix #974. Foil's Template doesn't implement __isset

### DIFF
--- a/resources/views/services/lg/route.foil.php
+++ b/resources/views/services/lg/route.foil.php
@@ -10,7 +10,7 @@
     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 </div>
 <div class="modal-body">
-    <?php if( isset( $t->content ) && isset( $t->content->routes ) ): ?>
+    <?php if( isset( $t->content->routes ) ): ?>
         <?php foreach( $t->content->routes as $r ): ?>
           <table class="table table-striped text-monospace" style="font-size: 14px;">
               <tbody>


### PR DESCRIPTION
Foils Template doesn't implement isset, so `empty($t->something)` and `isset($t->something)` will always fail even if they are set. `isset`/`empty` calls to nested properties seem to work fine, otherwise this problem would be very noticeable.

Thanks to [rfc1036](https://github.com/rfc1036) for the report