### PR TITLE
Vagrant env - add required flag to birdseye apache config 

### DIFF
--- a/tools/vagrant/bootstrap.sh
+++ b/tools/vagrant/bootstrap.sh
@@ -364,6 +364,7 @@ Listen 81
 
 <VirtualHost *:81>
     DocumentRoot /srv/birdseye/public
+    AllowEncodedSlashes NoDecode
 
     <Directory /srv/birdseye/public>
         Options FollowSymLinks


### PR DESCRIPTION
otherwise it returns 404 when a url encoded prefix is provided (eg `http://rs1-vix1-ipv4:81/api/route/134.226.0.0%2F16/table/master4?use_cache=0`)