### PR TITLE
Only run gitlab mirror on main repo (not forked copies)

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   mirror_to_gitlab:
+    if: github.repository == 'inex/IXP-Manager'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Tweak .github/workflows/mirror.yml workflow so it only tries to run on inex/IXP-Manager. 

This stops it bailing with an error and sending emails about it failing on commit to forked copies (because I don't have the INEX gitlab credentials set up.)