### PR TITLE
vagrant: install pysmi for snmpsim

### DIFF
--- a/tools/vagrant/bootstrap.sh
+++ b/tools/vagrant/bootstrap.sh
@@ -245,7 +245,7 @@ apt-get install -y python3-pip python3-venv python3-full &>/dev/null
 mkdir /srv/venv
 python3 -m venv /srv/venv/ &>/dev/null
 cd /srv/venv/
-./bin/pip install snmpsim &>/dev/null
+./bin/pip install snmpsim pysmi &>/dev/null
 mkdir /srv/snmpclients
 cp /vagrant/tools/vagrant/snmpwalks/*snmprec /srv/snmpclients/
 chown -R vagrant: /srv/snmpclients


### PR DESCRIPTION
`pysmi` is an optional dependency for `pysnmp`, and `snmpsim` [recently made the `pysmi` dependency optional.](https://github.com/lextudio/snmpsim/commit/f63b92d38289701cde4977f95c32d4b7aa53e787) This PR adds pysmi to the pip install command

```
    default: Traceback (most recent call last):
    default:   File "/srv/venv/bin/snmpsim-command-responder", line 5, in <module>
    default:     from snmpsim.commands.responder import main
    default:   File "/srv/venv/lib/python3.12/site-packages/snmpsim/commands/responder.py", line 31, in <module>
    default:     from snmpsim import controller
    default:   File "/srv/venv/lib/python3.12/site-packages/snmpsim/controller.py", line 15, in <module>
    default:     from snmpsim import datafile
    default:   File "/srv/venv/lib/python3.12/site-packages/snmpsim/datafile.py", line 23, in <module>
    default:     from snmpsim.record.search.database import RecordIndex
    default:   File "/srv/venv/lib/python3.12/site-packages/snmpsim/record/search/database.py", line 14, in <module>
    default:     from snmpsim import utils
    default:   File "/srv/venv/lib/python3.12/site-packages/snmpsim/utils.py", line 13, in <module>
    default:     import pysmi
    default: ModuleNotFoundError: No module named 'pysmi'
```

before:
<img width="1011" height="317" alt="Screenshot 2026-06-23 at 14 17 22" src="https://github.com/user-attachments/assets/6f6b8126-9bb4-4df4-b7d9-2c1f045af366" />

after:
<img width="636" height="331" alt="Screenshot 2026-06-23 at 14 23 37" src="https://github.com/user-attachments/assets/d2bca9fa-5ec4-4333-be46-5d01eb4bde59" />
