### PR TITLE
fix user login history link in logins.foil.php

### DIFF
--- a/resources/views/customer/overview-tabs/logins.foil.php
+++ b/resources/views/customer/overview-tabs/logins.foil.php
@@ -41,7 +41,7 @@
                 <td>
                     <?php if( $c2u->userLoginHistories->count() ): ?>
                         <div class="btn-group btn-group-sm">
-                            <a class="btn btn-white have-tooltip" title="History" href="<?= route( "login-history@view", [ 'id' => $c2u->id ] ) ?>">
+                            <a class="btn btn-white have-tooltip" title="History" href="<?= route( "login-history@view", [ 'id' => $c2u->user_id ] ) ?>">
                                 <i class="fa fa-history"></i>
                             </a>
                         </div>


### PR DESCRIPTION
[BF] Summary of fix - fixes #988 

Comparing 
`resources/views/customer/overview-tabs/logins.foil.php`
with 
`resources/views/customer/overview-tabs/users.foil.php`

I have found that the login History link uses [ 'id' => $c2u->id ] and not [ 'id' => $c2u->user_id ]
This PR fixes that.

In addition to the above, I have:

 - [ ] ensured unit tests all run without error
 - [ ] ran psalm and corrected any static analysis issues
 - [ ] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [ ] ensured appropriate checks against user privilege / resources accessed
 - [ ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
