### PR TITLE
Remove base href directive

### DIFF
--- a/resources/views/customer/overview.foil.php
+++ b/resources/views/customer/overview.foil.php
@@ -208,14 +208,14 @@
 
                 <?php if( !$c->typeAssociate() && count( $c->virtualInterfaces ) ):?>
                     <li role="ports" class="nav-item ">
-                        <a class="nav-link <?php if( $t->tab === 'ports' ): ?> active <?php endif; ?>" data-toggle="tab" href="#ports" data-toggle="tab">
+                        <a class="nav-link <?php if( $t->tab === 'ports' ): ?> active <?php endif; ?>" data-toggle="tab" href="#ports">
                             Ports
                         </a>
                     </li>
 
                     <?php if( $c->hasPrivateVLANs() ): ?>
                         <li role="private-vlans" class="nav-item ">
-                            <a class="nav-link <?php if( $t->tab === 'private-vlans' ): ?> active <?php endif; ?>" data-toggle="tab" href="#private-vlans" data-toggle="tab">
+                            <a class="nav-link <?php if( $t->tab === 'private-vlans' ): ?> active <?php endif; ?>" data-toggle="tab" href="#private-vlans">
                                 Private VLANs
                             </a>
                         </li>
@@ -223,25 +223,25 @@
                 <?php endif; ?>
 
                 <li role="users" class="nav-item ">
-                    <a class="nav-link <?php if( $t->tab === 'users' ): ?> active <?php endif; ?>" data-toggle="tab" href="#users" data-toggle="tab">
+                    <a class="nav-link <?php if( $t->tab === 'users' ): ?> active <?php endif; ?>" data-toggle="tab" href="#users">
                         Users
                     </a>
                 </li>
 
                 <li role="contacts" class="nav-item ">
-                    <a class="nav-link <?php if( $t->tab === 'contacts' ): ?> active <?php endif; ?>" data-toggle="tab" href="#contacts" data-toggle="tab">
+                    <a class="nav-link <?php if( $t->tab === 'contacts' ): ?> active <?php endif; ?>" data-toggle="tab" href="#contacts">
                         Contacts
                     </a>
                 </li>
 
                 <li role="logins" class="nav-item">
-                    <a class="nav-link <?php if( $t->tab === 'logins' ): ?> active <?php endif; ?>" data-toggle="tab" href="#logins" data-toggle="tab">
+                    <a class="nav-link <?php if( $t->tab === 'logins' ): ?> active <?php endif; ?>" data-toggle="tab" href="#logins">
                         Logins
                     </a>
                 </li>
 
                 <li role="notes" class="nav-item ">
-                    <a class="nav-link <?php if( $t->tab === 'notes' ): ?> active <?php endif; ?>" data-toggle="tab" href="#notes" id="tab-notes" data-toggle="tab">
+                    <a class="nav-link <?php if( $t->tab === 'notes' ): ?> active <?php endif; ?>" data-toggle="tab" href="#notes" id="tab-notes">
                         Notes
                         <?php if( $t->notesInfo[ "unreadNotes"] > 0 ): ?>
                             <span id="notes-unread-indicator" class="badge badge-success"><?= $t->ee( $t->notesInfo[ "unreadNotes"] ) ?></span>
@@ -250,20 +250,20 @@
                 </li>
 
                 <li role="cross-connects" class="nav-item ">
-                    <a class="nav-link <?php if( $t->tab === 'cross-connects' ): ?> active <?php endif; ?>" data-toggle="tab" href="#cross-connects" data-toggle="tab">
+                    <a class="nav-link <?php if( $t->tab === 'cross-connects' ): ?> active <?php endif; ?>" data-toggle="tab" href="#cross-connects">
                         Cross Connects
                     </a>
                 </li>
 
                 <li role="peers" class="nav-item">
-                    <a class="nav-link peers-tab <?php if( $t->tab === 'peers' ): ?> active <?php endif; ?>" data-toggle="tab" href="#peers" data-toggle="tab">
+                    <a class="nav-link peers-tab <?php if( $t->tab === 'peers' ): ?> active <?php endif; ?>" data-toggle="tab" href="#peers">
                         Peers
                     </a>
                 </li>
 
                 <?php if( !config( 'ixp_fe.frontend.disabled.console-server-connection' ) && $c->consoleServerConnections->count() ): ?>
                     <li role="console-server-connections" class="nav-item ">
-                        <a class="nav-link <?php if( $t->tab === 'console-server-connections' ): ?>active<?php endif; ?>" data-toggle="tab" href="#console-server-connections" data-toggle="tab">
+                        <a class="nav-link <?php if( $t->tab === 'console-server-connections' ): ?>active<?php endif; ?>" data-toggle="tab" href="#console-server-connections">
                             OOB Access
                         </a>
                     </li>

--- a/resources/views/layouts/ixpv4.foil.php
+++ b/resources/views/layouts/ixpv4.foil.php
@@ -3,8 +3,6 @@
     <head>
         <!--  IXP MANAGER - template directory: resources/[views|skins] -->
 
-        <base href="<?= url('') ?>/index.php">
-
         <meta http-equiv="Content-Type" content="text/html; charset=utf8" />
         <meta charset="utf-8">
 


### PR DESCRIPTION
Remove base href. It impacts copying a nav-tab link, and we dont have any other occasions we use relative URI's
 * If someone copies the URI for a tab on a page, we get the wrong URI - `http://ixp.local/ixp/index.php#overview` instead of `http://ixp.local/ixp/admin/customer/overview/2#overview`
 * When we navigate to such URI's the base href generated as `http://ixp.local/ixp/index.php/index.php`, and asset loading is broken (for instance, `http://ixp.local/ixp/index.php/css/ixp-pack.css?id=b4233f641050c48580902ad4b27b0b42`).

I've searched for relative URI's, forms, images, ajax requests that might be affected by removing it, run tests, and done some manual testing, and it seems fine to remove this
