### PR TITLE
[BF] Update MANRS API endpoint

### DIFF
--- a/app/Console/Commands/InManrs.php
+++ b/app/Console/Commands/InManrs.php
@@ -66,7 +66,7 @@ class InManrs extends  Command
                 'X-Request-Client'         => 'IXP Manager',
                 'X-Request-Client-Version' => APPLICATION_VERSION,
             ] )->throw()->acceptJson()
-                ->get( 'https://api.manrs.org/asns' );
+                ->get( 'https://observatory.manrs.org/api/v2/asns' );
         } catch(\Exception $e) {
             $this->error( 'Could not load ASNs via MANRS\'s API: ' . $e->getMessage() );
             return 1;


### PR DESCRIPTION
Very simple drop-in replacement for MANRS V2 API URL.

Endpoint format is identical to V1.

API documentation is here: https://docs.manrs.org/docs/api-migration/