### PR TITLE
Use url helper to generate maintenance mode default logo path

### DIFF
--- a/resources/views/errors/maintenance.blade.php
+++ b/resources/views/errors/maintenance.blade.php
@@ -53,9 +53,9 @@
 
     <div style="display: flex; justify-content: center;">
         @if( config( "identity.biglogo" ) )
-            <img class="tw-inline img-fluid tw-w-full tw-max-w-sm tw-mx-auto" src="<?= config( "identity.biglogo" ) ?>" />
+            <img class="tw-inline img-fluid tw-w-full tw-max-w-sm tw-mx-auto" src="<?= config( "identity.biglogo" ) ?>" alt="IXP Manager Logo" />
         @else
-            <img src="/images/ixp-manager.png" alt="" />
+            <img src="<?= url("/images/ixp-manager.png") ?>" alt="IXP Manager Logo" />
         @endif
     </div>
 


### PR DESCRIPTION
We currently hardcode the path for the default logo to `/images/ixp-manager.png`, however if the project is hosted under a sub-path this won't work - use the URL generator to create it.