### PR TITLE
[IM] Add option to disable editing per-VLAN-interface max prefix in UI.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,7 +141,6 @@ IXP_AS112_UI_ACTIVE=false
 # See: https://docs.ixpmanager.org/latest/usage/customers/#customer-logos
 IXP_FE_FRONTEND_DISABLED_LOGO=false
 
-
 # Send email notifications when a customer's billing details are updated.
 # See: https://docs.ixpmanager.org/latest/usage/customers/#notification-of-billing-details-changed
 # IXP_FE_CUSTOMER_BILLING_UPDATES_NOTIFY="mail@example.com"
@@ -152,6 +151,25 @@ IXP_FE_FRONTEND_DISABLED_LOGO=false
 
 # Enable the UI for route server community-based filtering by uncommenting this line:
 # IXP_FE_FRONTEND_DISABLED_RS_FILTERS=false
+
+# Enable/Disable per-VLAN-interface maximum prefix configuration.
+# If you only operate a single peering LAN / infrastructure in
+# a single geographic location, you may want to disable
+# per-VLAN interface maximum prefix setting and use only the global
+# max prefix settings for each member.
+#
+# Setting this to false disables editing in the frontend. It does not disable
+# the per-VLAN interface max prefix logic if a value is set in the database.
+#
+# Before disabling, ensure all existing per-VLAN max prefixes have been checked
+# and the global max prefix updated if needed before clearing all
+# per-VLAN-interface max prefix settings.
+#
+# Run: php ./artisan update:max-prefixes-7.1.0
+#
+
+IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED=true
+
 
 #######################################################################################
 ### Graphing - see https://docs.ixpmanager.org/latest/grapher/introduction

--- a/config/ixp_fe.php
+++ b/config/ixp_fe.php
@@ -282,6 +282,7 @@ return [
     */
     'vlaninterfaces' => [
         'hostname_required'  => env( 'IXP_FE_VLANINTERFACES_HOSTNAME_REQUIRED', true ),
+        'max_prefix_enabled' => env( 'IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED', true ),
     ],
 
     /*

--- a/config/ixp_fe_settings.php
+++ b/config/ixp_fe_settings.php
@@ -217,6 +217,21 @@ return [
                                         target="_blank">BGP detector</a> running.',
                 ],
 
+                'vlaninterfaces-max-prefix-enabled' => [
+                    'config_key' => 'ixp_fe.vlaninterfaces.max_prefix_enabled',
+                    'dotenv_key' => 'IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED',
+                    'type'       => 'radio',
+                    'invert'     => false,
+                    'rules'      => 'boolean',
+                    'name'       => 'Per-VLAN Interface Maximum Prefixes',
+                    'docs_url'   => null,
+                    'help'       => 'Allow maximum prefixes to be set per VLAN interface.
+                                        If you only operate a single peering VLAN or infrastructure in one geographic location,
+                                        you may want to disable this and only use the global maximum prefix settings for each
+                                        member. Before disabling, run <code>php ./artisan update:max-prefixes-7.1.0</code>',
+                ],
+
+
                 'phpinfo'                   => [
                     'config_key' => 'ixp_fe.frontend.disabled.phpinfo',
                     'dotenv_key' => 'IXP_FE_FRONTEND_DISABLED_PHPINFO',

--- a/resources/views/interfaces/common/vli/ipv4.foil.php
+++ b/resources/views/interfaces/common/vli/ipv4.foil.php
@@ -32,6 +32,10 @@
 
         <?= Former::number( 'ipv4maxbgpprefix' )
                 ->label( 'Max BGP Prefixes' )
+                ->disabled( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true ) )
+                ->title( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true )
+                    ? 'Per VLAN interface max. prefix disabled. Update via Edit ' . ucfirst(config( 'ixp_fe.lang.customer.one' )) . ' Details page.'
+                    : null )
                 ->blockHelp( 'The maximum IPv4 prefixes that any router configured via IXP Manager should accept for this endpoint. '
                         . 'See <a href="https://docs.ixpmanager.org/latest/usage/customers/#peering-details">the official documentation</a> for more details.' );
         ?>

--- a/resources/views/interfaces/common/vli/ipv6.foil.php
+++ b/resources/views/interfaces/common/vli/ipv6.foil.php
@@ -32,6 +32,10 @@
 
         <?= Former::number( 'ipv6maxbgpprefix' )
                 ->label( 'Max BGP Prefixes' )
+                ->disabled( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true ) )
+                ->title( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true )
+                    ? 'Per VLAN interface max. prefix disabled. Update via Edit ' . ucfirst(config( 'ixp_fe.lang.customer.one' )) . ' Details page.'
+                    : null )
                 ->blockHelp( 'The maximum IPv6 prefixes that any router configured via IXP Manager should accept for this endpoint. '
                         . 'See <a href="https://docs.ixpmanager.org/latest/usage/customers/#peering-details">the official documentation</a> for more details.' );
         ?>


### PR DESCRIPTION
[IM] Setting to disable editing of per-vlan max prefix in UI.

*Longer description*

This PR adds a new config option:

`IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED`

With the changes in behaviour as of 7.1.0, the per-VLAN max prefix is used if present instead of greater of the two,
I have run `php ./artisan update:max-prefixes-7.1.0` to update any to the global max prefix settings for members.

Since we operate a single peering LAN / infrastructure in one location, we never have any use for the per-VLAN maximum prefix setting. It is more confusing than useful to operators.
 
Setting `IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED=false` greys out editing of the per-VLAN interface max prefix settings to ensure we only ever edit the global (per member) max prefixes.

Default setting is true (to maintain backward compatibility.)


In addition to the above, I have:

 - [x] ensured unit tests all run without error
 - [x] ran psalm and corrected any static analysis issues
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  