### PR TITLE
[BF] Cleanup resources as part of customer delete

### DIFF
--- a/app/Http/Controllers/Customer/CustomerController.php
+++ b/app/Http/Controllers/Customer/CustomerController.php
@@ -562,25 +562,12 @@ class CustomerController extends Controller
      */
     public function deleteRecap( Customer $cust ): RedirectResponse|View
     {
-        // cannot delete a customer with active cross connects:
-        if( $cust->patchPanelPorts->isNotEmpty() ) {
-            AlertContainer::push( "This customer has active patch panel ports. Please cease "
-                . "these (or set them to awaiting cease and unset the customer link in the patch panel "
-                . "port) to proceed with deleting this customer.", Alert::DANGER
-            );
-            return redirect( route( "customer@overview", [ 'cust' => $cust->id ] ) );
-        }
-
-        // cannot delete a customer with fan out ports:
-        if( Customer::leftJoin( 'virtualinterface AS vi', 'vi.custid', 'cust.id' )
-            ->leftJoin( 'physicalinterface AS pi', 'pi.virtualinterfaceid', 'vi.id' )
-            ->whereNotNull( 'pi.fanout_physical_interface_id' )
-            ->whereNotNull( 'reseller' )->where( 'cust.id', $cust->id )->count() ){
-                        AlertContainer::push( "This customer has is a resold customer with fan out physical "
-                            . "interfaces. Please delete these manually before proceeding with deleting the customer.",
-                            Alert::DANGER
-                        );
-                        return redirect( route( "customer@overview", [ 'cust' => $cust->id ] ) );
+        if ($redirect = $this->redirectIfCustomerHasResellerCustomers($cust)) {
+            return $redirect;
+        } else if ($redirect = $this->redirectIfCustomerHasActiveCrossConnects($cust)) {
+            return $redirect;
+        } else if ($redirect = $this->redirectIfCustomerHasActiveFanoutPorts($cust)) {
+            return $redirect;
         }
 
         return view( 'customer/delete' )->with([
@@ -599,6 +586,14 @@ class CustomerController extends Controller
      */
     public function delete( Customer $cust ) : RedirectResponse
     {
+        if ($redirect = $this->redirectIfCustomerHasResellerCustomers($cust)) {
+            return $redirect;
+        } else if ($redirect = $this->redirectIfCustomerHasActiveCrossConnects($cust)) {
+            return $redirect;
+        } else if ($redirect = $this->redirectIfCustomerHasActiveFanoutPorts($cust)) {
+            return $redirect;
+        }
+
         if( CustomerAggregator::deleteObject( $cust ) ) {
             AlertContainer::push( "Customer <em>{$cust->getFormattedName()}</em> deleted.", Alert::SUCCESS );
             Cache::forget( 'admin_home_customers' );
@@ -606,5 +601,43 @@ class CustomerController extends Controller
             AlertContainer::push( "Customer could not be deleted. Please open a GitHub bug report.", Alert::DANGER );
         }
         return redirect( route( "customer@list" ) );
+    }
+
+    private function redirectIfCustomerHasResellerCustomers( Customer $cust ): ?RedirectResponse
+    {
+        if( $cust->isReseller && Customer::whereReseller( $cust->id )->notDeleted()->count() > 0 ) {
+            AlertContainer::push( "This customer is a reseller still associated with active resold customers. Please ".
+                " disassociate their customers before proceeding with deleting the reselling customer.", Alert::DANGER );
+            return redirect( route( "customer@overview", [ 'cust' => $cust->id ] ) );
+        }
+        return null;
+    }
+
+    private function redirectIfCustomerHasActiveCrossConnects( Customer $cust ): ?RedirectResponse
+    {
+        if( $cust->patchPanelPorts->isNotEmpty() ) {
+            AlertContainer::push( "This customer has active patch panel ports. Please cease "
+                . "these (or set them to awaiting cease and unset the customer link in the patch panel "
+                . "port) to proceed with deleting this customer.", Alert::DANGER
+            );
+            return redirect( route( "customer@overview", [ 'cust' => $cust->id ] ) );
+        }
+        return null;
+    }
+
+    private function redirectIfCustomerHasActiveFanoutPorts( Customer $cust ): ?RedirectResponse
+    {
+        // cannot delete a customer with fan out ports:
+        if( Customer::leftJoin( 'virtualinterface AS vi', 'vi.custid', 'cust.id' )
+            ->leftJoin( 'physicalinterface AS pi', 'pi.virtualinterfaceid', 'vi.id' )
+            ->whereNotNull( 'pi.fanout_physical_interface_id' )
+            ->whereNotNull( 'reseller' )->where( 'cust.id', $cust->id )->count() ){
+            AlertContainer::push( "This customer has is a resold customer with fan out physical "
+                . "interfaces. Please delete these manually before proceeding with deleting the customer.",
+                Alert::DANGER
+            );
+            return redirect( route( "customer@overview", [ 'cust' => $cust->id ] ) );
+        }
+        return null;
     }
 }

--- a/app/Models/Aggregators/CustomerAggregator.php
+++ b/app/Models/Aggregators/CustomerAggregator.php
@@ -521,7 +521,12 @@ class CustomerAggregator extends Customer
                 $cb->deleteObject();
             }
             $cust->tags()->detach();
-            
+
+            $cust->routeServerFiltersInProduction()->delete();
+            $cust->routeServerFilters()->delete();
+            $cust->docstoreCustomerFiles()->delete();
+            $cust->docstoreCustomerDirectories()->delete();
+            $cust->irrdbUpdateLog()->delete();
             $cust->delete();
 
             $cust->companyBillingDetail()->delete();

--- a/resources/views/customer/delete.foil.php
+++ b/resources/views/customer/delete.foil.php
@@ -60,10 +60,6 @@
                         <li>
                             all peering manager records (peering request emails sent/received, ignored status, etc.);
                         </li>
-                        <li>
-                            all <b><?= $c->patchPanelPorts()->count() ?></b> customer patch panel ports will be be set to awaiting-cease
-                            <em>(if this is non-zero, you should really sort these out before deleting the customer!)</em>;
-                        </li>
 
                         <li>
                             <b><?= $c->consoleServerConnections()->count() ?></b> console server connections;

--- a/resources/views/customer/delete.foil.php
+++ b/resources/views/customer/delete.foil.php
@@ -78,7 +78,15 @@
                         <li>
                             all route server entries learned from IRRDB for prefixes and origin ASNs as well as prefixes learned from the route servers.
                         </li>
-
+                        <li>
+                            IRRDB update logs
+                        </li>
+                        <li>
+                            <b><?= $c->docstoreCustomerDirectories()->count() ?></b> directories and <b><?= $c->docstoreCustomerFiles()->count() ?></b> files from the customers Document Store;</b>
+                        </li>
+                        <li>
+                            any route server filters (staged or in production)
+                        </li>
                         <li>
                             all Ripe Atlas Probes.
                         </li>

--- a/tests/Http/Controllers/CustomerControllerTest.php
+++ b/tests/Http/Controllers/CustomerControllerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Tests\Http\Controllers;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use IXP\Models\Cabinet;
+use IXP\Models\CompanyBillingDetail;
+use IXP\Models\CompanyRegisteredDetail;
+use IXP\Models\Customer;
+use IXP\Models\Location;
+use IXP\Models\PatchPanel;
+use IXP\Models\PatchPanelPort;
+use IXP\Models\PhysicalInterface;
+use IXP\Models\VirtualInterface;
+use Tests\TestCase;
+
+class CustomerControllerTest extends TestCase
+{
+    protected $deleteRows = [];
+
+    public function tearDown(): void
+    {
+        foreach ($this->deleteRows as [$table, $id]) {
+            \DB::table( $table )->where( 'id', $id )->delete();
+        }
+        parent::tearDown();
+    }
+
+    protected function deleteLater(Model... $models)
+    {
+        foreach ($models as $model) {
+            $this->deleteRows[] = [$model->getTable(), $model->id];
+        }
+    }
+
+    public function testCannotDeleteResellerWithCustomers()
+    {
+        $resellerRegisteredDetails = new CompanyRegisteredDetail();
+        $resellerRegisteredDetails->save();
+        $resellerBillingDetails = new CompanyBillingDetail();
+        $resellerBillingDetails->save();
+
+        $reseller = new Customer();
+        $reseller->isReseller = true;
+        $reseller->company_registered_detail_id = $resellerRegisteredDetails->id;
+        $reseller->company_billing_details_id = $resellerBillingDetails->id;
+        $reseller->save();
+        $this->deleteLater($reseller, $resellerBillingDetails, $resellerRegisteredDetails);
+
+        $resoldCustomer = new Customer();
+        $resoldCustomer->reseller = $reseller->id;
+        $resoldCustomer->save();
+        $this->deleteLater($resoldCustomer);
+
+        $this->actingAs($this->getSuperUser());
+
+        // Can't go to delete-recap if they are a reseller with reseller customers
+        $this
+            ->get( route("customer@delete-recap", ['cust' => $reseller->id] ) )
+            ->assertStatus(302)
+            ->assertRedirect( route("customer@overview", ['cust' => $reseller->id] ) );
+
+        $this
+            ->get( route("customer@overview", ['cust' => $reseller->id] ) )
+            ->assertStatus(200)
+            ->assertSee("This customer is a reseller still associated with active resold customers. Please ".
+                " disassociate their customers before proceeding with deleting the reselling customer.");
+
+        // Can't go to delete if they are a reseller with reseller customers
+        $this
+            ->delete( route("customer@delete", ['cust' => $reseller->id] ) )
+            ->assertStatus(302)
+            ->assertRedirect( route("customer@overview", ['cust' => $reseller->id] ) );
+
+        $this
+            ->get( route("customer@overview", ['cust' => $reseller->id] ) )
+            ->assertStatus(200)
+            ->assertSee("This customer is a reseller still associated with active resold customers. Please ".
+                " disassociate their customers before proceeding with deleting the reselling customer.");
+
+        // We can go to delete-recap when the resold customer is dissociated
+        $resoldCustomer->reseller = null;
+        $resoldCustomer->save();
+
+        $this
+            ->get( route("customer@delete-recap", ['cust' => $reseller->id] ) )
+            ->assertStatus(200);
+
+        // We can proceed with the delete delete-recap when the resold customer is dissociated
+
+        $this
+            ->delete( route("customer@delete", ['cust' => $reseller->id] ) )
+            ->assertStatus(302)
+            ->assertRedirect( route("customer@list" ) );
+
+        $this->assertNull(Customer::find($reseller->id));
+    }
+
+    public function testCannotDeleteCustomerWithActivePatchPanelPorts()
+    {
+        $regDetail = new CompanyRegisteredDetail();
+        $regDetail->save();
+
+        $billingDetail = new CompanyBillingDetail();
+        $billingDetail->save();
+
+        $customer = new Customer();
+        $customer->company_registered_detail_id = $regDetail->id;
+        $customer->company_billing_details_id = $billingDetail->id;
+        $customer->save();
+        $this->deleteLater($customer, $billingDetail, $regDetail);
+
+        $location = new Location();
+        $location->save();
+
+        $cabinet = new Cabinet();
+        $cabinet->locationid = $location->id;
+        $cabinet->save();
+
+        $pp = new PatchPanel();
+        $pp->cabinet_id = $cabinet->id;
+        $pp->save();
+
+        $ppp = new PatchPanelPort();
+        $ppp->customer_id = $customer->id;
+        $ppp->patch_panel_id = $pp->id;
+        $ppp->save();
+        $this->deleteLater($ppp, $pp, $cabinet, $location);
+        $this->actingAs($this->getSuperUser());
+
+        // Can't go to delete-recap if they have active patch panel ports
+        $this
+            ->get( route("customer@delete-recap", ['cust' => $customer->id] ) )
+            ->assertStatus(302)
+            ->assertRedirect( route("customer@overview", ['cust' => $customer->id] ) );
+
+        $this
+            ->get( route("customer@overview", ['cust' => $customer->id] ) )
+            ->assertStatus(200)
+            ->assertSee("This customer has active patch panel ports. Please cease "
+                . "these (or set them to awaiting cease and unset the customer link in the patch panel "
+                . "port) to proceed with deleting this customer.");
+
+        // Can't go to delete if they have active patch panel ports
+        $this
+            ->delete( route("customer@delete", ['cust' => $customer->id] ) )
+            ->assertStatus(302)
+            ->assertRedirect( route("customer@overview", ['cust' => $customer->id] ) );
+
+        $this
+            ->get( route("customer@overview", ['cust' => $customer->id] ) )
+            ->assertStatus(200)
+            ->assertSee("This customer has active patch panel ports. Please cease "
+                . "these (or set them to awaiting cease and unset the customer link in the patch panel "
+                . "port) to proceed with deleting this customer.");
+
+        // We can go to delete-recap when the patch panel port is not associated with customer
+        $ppp->customer_id = null;
+        $ppp->save();
+
+        $this
+            ->get( route("customer@delete-recap", ['cust' => $customer->id] ) )
+            ->assertStatus(200);
+
+        // We can proceed with delete then too
+        $this
+            ->delete( route("customer@delete", ['cust' => $customer->id] ) )
+            ->assertStatus(302)
+            ->assertRedirect( route("customer@list") );
+
+        $this->assertNull(Customer::find($customer->id));
+    }
+}

--- a/tests/Http/Controllers/CustomerControllerTest.php
+++ b/tests/Http/Controllers/CustomerControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Http\Controllers;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use IXP\Models\Cabinet;
 use IXP\Models\CompanyBillingDetail;
 use IXP\Models\CompanyRegisteredDetail;
@@ -11,8 +10,6 @@ use IXP\Models\Customer;
 use IXP\Models\Location;
 use IXP\Models\PatchPanel;
 use IXP\Models\PatchPanelPort;
-use IXP\Models\PhysicalInterface;
-use IXP\Models\VirtualInterface;
 use Tests\TestCase;
 
 class CustomerControllerTest extends TestCase


### PR DESCRIPTION
Best effort fix for #984, following review of foreign keys referencing `customer.id`

During customer delete we now remove their 1) route server filters 2) document store items and 3) irrdb update logs, which if left untouched would prevent the customer from being removed

In addition to the above, I have:

 - [x] ensured unit tests all run without error
 - [x] ran psalm and corrected any static analysis issues
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
