### PR TITLE
customer edit/create: fix populating fields from PeeringDB

### DIFF
--- a/resources/views/customer/js/edit.foil.php
+++ b/resources/views/customer/js/edit.foil.php
@@ -87,7 +87,7 @@
     btn_populate.on( 'click', function( e ) {
         if( input_search.val() && /^\s*\d+\s*$/.test( input_search.val() ) ) {
             let peering_policy = '';
-            let url = " <?= url( "admin/api/v4/customer/query-peeringdb/asn" ) ?>/" + input_search.val().trim();
+            let url = "<?= url( "admin/api/v4/customer/query-peeringdb/asn" ) ?>/" + input_search.val().trim();
 
             btn_populate.attr( "disabled", "disabled" );
             $( '#error-message' ).remove();
@@ -97,33 +97,33 @@
                 .done( function( response ) {
                     if( typeof response.net !== "undefined" ) {
                         // fill inputs with info received
-                        input_name.val(             htmlEntities( response.net.name ) ).addClass( 'is-valid' );
-                        input_abbreviated_name.val( htmlEntities( response.net.name ) ).addClass( 'is-valid' );
-                        input_shortname.val(        htmlEntities( response.net.name ).replace( /[^a-zA-Z0-9]+/g, "" ).toLowerCase().substr( 0, 10 ) ).addClass( 'is-valid' );
+                        input_name.val(             response.net.name ).addClass( 'is-valid' );
+                        input_abbreviated_name.val( response.net.name ).addClass( 'is-valid' );
+                        input_shortname.val(        response.net.name.replace( /[^a-zA-Z0-9]+/g, "" ).toLowerCase().substr( 0, 10 ) ).addClass( 'is-valid' );
                         input_datejoin.val(         getCurrentDate() ).addClass( 'is-valid' );
-                        input_corp_www.val(         htmlEntities( response.net.website ) ).addClass( 'is-valid' );
-                        input_autsys.val(           htmlEntities( response.net.asn ) ).addClass( 'is-valid' );
-                        input_peeringmacro.val(     htmlEntities( response.net.irr_as_set ) ).addClass( 'is-valid' );
+                        input_corp_www.val(         response.net.website ).addClass( 'is-valid' );
+                        input_autsys.val(           response.net.asn ).addClass( 'is-valid' );
+                        input_peeringmacro.val(     response.net.irr_as_set ).addClass( 'is-valid' );
 
-                        if( response.net.info_prefixes4 !== "undefined" ) {
-                            input_maxprefixes.val( Math.ceil( htmlEntities( response.net.info_prefixes4 ) ) ).addClass( 'is-valid' );
+                        if( typeof response.net.info_prefixes4 !== "undefined" ) {
+                            input_maxprefixes.val( Math.ceil( response.net.info_prefixes4 ) ).addClass( 'is-valid' );
                         }
 
-                        if( response.net.info_prefixes6 !== "undefined" ) {
-                            input_maxprefixesv6.val( Math.ceil( htmlEntities( response.net.info_prefixes6 ) ) ).addClass( 'is-valid' );
+                        if( typeof response.net.info_prefixes6 !== "undefined" ) {
+                            input_maxprefixesv6.val( Math.ceil( response.net.info_prefixes6 ) ).addClass( 'is-valid' );
                         }
 
-                        dd_peering_policy.val(  htmlEntities( response.net.policy_general ).toLowerCase() ).trigger( "change" ).addClass( 'is-valid' );
+                        dd_peering_policy.val(  response.net.policy_general.toLowerCase() ).trigger( "change" ).addClass( 'is-valid' );
 
-                        if( response.net.poc_set !== "undefined" ) {
+                        if( typeof response.net.poc_set !== "undefined" ) {
                             $.each( response.net.poc_set, function( key, noc ) {
                                 if( noc.role.toUpperCase() === "NOC" ) {
-                                    if( noc.phone !== "undefined" && noc.phone !== "" ){
-                                        input_nocphone.val( htmlEntities( noc.phone ) ).addClass( 'is-valid' );
+                                    if( typeof noc.phone !== "undefined" && noc.phone !== "" ){
+                                        input_nocphone.val( noc.phone ).addClass( 'is-valid' );
                                     }
-                                    if( noc.email !== "undefined" ) {
-                                        input_nocemail.val( htmlEntities( noc.email ) ).addClass( 'is-valid' );
-                                        input_peeringemail.val( htmlEntities( noc.email ) ).addClass( 'is-valid' );
+                                    if( typeof noc.email !== "undefined" ) {
+                                        input_nocemail.val( noc.email ).addClass( 'is-valid' );
+                                        input_peeringemail.val( noc.email ).addClass( 'is-valid' );
                                     }
                                 }
                             });


### PR DESCRIPTION
After the Populate from PeeringDB feature was added, we added a call to htmlEntities to sanitize the incoming data. In a recent commit I added more substitutions to that function (/ -> &#2f;)

After #1015 I reviewed the populate feature, and it seems we can do without the htmlEntities here. We're using jQuery's .val which treats the parameter as text, so even if there was javascript returned from PeeringDB, it'll be treated by the browser as text not code.

As for saving it to the database on form submission -- we shouldn't be saving escaped content to the database as it's better practice to escape on output instead, and encoding on the way in can produce messy double encoded output.

So I'm removing the call to htmlEntities here and I hope never to regret it :)