### PR TITLE
Fix MySQL 8.0 foreign key type mismatch in atlas migrations

### DIFF
--- a/database/migrations/2021_03_30_125422_create_atlas_measurements.php
+++ b/database/migrations/2021_03_30_125422_create_atlas_measurements.php
@@ -15,7 +15,7 @@ class CreateAtlasMeasurements extends Migration
     {
         Schema::create('atlas_measurements', function (Blueprint $table) {
             $table->increments('id')->unsigned();
-            $table->integer('run_id' );
+            $table->integer('run_id' )->unsigned();
             $table->integer('cust_source' )->nullable();
             $table->integer('cust_dest' )->nullable();
             $table->integer('atlas_id' )->nullable();

--- a/database/migrations/2021_03_30_125723_create_atlas_results.php
+++ b/database/migrations/2021_03_30_125723_create_atlas_results.php
@@ -15,7 +15,7 @@ class CreateAtlasResults extends Migration
     {
         Schema::create('atlas_results', function (Blueprint $table) {
             $table->increments('id')->unsigned();
-            $table->integer('measurement_id' )->nullable()->unique();
+            $table->integer('measurement_id' )->nullable()->unsigned()->unique();
             $table->string('routing', 255)->nullable();
             $table->longText('path' )->nullable();
             $table->timestamps();


### PR DESCRIPTION
MySQL 8.0+ enforces strict type compatibility for foreign key references. The atlas_runs.id column is defined as INT UNSIGNED (via $table->increments('id')->unsigned()), but atlas_measurements.run_id was defined as a plain INT (signed), causing migration failure with:

```
  SQLSTATE[HY000]: General error: 3780 Referencing column 'run_id'
  and referenced column 'id' in foreign key constraint
  'atlas_measurements_run_id_foreign' are incompatible.
```

Fix by adding ->unsigned() to atlas_measurements.run_id to match the referenced column type.

Also apply the same fix to atlas_results.measurement_id, which references atlas_measurements.id (also INT UNSIGNED), to prevent the same error when that migration runs.

This issue only manifests on MySQL 8.0+ with strict SQL mode enabled (the default on Ubuntu 24.04).

This issue fixes https://github.com/inex/IXP-Manager/issues/1013

---

In addition to the above, I have:

 - [ ] ensured unit tests all run without error
 - [ ] ran psalm and corrected any static analysis issues
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
---

I am going to let github actions do the unit tests and psalm, I can now install ixpmanager with these fixes, but I've not programmed PHP for 10+ years so I am very out of my depth on how to do the first two