### PR TITLE
[BF] remove incorrect '/admin' from URLROOT

### DIFF
--- a/tools/runtime/router-reconfigure-scripts/api-reconfigure-example-birdv2.sh
+++ b/tools/runtime/router-reconfigure-scripts/api-reconfigure-example-birdv2.sh
@@ -32,7 +32,7 @@
 ###########################################################################################
 
 APIKEY="your-api-key"
-URLROOT="https://ixp.example.com/admin"
+URLROOT="https://ixp.example.com"
 
 # prevent errors by limiting this server/script to the following space separated handles
 ALLOWED_HANDLES="rs1-ipv4 rs1-ipv6"


### PR DESCRIPTION
Was getting set twice and requesting "/admin/admin...."

```
URL_LOCK="${URLROOT}/admin/api/v4/router/get-update-lock"
URL_CONF="${URLROOT}/admin/api/v4/router/gen-config"
URL_RELEASE="${URLROOT}/admin/api/v4/router/release-update-lock"
URL_DONE="${URLROOT}/admin/api/v4/router/updated"
```

In addition to the above, I have:

 - [ ] ensured unit tests all run without error
 - [ ] ran psalm and corrected any static analysis issues
 - [ ] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [ ] ensured appropriate checks against user privilege / resources accessed
 - [ ] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
