### PR TITLE
[BF] correct config_key for app-passwords in settings UI

### DIFF
--- a/config/ixp_fe_settings.php
+++ b/config/ixp_fe_settings.php
@@ -62,7 +62,7 @@ return [
                 ],
                 
                 'app-passwords' => [
-                    'config_key' => 'ixp_fe.frontend.disabled.app-password',
+                    'config_key' => 'ixp_fe.frontend.disabled.app-passwords',
                     'dotenv_key' => 'IXP_FE_FRONTEND_DISABLED_APP_PASSWORD',
                     'type'       => 'radio',
                     'invert'     => true,


### PR DESCRIPTION
Tweak to correct config_key for app-passwords so settings UI displays correct value.
