### PR TITLE
DotEnvParser: fix deprecation 'Using null as an array offset is depre…

### DIFF
--- a/app/Utils/DotEnv/DotEnvParser.php
+++ b/app/Utils/DotEnv/DotEnvParser.php
@@ -187,7 +187,10 @@ class DotEnvParser
         // check for duplicate keys
         $keys = [];
         foreach( $this->settings as $setting ) {
-            if( $setting['key'] !== null && isset( $keys[ $setting['key'] ] ) ) {
+            if( $setting['key'] === null ) {
+                continue;
+            }
+            if(isset( $keys[ $setting['key'] ] ) ) {
                 throw new DotEnvParserException( "Cannot parse .env - at least two variables have the same name: " . $setting['key'] );
             }
             $keys[ $setting['key'] ] = true;


### PR DESCRIPTION
'Using null as an array offset is deprecated, use an empty string instead' is deprecated in php8.5, fixing now