### PR TITLE
Fix route prefix summary crash when a category has no rows

### DIFF
--- a/app/Models/Aggregators/RsPrefixAggregator.php
+++ b/app/Models/Aggregators/RsPrefixAggregator.php
@@ -166,7 +166,11 @@ class RsPrefixAggregator extends RsPrefix
         $summary = [];
         foreach( RsPrefix::$SUMMARY_TYPES_FNS as $type => $fn ) {
             foreach( [ 4, 6 ] as $protocol ) {
-                foreach( self::$fn( $protocol ) as $route ) {
+                if( !( $routes = self::$fn( $protocol ) ) ) {
+                    continue;
+                }
+
+                foreach( $routes as $route ) {
                     // initialise customer's summary array if necessary
                     if( !isset( $summary[ $route[ 'id' ] ] ) ) {
                         $summary[ $route['id'] ] = self::initialiseAggregateRouteSummariesArray();


### PR DESCRIPTION
Check if routes are empty before processing them to avoid HTTP 500 Error

[BF] Fix route prefix summary crash when a category has no rows

This fixes an error in the route server prefix summary page where aggregateRouteSummaries() could attempt to iterate over false.
getSummaryRoutes() returns false when no matching prefixes exist for a given route category/protocol combination. The all-customer summary path did not guard against that case, causing:
foreach() argument must be of type array|object, false given
The fix skips empty summary results before iterating, matching the defensive behavior already used by the per-customer summary method.
 
