### PR TITLE
eloquent controllers: use [static::class, ] as controller method refe…

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -60,7 +60,7 @@ class AdminController extends Controller
      *
      * @param Request $r
      *
-     * @return view
+     * @return View
      */
     public function dashboard( Request $r ): View
     {

--- a/app/Http/Controllers/AppPasswordController.php
+++ b/app/Http/Controllers/AppPasswordController.php
@@ -154,7 +154,7 @@ class AppPasswordController extends EloquentController
     protected static function additionalRoutes( string $route_prefix ): void
     {
         Route::group( [  'prefix' => 'admin/' . $route_prefix ], static function() use ( $route_prefix ) {
-            Route::get(   'history/{id}',            'AppPasswordController@history' )->name( $route_prefix . '@history' );
+            Route::get(   'history/{id}',            [self::class, 'history'] )->name( $route_prefix . '@history' );
         });
     }
 

--- a/app/Http/Controllers/ConsoleServer/ConsoleServerConnectionController.php
+++ b/app/Http/Controllers/ConsoleServer/ConsoleServerConnectionController.php
@@ -150,7 +150,7 @@ class ConsoleServerConnectionController extends EloquentController
     protected static function additionalRoutes( string $route_prefix ): void
     {
         Route::group( [ 'prefix' => ( static::$is_admin_route ? 'admin/' : '' ) . $route_prefix ], static function() use ( $route_prefix ) {
-            Route::get(     'list/port/{cs}',               'ConsoleServer\ConsoleServerConnectionController@listPort'    )->name( $route_prefix . '@listPort'   );
+            Route::get(     'list/port/{cs}',               [self::class, 'listPort']    )->name( $route_prefix . '@listPort'   );
         });
     }
 

--- a/app/Http/Controllers/Customer/CustomerTagController.php
+++ b/app/Http/Controllers/Customer/CustomerTagController.php
@@ -126,8 +126,8 @@ class CustomerTagController extends EloquentController
     protected static function additionalRoutes( string $route_prefix ): void
     {
         Route::group( [ 'prefix' => ( static::$is_admin_route ? 'admin/' : '' ) .  $route_prefix ], static function() use ( $route_prefix ) {
-            Route::get(     'cust/{cust}',  'Customer\CustomerTagController@linkCustomer' )->name( $route_prefix . '@link-customer' );
-            Route::post(    'link/{cust}',  'Customer\CustomerTagController@link'         )->name( $route_prefix . '@link'          );
+            Route::get(     'cust/{cust}',  [self::class, 'linkCustomer'] )->name( $route_prefix . '@link-customer' );
+            Route::post(    'link/{cust}',  [self::class, 'link']         )->name( $route_prefix . '@link'          );
         });
     }
 

--- a/app/Http/Controllers/DocstoreCustomer/DirectoryController.php
+++ b/app/Http/Controllers/DocstoreCustomer/DirectoryController.php
@@ -160,7 +160,7 @@ class DirectoryController extends Controller
      *
      * @throws AuthorizationException
      */
-    public function create( Request $r, Customer $cust ): view
+    public function create( Request $r, Customer $cust ): View
     {
         $this->authorize( 'create', [ DocstoreCustomerDirectory::class, $cust ] );
 

--- a/app/Http/Controllers/DocstoreCustomer/FileController.php
+++ b/app/Http/Controllers/DocstoreCustomer/FileController.php
@@ -147,7 +147,7 @@ class FileController extends Controller
      *
      * @throws AuthorizationException
      */
-    public function upload( Request $r, Customer $cust ): view
+    public function upload( Request $r, Customer $cust ): View
     {
         $this->authorize( 'create', DocstoreCustomerFile::class );
 

--- a/app/Http/Controllers/IpAddressController.php
+++ b/app/Http/Controllers/IpAddressController.php
@@ -144,7 +144,7 @@ class IpAddressController extends Controller
      *
      * @param int   $protocol   Protocol of the IP address
      *
-     * @return view
+     * @return View
      */
     public function create( int $protocol ): View
     {

--- a/app/Http/Controllers/Layer2AddressController.php
+++ b/app/Http/Controllers/Layer2AddressController.php
@@ -142,7 +142,7 @@ class Layer2AddressController extends EloquentController
     {
         // NB: this route is marked as 'read-only' to disable normal CRUD operations. It's not really read-only.
         Route::group( [ 'prefix' => ( static::$is_admin_route ? 'admin/' : '' ) . $route_prefix ], function() use ( $route_prefix ) {
-            Route::get(  'vlan-interface/{vli}', 'Layer2AddressController@forVlanInterface' )->name( $route_prefix . '@forVlanInterface' );
+            Route::get(  'vlan-interface/{vli}', [self::class, 'forVlanInterface'] )->name( $route_prefix . '@forVlanInterface' );
         });
     }
 

--- a/app/Http/Controllers/RipeAtlas/MeasurementController.php
+++ b/app/Http/Controllers/RipeAtlas/MeasurementController.php
@@ -182,10 +182,10 @@ class MeasurementController extends Eloquent2Frontend
     protected static function additionalRoutes( string $route_prefix ): void
     {
         Route::group( [ 'prefix' => $route_prefix ], function() use ( $route_prefix ) {
-            Route::get( 'matrix/{atlasRun}',            'RipeAtlas\MeasurementController@matrix'                )->name( $route_prefix . '@matrix'              );
-            Route::post('run/{atlasrun}',               'RipeAtlas\MeasurementController@runMeasurements'       )->name( $route_prefix . '@run-measurements'    );
-            Route::put( 'update/{atlasrun}',            'RipeAtlas\MeasurementController@updateMeasurements'    )->name( $route_prefix . '@update-measurements' );
-            Route::put( 'stop-measurements/{atlasrun}', 'RipeAtlas\MeasurementController@stopMeasurements'      )->name( $route_prefix . '@stop-measurements'   );
+            Route::get( 'matrix/{atlasRun}',            [self::class, 'matrix']                )->name( $route_prefix . '@matrix'              );
+            Route::post('run/{atlasrun}',               [self::class, 'runMeasurements']       )->name( $route_prefix . '@run-measurements'    );
+            Route::put( 'update/{atlasrun}',            [self::class, 'updateMeasurements']    )->name( $route_prefix . '@update-measurements' );
+            Route::put( 'stop-measurements/{atlasrun}', [self::class, 'stopMeasurements']      )->name( $route_prefix . '@stop-measurements'   );
         });
     }
 

--- a/app/Http/Controllers/RipeAtlas/RunController.php
+++ b/app/Http/Controllers/RipeAtlas/RunController.php
@@ -143,8 +143,8 @@ class RunController extends Eloquent2Frontend
     protected static function additionalRoutes( string $route_prefix ): void
     {
         Route::group( [ 'prefix' => $route_prefix ], function() use ( $route_prefix ) {
-            Route::get( 'add-step-2',                   'RipeAtlas\RunController@addStep2'      )->name( $route_prefix . '@add-step-2'    );
-            Route::put( 'run/complete/{atlasrun}',      'RipeAtlas\RunController@completeRun'   )->name( $route_prefix . '@complete-run'  );
+            Route::get( 'add-step-2',                   [self::class, 'addStep2']      )->name( $route_prefix . '@add-step-2'    );
+            Route::put( 'run/complete/{atlasrun}',      [self::class, 'completeRun']   )->name( $route_prefix . '@complete-run'  );
         });
     }
 

--- a/app/Http/Controllers/Switches/SwitchController.php
+++ b/app/Http/Controllers/Switches/SwitchController.php
@@ -209,14 +209,14 @@ class SwitchController extends EloquentController
     {
         // NB: this route is marked as 'read-only' to disable normal CRUD operations. It's not really read-only.
         Route::group( [  'prefix' => ( static::$is_admin_route ? 'admin/' : '' ) . $route_prefix ], function() {
-            Route::get(  'create-by-snmp',      'Switches\SwitchController@addBySnmp'       )->name( 'switch@create-by-snmp'   );
-            Route::get(  'port-report/{switch}','Switches\SwitchController@portReport'      )->name( "switch@port-report"   );
-            Route::post( 'store-by-snmp',       'Switches\SwitchController@storeBySmtp'     )->name( "switch@store-by-snmp" );
+            Route::get(  'create-by-snmp',       [self::class, 'addBySnmp']     )->name( 'switch@create-by-snmp'   );
+            Route::get(  'port-report/{switch}', [self::class, 'portReport']    )->name( "switch@port-report"   );
+            Route::post( 'store-by-snmp',        [self::class, 'storeBySmtp']   )->name( "switch@store-by-snmp" );
         });
 
         // never an admin route:
         Route::group( [  'prefix' => $route_prefix ], function() {
-            Route::get(  'configuration',       'Switches\SwitchController@configuration'   )->name( "switch@configuration" );
+            Route::get(  'configuration',        [self::class, 'configuration']  )->name( "switch@configuration" );
         });
 
     }
@@ -581,7 +581,7 @@ class SwitchController extends EloquentController
      *
      * @param Switcher $switch ID for the switch
      *
-     * @return view
+     * @return View
      */
     public function portReport( Switcher $switch ) : View
     {
@@ -620,7 +620,7 @@ class SwitchController extends EloquentController
      *
      * @param Request $r
      *
-     * @return view
+     * @return View
      *
      * @throws
      */

--- a/app/Http/Controllers/Switches/SwitchPortController.php
+++ b/app/Http/Controllers/Switches/SwitchPortController.php
@@ -131,16 +131,16 @@ class SwitchPortController extends EloquentController
     {
         // NB: this route is marked as 'read-only' to disable normal CRUD operations. It's not really read-only.
         Route::group( [  'prefix' => ( static::$is_admin_route ? 'admin/' : '' ) . $route_prefix ], static function() {
-            Route::get(  'unused-optics',       'Switches\SwitchPortController@unusedOptics'   )->name( 'switch-port@unused-optics'     );
-            Route::get(  'optic-inventory',     'Switches\SwitchPortController@opticInventory' )->name( 'switch-port@optic-inventory'   );
-            Route::get(  'optic-list',          'Switches\SwitchPortController@opticList'      )->name( 'switch-port@optic-list'        );
-            Route::get(  'list-mau/{switch}',   'Switches\SwitchPortController@listMau'        )->name( 'switch-port@list-mau'          );
-            Route::get(  'op-status/{switch}',  'Switches\SwitchPortController@listOpStatus'   )->name( 'switch-port@list-op-status'    );
-            Route::get(  'snmp-poll/{switch}',  'Switches\SwitchPortController@snmpPoll'       )->name( 'switch-port@snmp-poll'         );
+            Route::get(  'unused-optics',       [self::class, 'unusedOptics']   )->name( 'switch-port@unused-optics'     );
+            Route::get(  'optic-inventory',     [self::class, 'opticInventory'] )->name( 'switch-port@optic-inventory'   );
+            Route::get(  'optic-list',          [self::class, 'opticList']      )->name( 'switch-port@optic-list'        );
+            Route::get(  'list-mau/{switch}',   [self::class, 'listMau']        )->name( 'switch-port@list-mau'          );
+            Route::get(  'op-status/{switch}',  [self::class, 'listOpStatus']   )->name( 'switch-port@list-op-status'    );
+            Route::get(  'snmp-poll/{switch}',  [self::class, 'snmpPoll']       )->name( 'switch-port@snmp-poll'         );
 
-            Route::post( 'set-type',            'Switches\SwitchPortController@setType'        )->name( 'switch-port@set-type'          );
-            Route::post( 'change-status',       'Switches\SwitchPortController@changeStatus'   )->name( 'switch-port@change-status'     );
-            Route::delete( 'delete-snmp-poll',  'Switches\SwitchPortController@deleteSnmpPoll' )->name( 'switch-port@delete-snmp-poll'  );
+            Route::post( 'set-type',            [self::class, 'setType']        )->name( 'switch-port@set-type'          );
+            Route::post( 'change-status',       [self::class, 'changeStatus']   )->name( 'switch-port@change-status'     );
+            Route::delete( 'delete-snmp-poll',  [self::class, 'deleteSnmpPoll'] )->name( 'switch-port@delete-snmp-poll'  );
         });
     }
 
@@ -376,7 +376,7 @@ class SwitchPortController extends EloquentController
     /**
      * Display the unused optics
      *
-     * @return view
+     * @return View
      *
      * @throws
      */
@@ -850,9 +850,9 @@ class SwitchPortController extends EloquentController
     /**
      * Display the Optic list
      *
-     * @return view
+     * @return View
      */
-    public function opticList(): view
+    public function opticList(): View
     {
         $this->setUpOpticList();
 

--- a/app/Http/Controllers/User/UserRememberTokenController.php
+++ b/app/Http/Controllers/User/UserRememberTokenController.php
@@ -134,7 +134,7 @@ class UserRememberTokenController extends EloquentController
     {
         // NB: this route is marked as 'read-only' to disable normal CRUD operations. It's not really read-only.
         Route::group( [  'prefix' => $route_prefix ], static function() use ( $route_prefix ) {
-            Route::delete(  'delete',   'User\UserRememberTokenController@delete' )->name( $route_prefix."@delete" );
+            Route::delete(  'delete',   [self::class, 'delete'] )->name( $route_prefix."@delete" );
         });
     }
 

--- a/app/Http/Controllers/VlanController.php
+++ b/app/Http/Controllers/VlanController.php
@@ -138,10 +138,10 @@ class VlanController extends EloquentController
     protected static function additionalRoutes( string $route_prefix ): void
     {
         Route::group( [ 'prefix' => ( static::$is_admin_route ? 'admin/' : '' ) . $route_prefix ], static function() use ( $route_prefix ) {
-            Route::get(     'private',                             'VlanController@listPrivate'    )->name( $route_prefix . '@private'        );
-            Route::get(     'private/infra/{infra}',               'VlanController@listPrivate'    )->name( $route_prefix . '@privateInfra'   );
-            Route::get(     'list/infra/{infra}',                  'VlanController@listInfra'      )->name( $route_prefix . '@infra'          );
-            Route::get(     'list/infra/{infra}/public/{public}',  'VlanController@listInfra'      )->name( $route_prefix . '@infraPublic'    );
+            Route::get(     'private',                             [self::class, 'listPrivate']    )->name( $route_prefix . '@private'        );
+            Route::get(     'private/infra/{infra}',               [self::class, 'listPrivate']    )->name( $route_prefix . '@privateInfra'   );
+            Route::get(     'list/infra/{infra}',                  [self::class, 'listInfra']      )->name( $route_prefix . '@infra'          );
+            Route::get(     'list/infra/{infra}/public/{public}',  [self::class, 'listInfra']      )->name( $route_prefix . '@infraPublic'    );
         });
     }
 

--- a/app/Utils/Http/Controllers/Frontend/EloquentController.php
+++ b/app/Utils/Http/Controllers/Frontend/EloquentController.php
@@ -217,25 +217,24 @@ abstract class EloquentController extends Controller
     public static function routes(): void
     {
         // add leading slash to class name for absolute resolution:
-        $class = '\\' . static::class;
         $route_prefix = self::route_prefix();
 
-        Route::group( [ 'prefix' => ( static::$is_admin_route ? 'admin/' : '' ) . $route_prefix ], static function() use ( $class, $route_prefix ) {
-            Route::get( 'list',      $class . '@list' )->name( $route_prefix . '@list' );
-            Route::get( 'view/{id}', $class . '@view' )->name( $route_prefix . '@view' );
+        Route::group( [ 'prefix' => ( static::$is_admin_route ? 'admin/' : '' ) . $route_prefix ], static function() use ( $route_prefix ) {
+            Route::get( 'list',      [static::class, 'list'] )->name( $route_prefix . '@list' );
+            Route::get( 'view/{id}', [static::class, 'view'] )->name( $route_prefix . '@view' );
 
             if( !static::$read_only ) {
-                Route::get(  'create',          $class . '@create'  )->name( $route_prefix . '@create'  );
-                Route::delete( 'delete/{id}',   $class . '@delete'  )->name( $route_prefix . '@delete'  );
+                Route::get(  'create',          [static::class, 'create']  )->name( $route_prefix . '@create'  );
+                Route::delete( 'delete/{id}',   [static::class, 'delete']  )->name( $route_prefix . '@delete'  );
                 if( !static::$disable_edit ) {
-                    Route::get( 'edit/{id}',    $class . '@edit'    )->name( $route_prefix . '@edit'    );
-                    Route::put( 'update/{id}',  $class . '@update'  )->name( $route_prefix . '@update'  );
+                    Route::get( 'edit/{id}',    [static::class, 'edit']    )->name( $route_prefix . '@edit'    );
+                    Route::put( 'update/{id}',  [static::class, 'update']  )->name( $route_prefix . '@update'  );
                 }
-                Route::post( 'store', $class . '@' . static::$storeFn )->name( $route_prefix . '@store' );
+                Route::post( 'store', [static::class, static::$storeFn] )->name( $route_prefix . '@store' );
             }
         });
 
-        $class::additionalRoutes( $route_prefix );
+        static::additionalRoutes( $route_prefix );
     }
 
     /**
@@ -245,13 +244,11 @@ abstract class EloquentController extends Controller
      */
     public static function route_prefix(): ?string
     {
-        $class = static::class;
-
-        if( $class::$route_prefix ) {
-            return $class::$route_prefix;
+        if( static::$route_prefix ) {
+            return static::$route_prefix;
         }
 
-        return Str::kebab( substr( class_basename( $class ), 0, -10 ) );
+        return Str::kebab( substr( class_basename( static::class ), 0, -10 ) );
     }
 
     /**
@@ -442,7 +439,7 @@ abstract class EloquentController extends Controller
      *
      * @param int $id ID of the object to edit
      *
-     * @return view
+     * @return View
      *
      * @throws GeneralException
      */


### PR DESCRIPTION
a typo in the string format isn't detected until much later, whereas static::class is always correct, and can't be typod without producing compile errors (detected early)

it's also invisible to 'Find Usages' in PhpStorm in the string format, so this helps navigating the project