### PR TITLE
Begin deprecation of API Keys via GET parameter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -344,3 +344,10 @@ CACHE_DRIVER=array
 # IXP_NO_TRANSIT_ASNS_OVERRIDE=65501,65502,65503
 
 # Full slash 'description' with /slashes\ and "quotes"
+
+
+#########################################################################################
+### See: https://docs.ixpmanager.org/latest/features/api/
+
+# Allow API keys to be specified via GET parameter.
+# IXP_ALLOW_DEPRECATED_APIKEYS_VIA_GET=true

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -15,9 +15,21 @@ If you need to share sensitive information, you can encrypt your email using [ou
 **What to expect:**
 
 * We aim to acknowledge receipt of your vulnerability report within 48 hours.
-* We will keep you updated as we triage the issue and establish a timeline for the fix.
+* We will keep you updated as we triage the issue and establish a timeline for the fix and public disclosure.
 * While we do not offer a financial bug bounty program, we are delighted to offer public acknowledgement (see below).
-  
+
+### Disclosure and Regulatory Compliance
+
+INEX has a long track record of identifying security issues through internal audits or via third-party reporting, implementing fixes, and publishing advisories with new version releases.
+
+From June 2026, we utilise [GitHub's Security Advisories](https://github.com/inex/IXP-Manager/security/advisories) service to provide clarity and consistency when publishing security disclosures, which also supplies machine-readable vulnerability data to downstream networks.
+
+As an Open-Source Software Steward under the EU Cyber Resilience Act (CRA):
+
+* **Upstream Reporting:** If a reported vulnerability in IXP Manager is confirmed to be actively exploited in the wild, INEX will notify the ENISA Single Reporting Platform and relevant national CSIRTs within the legally mandated timeframes.
+* **Infrastructure Security:** Any severe cyber incident that compromises our development or distribution infrastructure (such as version control or build pipelines) will be reported to EU authorities and communicated transparently to our users.
+* **Ecosystem Cooperation:** If a reported vulnerability stems from an upstream open-source dependency used by IXP Manager, we will responsibly share relevant information with the maintainers of that project to help secure the wider ecosystem.
+
 
 ### Confidentiality and Acknowledgements
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -18,7 +18,14 @@ If you need to share sensitive information, you can encrypt your email using [ou
 * We will keep you updated as we triage the issue and establish a timeline for the fix and public disclosure.
 * While we do not offer a financial bug bounty program, we are delighted to offer public acknowledgement (see below).
 
-### Disclosure and Regulatory Compliance
+### Confidentiality and Acknowledgements
+
+We understand that some organisations do not wish to disclose their use of specific software for security reasons. If you do not want to be named or acknowledged in the release notes addressing the security issue, please let us know, and we will ensure your anonymity. 
+
+Likewise, we are delighted to acknowledge and thank anyone who responsibly reports security issues to us. We usually do this in the release notes and related announcements. Please do let us know the appropriate attribution when you contact us.
+
+
+## Disclosure and Regulatory Compliance
 
 INEX has a long track record of identifying security issues through internal audits or via third-party reporting, implementing fixes, and publishing advisories with new version releases.
 
@@ -29,13 +36,6 @@ As an Open-Source Software Steward under the EU Cyber Resilience Act (CRA):
 * **Upstream Reporting:** If a reported vulnerability in IXP Manager is confirmed to be actively exploited in the wild, INEX will notify the ENISA Single Reporting Platform and relevant national CSIRTs within the legally mandated timeframes.
 * **Infrastructure Security:** Any severe cyber incident that compromises our development or distribution infrastructure (such as version control or build pipelines) will be reported to EU authorities and communicated transparently to our users.
 * **Ecosystem Cooperation:** If a reported vulnerability stems from an upstream open-source dependency used by IXP Manager, we will responsibly share relevant information with the maintainers of that project to help secure the wider ecosystem.
-
-
-### Confidentiality and Acknowledgements
-
-We understand that some organisations do not wish to disclose their use of specific software for security reasons. If you do not want to be named or acknowledged in the release notes addressing the security issue, please let us know, and we will ensure your anonymity. 
-
-Likewise, we are delighted to acknowledge and thank anyone who responsibly reports security issues to us. We usually do this in the release notes and related announcements. Please do let us know the appropriate attribution when you contact us.
 
 
 ## Supported Versions

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,14 +6,14 @@ Please see: [https://docs.ixpmanager.org/dev/policy/](https://docs.ixpmanager.or
 
 ## Reporting a Vulnerability
 
-Thank you in advance for looking to responsibly report security issues. 
+Thank you in advance for responsibly reporting security issues. 
 
-Please contact us by email at [security@ixpmanager.org](mailto:security@ixpmanager.org) to report security issues or discuss security concerns. All security vulnerabilities will be promptly addressed.
+Please contact us by email at [security@ixpmanager.org](mailto:security@ixpmanager.org) to report security issues or discuss security concerns. All security vulnerabilities will be promptly addressed. You can also [submit security issues securely via GitHub here](https://github.com/inex/IXP-Manager/security/advisories/new).
 
 
 ### Confidentiality and Acknowledgements
 
-We understand that some organisations do not wish to disclose their use of specific software for security reasons. If you do not want to be named or acknowledged in the release notes where the security issue is addressed, please let us know, and we will ensure your anonymity. 
+We understand that some organisations do not wish to disclose their use of specific software for security reasons. If you do not want to be named or acknowledged in the release notes addressing the security issue, please let us know, and we will ensure your anonymity. 
 
 Likewise, we are delighted to acknowledge and thank anyone who responsibly reports security issues to us. We usually do this in the release notes and related announcements. Please do let us know the appropriate attribution when you contact us.
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,6 +10,14 @@ Thank you in advance for responsibly reporting security issues.
 
 Please contact us by email at [security@ixpmanager.org](mailto:security@ixpmanager.org) to report security issues or discuss security concerns. All security vulnerabilities will be promptly addressed. You can also [submit security issues securely via GitHub here](https://github.com/inex/IXP-Manager/security/advisories/new).
 
+If you need to share sensitive information, you can encrypt your email using [our PGP key](https://www.ixpmanager.org/security-at-ixpmanager.asc), or email and request another channel such as Signal.
+
+**What to expect:**
+
+* We aim to acknowledge receipt of your vulnerability report within 48 hours.
+* We will keep you updated as we triage the issue and establish a timeline for the fix.
+* While we do not offer a financial bug bounty program, we are delighted to offer public acknowledgement (see below).
+  
 
 ### Confidentiality and Acknowledgements
 
@@ -24,7 +32,7 @@ Likewise, we are delighted to acknowledge and thank anyone who responsibly repor
 | Version | Supported          | Details / Until                                                             |
 |---------|--------------------|-----------------------------------------------------------------------------|
 | 7.x.y   | :white_check_mark: | Current release, full support until min. 6 months after a future v8 release |
-| 6.x.y   | :x:                | March 1st 2026, security issues only                                        |
+| 6.x.y   | :x:                | Security support ended March 1st 2026.                                      |
 | 5.x.y   | :x:                |                                                                             |
 | 4.x.y   | :x:                |                                                                             |
 | < 4.0   | :x:                |                                                                             |

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -35,7 +35,8 @@ use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Http\Middleware\{
     CheckForMaintenanceMode,
     ConvertEmptyStringsToNull,
-    ValidatePostSize
+    InvokeDeferredCallbacks,
+    ValidatePostSize,
 };
 
 use Illuminate\Http\Middleware\HandleCors;
@@ -72,7 +73,7 @@ class Kernel extends HttpKernel
         ValidatePostSize::class,
         Middleware\TrimStrings::class,
         ConvertEmptyStringsToNull::class,
-
+        InvokeDeferredCallbacks::class,
     ];
 
     /**

--- a/app/Http/Middleware/ApiAuthenticate.php
+++ b/app/Http/Middleware/ApiAuthenticate.php
@@ -27,6 +27,7 @@ use Auth, Closure;
 
 use Illuminate\Http\Request;
 
+use Illuminate\Support\Facades\Log;
 use IXP\Models\Aggregators\ApiKeyAggregator;
 use IXP\Models\ApiKey;
 use IXP\Models\User;
@@ -48,10 +49,10 @@ class ApiAuthenticate
 	/**
 	 * Authenticate protected APIv4 calls
 	 *
-	 * API key can be passed in the header (preferred) or on the URL.
+	 * API key can be passed in the header (preferred) or on the URL (deprecated)
 	 *
 	 *     curl -X GET -H "X-IXP-Manager-API-Key: mySuperSecretApiKey" http://ixpv.dev/api/v4/test
-	 *     wget http://ixpv.dev/api/v4/test?apikey=mySuperSecretApiKey
+	 *     DEPRECATED: wget http://ixpv.dev/api/v4/test?apikey=mySuperSecretApiKey
 	 *
 	 * @param   Request     $r
 	 * @param   Closure     $next
@@ -59,17 +60,25 @@ class ApiAuthenticate
 	 * @return mixed
      *
      * @throws
-	 */
+     */
 	public function handle( Request $r, Closure $next )
 	{
         // are we already logged in?
 		if( !Auth::check() ) {
 			// find API key. Prefer header to URL:
 			$apikey = false;
+            $logIdentifier = null;
 			if( $r->header('X-IXP-Manager-API-Key') ) {
 				$apikey = $r->header('X-IXP-Manager-API-Key');
 			} else if( $r->apikey ) {
-				$apikey = $r->apikey;
+                // use always because normal deferred functions only run when the status code < 400
+                defer(function() use ($r, &$logIdentifier) {
+                    Log::notice( 'DEPRECATED usage of API Key in GET parameter (' . $logIdentifier . '): ' . $r->path() . ' from ' . ixp_get_client_ip() );
+                })->always();
+
+                if ( config('ixp_api.allow_apikeys_get_parameter') ) {
+                    $apikey = $r->apikey;
+                }
 			}
 
 			if( !$apikey ) {
@@ -87,13 +96,17 @@ class ApiAuthenticate
                     // if it's not an ApiKey object, it's an error response
                     return $key;
                 }
-
+                // record a token identifier in case we need to report an APIKEY via get parameter
+                $logIdentifier = "API Token Identifier: " . $key->token_identifier;
             } else {
                 // legacy
 
                 if( !( $key = ApiKey::where( 'api_key', $apikey )->with( 'user.customer' )->first() ) ) {
                     return response( 'Valid API key required', 401 );
                 }
+
+                // record Api Key ID in case we need to report a APIKEY via get parameter
+                $logIdentifier = "API Key ID: " . $key->id;
             }
 
             if( $key->expires->isPast() ) {

--- a/app/Http/Middleware/ApiAuthenticate.php
+++ b/app/Http/Middleware/ApiAuthenticate.php
@@ -68,6 +68,7 @@ class ApiAuthenticate
 			// find API key. Prefer header to URL:
 			$apikey = false;
             $logIdentifier = null;
+            
 			if( $r->header('X-IXP-Manager-API-Key') ) {
 				$apikey = $r->header('X-IXP-Manager-API-Key');
 			} else if( $r->apikey ) {

--- a/app/Http/Middleware/ApiMaybeAuthenticate.php
+++ b/app/Http/Middleware/ApiMaybeAuthenticate.php
@@ -73,6 +73,7 @@ class ApiMaybeAuthenticate
             // find API key. Prefer header to URL:
             $apikey = false;
             $logIdentifier = null;
+            
             if( $r->header('X-IXP-Manager-API-Key') ) {
                 $apikey = $r->header('X-IXP-Manager-API-Key');
             } else if( $r->apikey ) {
@@ -126,7 +127,6 @@ class ApiMaybeAuthenticate
                 }
 
                 Auth::onceUsingId( $key->user_id );
-                $us = Auth::user();
 
                 $key->updateLastSeen();
             }

--- a/app/Http/Middleware/ApiMaybeAuthenticate.php
+++ b/app/Http/Middleware/ApiMaybeAuthenticate.php
@@ -27,6 +27,7 @@ use Auth, Closure;
 
 use Illuminate\Http\Request;
 
+use Illuminate\Support\Facades\Log;
 use IXP\Models\Aggregators\ApiKeyAggregator;
 use IXP\Models\ApiKey;
 use IXP\Models\User;
@@ -52,7 +53,7 @@ class ApiMaybeAuthenticate
 	 * API key can be passed in the header (preferred) or on the URL.
 	 *
 	 *     curl -X GET -H "X-IXP-Manager-API-Key: mySuperSecretApiKey" http://ixpv.dev/api/v4/test
-	 *     wget http://ixpv.dev/api/v4/test?apikey=mySuperSecretApiKey
+	 *     DEPRECATED wget http://ixpv.dev/api/v4/test?apikey=mySuperSecretApiKey
 	 *
 	 * @param   Request     $r
 	 * @param   Closure     $next
@@ -67,17 +68,25 @@ class ApiMaybeAuthenticate
         $us = Auth::user();
 
         // are we already logged in?
-		if( !Auth::check() ) {
+        if( !Auth::check() ) {
 
-			// find API key. Prefer header to URL:
-			$apikey = false;
-			if( $r->header('X-IXP-Manager-API-Key') ) {
-				$apikey = $r->header('X-IXP-Manager-API-Key');
-			} else if( $r->apikey ) {
-				$apikey = $r->apikey;
-			}
+            // find API key. Prefer header to URL:
+            $apikey = false;
+            $logIdentifier = null;
+            if( $r->header('X-IXP-Manager-API-Key') ) {
+                $apikey = $r->header('X-IXP-Manager-API-Key');
+            } else if( $r->apikey ) {
+                // use always because normal deferred functions only run when the status code < 400
+                defer(function() use ($r, &$logIdentifier) {
+                    Log::notice( 'DEPRECATED usage of API Key in GET parameter (' . $logIdentifier . '): ' . $r->path() . ' from ' . ixp_get_client_ip() );
+                })->always();
 
-			if( $apikey ) {
+                if ( config( 'ixp_api.allow_apikeys_get_parameter' ) ) {
+                    $apikey = $r->apikey;
+                }
+            }
+
+            if( $apikey ) {
 
                 /** @var ApiKey $key */
 
@@ -90,13 +99,16 @@ class ApiMaybeAuthenticate
                         // if it's not an ApiKey object, it's an error response
                         return $key;
                     }
-
+                    // record a token identifier in case we need to report an APIKEY via get parameter
+                    $logIdentifier = "API Token Identifier: " . $key->token_identifier;
                 } else {
                     // legacy
 
                     if( !( $key = ApiKey::where( 'api_key', $apikey )->with( 'user.customer' )->first() ) ) {
                         return response( 'Valid API key required', 401 );
                     }
+                    // record Api Key ID in case we need to report a APIKEY vqia get parameter
+                    $logIdentifier = "API Key ID: " . $key->id;
                 }
 
                 if( $key->expires->isPast() ) {

--- a/app/Models/Infrastructure.php
+++ b/app/Models/Infrastructure.php
@@ -64,7 +64,6 @@ use IXP\Traits\Observable;
  * @method static Builder|Infrastructure wherePeeringdbIxId($value)
  * @method static Builder|Infrastructure whereShortname($value)
  * @method static Builder|Infrastructure whereUpdatedAt($value)
- * @property int $ixp_id
  * @method static Builder|Infrastructure whereIxpId($value)
  * @property int $exclude_from_ixf_export
  * @method static Builder<static>|Infrastructure whereExcludeFromIxfExport($value)
@@ -87,7 +86,6 @@ class Infrastructure extends Model
      * @var array
      */
     protected $fillable = [
-        'ixp_id',
         'name',
         'shortname',
         'isPrimary',

--- a/config/ixp_api.php
+++ b/config/ixp_api.php
@@ -165,9 +165,21 @@ return [
     |
     | The default was switched from true to false in v7.2.0.
     |
-    | See: https://docs.ixpmanager.org/install/security/
+    | See: https://docs.ixpmanager.org/latest/install/security/
     */
 
     'unsecured_api_access' => env( 'UNSECURED_API_ACCESS', false ),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Allow API Keys to be provided via GET parameter in URL.
+    |--------------------------------------------------------------------------
+    |
+    | This previously supported authentication mode is being deprecated in favour of
+    | providing the key via HTTP Headers. A log will be generated when an API Key uses
+    | this feature. The setting will be turned off in a future release.
+    |
+    | See: https://docs.ixpmanager.org/latest/features/api/
+    */
+    'allow_apikeys_get_parameter' => env( 'IXP_ALLOW_DEPRECATED_APIKEYS_VIA_GET', true ),
 ];

--- a/resources/views/api-key/list-postamble.foil.php
+++ b/resources/views/api-key/list-postamble.foil.php
@@ -1,30 +1,26 @@
 
 <?php $example_api_key = 'ixpm_exampleKey_uPq9H...' ?>
 
+<br><br>
+
 <div class="card mt-4">
     <div class="card-header">
-        <h3>Available API Endpoints</h3>
+        <h3>Brief Instructions and Sample API Endpoints</h3>
     </div>
     <div class="card-body">
         <p>
             Please see the <a href="https://docs.ixpmanager.org/latest/features/api/">official API documentation here.</a>
         </p>
         <p>
-
-            The API key can be passed in the header (preferred) or on the URL (though this is currently being deprecated). For example:
-        <ul>
-            <li>
-                <code>curl -X GET -H "X-IXP-Manager-API-Key: <?= $t->ee( $example_api_key ) ?>" <?= url( "/api/v4/test" ) ?></code>
-            </li>
-            <li>
-                <code>wget <?= url()->query("/api/v4/test", [ 'apikey'=> $example_api_key ] ) ?></code>
-            </li>
-            <li>
-                <a href="<?= url()->query("/api/v4/test", [ 'apikey'=> $example_api_key ] ) ?>"><?= url()->query("/api/v4/test", [ 'apikey'=> $example_api_key ] ) ?></a>
-            </li>
-        </ul>
+            The API key is passed in the HTTP header, for example:
         </p>
 
+<pre>
+    curl -X GET -H "X-IXP-Manager-API-Key: <?= $t->ee( $example_api_key ) ?>" <?= url( "/api/v4/test" ) ?>
+</pre>
+
+    <hr>
+        
         <dl>
 
             <dt>IX-F Member List Export</dt>
@@ -33,9 +29,10 @@
                 (or <a href="https://github.com/euro-ix/json-schemas/">the GitHub repo</a>)
                 and <a href="https://docs.ixpmanager.org/latest/features/ixf-export/">here for IXP Manager's IX-F
                     Member List export instructions</a>.<br><br>
-                Examples:
                 <ul>
-                    <?php foreach( \IXP\Utils\Export\JsonSchema::EUROIX_JSON_VERSIONS as $v ): ?>
+                    <?php foreach( \IXP\Utils\Export\JsonSchema::EUROIX_JSON_VERSIONS as $v ):
+                        if( $v < 1.0 ) { continue; }
+                    ?>
                         <li>
                             <code>
                                 <a href="<?= url( "/api/v4/member-export/ixf/" . $v )?>">
@@ -45,6 +42,7 @@
                         </li>
                     <?php endforeach; ?>
                 </ul>
+                <br><hr>
             </dd>
 
 
@@ -56,11 +54,12 @@
                         <a target="_blank" href="<?= route('api-v4:ping') ?>"><?= route('api-v4:ping') ?></a>
                     </li>
                 </ul>
+                <br><hr>
             </dd>
 
             <dt>Test Endpoint</dt>
             <dd>
-                A simple test endpoint which is useful for testing if your are providing the API key correctly.
+                A simple test endpoint which is useful for testing if you are providing the API key correctly.
                 <em>Note that it will show that you are authenticated also if it receives a valid cookie.</em>
                 <br>
                 <ul>
@@ -68,6 +67,7 @@
                         <a target="_blank" href="<?= route('api-v4:test') ?>"><?= route('api-v4:test') ?></a>
                     </li>
                 </ul>
+                <br><hr>
             </dd>
 
 
@@ -93,6 +93,7 @@
                         <li>Basic Switch Information: <code><?= url( "/admin/api/v4/provisioner/switch/switch-name" ) ?>/{switchname}.yaml</code></li>
                         <li>VLANs: <code><?= url( "/admin/api/v4/provisioner/vlans/switch-name" ) ?>/{switchname}.yaml</code></li>
                     </ul>
+                    <br><hr>
                 </dd>
 
 
@@ -115,6 +116,7 @@
                         <li> each infrastructure object has per VLAN objects indexed by the VLAN <b>tag</b> (NB: this is not the VLAN database ID but the VLAN tag) </li>
                         <li> each VLAN object has key/value pairs of <code>macaddress: vlaninterfaceid</code> </li>
                     </ul>
+                    <br><hr>
                 </dd>
 
 

--- a/resources/views/api-key/list-postamble.foil.php
+++ b/resources/views/api-key/list-postamble.foil.php
@@ -87,11 +87,11 @@
                     You may change <code>.yaml</code> to <code>.json</code> in the URL if you prefer. If you wish to use the switch
                     database ID rather than the name, alter the URL for: <code>s#switch-name/{switchname}#switch/{id}#</code>.
                     <ul>
-                        <li>Layer2 Interfaces: <code><?= url( "/api/v4/provisioner/layer2interfaces/switch-name" ) ?>/{switchname}.yaml</code></li>
-                        <li>Layer3 Interfaces: <code><?= url( "/api/v4/provisioner/layer3interfaces/switch-name" ) ?>/{switchname}.yaml</code></li>
-                        <li>Routing: <code><?= url( "/api/v4/provisioner/routing/switch-name" ) ?>/{switchname}.yaml</code></li>
-                        <li>Basic Switch Information: <code><?= url( "/api/v4/provisioner/switch/switch-name" ) ?>/{switchname}.yaml</code></li>
-                        <li>VLANs: <code><?= url( "/api/v4/provisioner/vlans/switch-name" ) ?>/{switchname}.yaml</code></li>
+                        <li>Layer2 Interfaces: <code><?= url( "/admin/api/v4/provisioner/layer2interfaces/switch-name" ) ?>/{switchname}.yaml</code></li>
+                        <li>Layer3 Interfaces: <code><?= url( "/admin/api/v4/provisioner/layer3interfaces/switch-name" ) ?>/{switchname}.yaml</code></li>
+                        <li>Routing: <code><?= url( "/admin/api/v4/provisioner/routing/switch-name" ) ?>/{switchname}.yaml</code></li>
+                        <li>Basic Switch Information: <code><?= url( "/admin/api/v4/provisioner/switch/switch-name" ) ?>/{switchname}.yaml</code></li>
+                        <li>VLANs: <code><?= url( "/admin/api/v4/provisioner/vlans/switch-name" ) ?>/{switchname}.yaml</code></li>
                     </ul>
                 </dd>
 

--- a/resources/views/api-key/list-postamble.foil.php
+++ b/resources/views/api-key/list-postamble.foil.php
@@ -11,7 +11,7 @@
         </p>
         <p>
 
-            The API key can be passed in the header (preferred) or on the URL. For example:
+            The API key can be passed in the header (preferred) or on the URL (though this is currently being deprecated). For example:
         <ul>
             <li>
                 <code>curl -X GET -H "X-IXP-Manager-API-Key: <?= $t->ee( $example_api_key ) ?>" <?= url( "/api/v4/test" ) ?></code>
@@ -106,8 +106,8 @@
                     As IXP Manager <a href="https://docs.ixpmanager.org/latest/features/layer2-addresses/">supports layer2 / MAC addresses in two ways</a>
                     (learned versus configured), there are two endpoints.
                     <ul>
-                        <li>Learned: <code><a href="<?= url( "/api/v4/sflow-db-mapper/learned-macs" ) ?>"><?= url( "/api/v4/sflow-db-mapper/learned-macs" ) ?></a></code></li>
-                        <li>Configured: <code><a href="<?= url( "/api/v4/sflow-db-mapper/configured-macs" ) ?>"><?= url( "/api/v4/sflow-db-mapper/configured-macs" ) ?></a></code></li>
+                        <li>Learned: <code><a href="<?= url( "/admin/api/v4/sflow-db-mapper/learned-macs" ) ?>"><?= url( "/admin/api/v4/sflow-db-mapper/learned-macs" ) ?></a></code></li>
+                        <li>Configured: <code><a href="<?= url( "/admin/api/v4/sflow-db-mapper/configured-macs" ) ?>"><?= url( "/admin/api/v4/sflow-db-mapper/configured-macs" ) ?></a></code></li>
                     </ul>
                     The JSON output is structured as follows:
                     <ul>

--- a/resources/views/api-key/list-preamble.foil.php
+++ b/resources/views/api-key/list-preamble.foil.php
@@ -4,7 +4,7 @@
             <i class="fa fa-exclamation-circle fa-2x"></i>
         </div>
         <div class="col-sm-12">
-            <strong>Treat your API key as a password.</strong>
+            <strong>Treat your API key as a password - never share it and store it securely.</strong>
         </div>
     </div>
 </div>

--- a/routes/apiv4-auth-superuser.php
+++ b/routes/apiv4-auth-superuser.php
@@ -34,10 +34,10 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-// API key can be passed in the header (preferred) or on the URL.
+// API key can be passed in the header (preferred) or on the URL (deprecated).
 //
 //     curl -X GET -H "X-IXP-Manager-API-Key: mySuperSecretApiKey" http://ixpv.dev/api/v4/test
-//     wget http://ixpv.dev/api/v4/test?apikey=mySuperSecretApiKey
+//     DEPRECATED wget http://ixpv.dev/api/v4/test?apikey=mySuperSecretApiKey
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Customers

--- a/routes/apiv4.php
+++ b/routes/apiv4.php
@@ -35,10 +35,10 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-// API key can be passed in the header (preferred) or on the URL.
+// API key can be passed in the header (preferred) or on the URL (deprecated).
 //
 //     curl -X GET -H "X-IXP-Manager-API-Key: mySuperSecretApiKey" http://ixpv.dev/api/v4/test
-//     wget http://ixpv.dev/api/v4/test?apikey=mySuperSecretApiKey
+//     DEPRECATED: wget http://ixpv.dev/api/v4/test?apikey=mySuperSecretApiKey
 
 Route::any( 'ping', 'PublicController@ping' )->name('api-v4:ping' );
 Route::any( 'test', 'PublicController@test' )->name('api-v4:test' );

--- a/tests/Api/PublicControllerTest.php
+++ b/tests/Api/PublicControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Api;
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use IXP\Models\ApiKey;
 use IXP\Models\Customer;
@@ -109,6 +110,17 @@ class PublicControllerTest extends TestCase
 
         $apiKey->refresh();
         $this->assertEquals($now->timestamp, $apiKey->last_seen_at->timestamp);
+
+        // This is needed because for some reason laravel doesn't clear Auth between test HTTP requests?
+        Auth::forgetUser();
+
+        // test disabled legacy apikey
+        config()->set('ixp_api.allow_apikeys_get_parameter', false);
+        $this->assertFalse(config('ixp_api.allow_apikeys_get_parameter'));
+
+        $response = $this->get( '/api/v4/test?apikey=' . $legacyApiKey );
+        $response->assertStatus( 200 )
+            ->assertSee( 'Authenticated: No' );
     }
 
     public function testPing()

--- a/tools/runtime/nagios/ixp-manager-check-core-bundles.sh
+++ b/tools/runtime/nagios/ixp-manager-check-core-bundles.sh
@@ -61,7 +61,7 @@ if [ -z "${APIKEY}" ] || [ -z "${ID}" ]; then
     usage
 fi
 
-STATUS="$( wget -O - -q  "${URL}/admin/api/v4/switch/${ID}/core-bundles-status?apikey=${APIKEY}" )"
+STATUS="$( wget -O - -q --header="X-IXP-Manager-API-Key: ${APIKEY}" "${URL}/admin/api/v4/switch/${ID}/core-bundles-status" )"
 
 if [ $? -ne 0 ] || [ -z "$STATUS" ]; then
     echo Could not query core bundle status via API

--- a/tools/runtime/nagios/ixp-manager-check-switch.sh
+++ b/tools/runtime/nagios/ixp-manager-check-switch.sh
@@ -62,7 +62,7 @@ if [ -z "${APIKEY}" ] || [ -z "${ID}" ]; then
 fi
 
 
-STATUS="$( wget -O - -q  "${URL}/admin/api/v4/switch/${ID}/status?apikey=${APIKEY}" )"
+STATUS="$( wget -O - -q --header="X-IXP-Manager-API-Key: ${APIKEY}" "${URL}/admin/api/v4/switch/${ID}/status" )"
 
 if [ $? -ne 0 ] || [ -z "$STATUS" ]; then
     echo Could not query switch status via API


### PR DESCRIPTION
- Logs all attempted use of the apikey get parameter
- Accepts apikey get parameter by default, or can be configured using `IXP_ALLOW_DEPRECATED_APIKEYS_VIA_GET`. Added this envvar to .env.example.
- Updates two scripts to use header auth method (ixp-manager-check-core-bundles.sh and ixp-manager-check-switch.sh)
- Enables InvokeDeferredCallbacks middleware globally
- Add /admin to some urls

In addition to the above, I have:

 - [x] ensured unit tests all run without error
 - [x] ran psalm and corrected any static analysis issues
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
