### PR TITLE
[BF/IM] Improvements to settings UI config parser. Display config if read-only. Show .env modification time. Bugfixes.

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -84,7 +84,7 @@ class SettingsController extends Controller
     protected function index(): View
     {
         try {
-            $this->checkIfDotEnvIsCompatible();
+            $readOnly = !$this->checkIfDotEnvIsCompatible();
         } catch( Exception $e ) {
             
             AlertContainer::push( $e->getMessage(), Alert::DANGER );
@@ -93,10 +93,16 @@ class SettingsController extends Controller
                 'exception' => $e,
             ] );
         }
+
+        if( $readOnly ) {
+            AlertContainer::push( 'Server has no write permissions for .env file. Changes disabled.', Alert::WARNING );
+        }
         
         return view( 'settings.index' )->with( [
-            'settings' => $this->fe_settings,
-            'rules'    => [], //$this->gatherRules(),
+            'settings'     => $this->fe_settings,
+            'rules'        => [], //$this->gatherRules(),
+            'readOnly'     => $readOnly,
+            'lastModified' => date( 'Y-m-d H:i:s T', filemtime( base_path( '.env' ) ) ),
         ] );
     }
     
@@ -105,14 +111,10 @@ class SettingsController extends Controller
      * @throws DotEnvParserException
      * @throws Exception
      */
-    private function checkIfDotEnvIsCompatible()
+    private function checkIfDotEnvIsCompatible(): bool
     {
         if( !file_exists( base_path( '.env' ) ) ) {
             throw new Exception( "The .env file is missing. Please create it and try again." );
-        }
-        
-        if( !is_writable( base_path( '.env' ) ) ) {
-            throw new Exception( "The .env file cannot be written to. Please check the file permissions and try again." );
         }
         
         if( !( $env = file_get_contents( base_path( '.env' ) ) ) ) {
@@ -120,6 +122,8 @@ class SettingsController extends Controller
         }
         
         new DotEnvParser( $env )->parse();
+
+        return is_writable( base_path( '.env' ) );
     }
     
     /**

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace IXP\Http\Controllers;
 
 /*
- * Copyright (C) 2009 - 2025 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * This file is part of IXP Manager.
@@ -112,7 +112,7 @@ class SettingsController extends Controller
         }
         
         if( !is_writable( base_path( '.env' ) ) ) {
-            throw new Exception( "The .env file is can not be written to. Please check the file permissions and try again." );
+            throw new Exception( "The .env file cannot be written to. Please check the file permissions and try again." );
         }
         
         if( !( $env = file_get_contents( base_path( '.env' ) ) ) ) {
@@ -150,7 +150,7 @@ class SettingsController extends Controller
         }
         
         if( !is_writable( base_path( '.env' ) ) ) {
-            throw new Exception( "The .env file is can not be written to. Please check the file permissions and try again." );
+            throw new Exception( "The .env file cannot be written to. Please check the file permissions and try again." );
         }
         
         if( !( file_put_contents( base_path( '.env' ), $dotEnv ) ) ) {
@@ -181,7 +181,19 @@ class SettingsController extends Controller
                         $validated[ $fname ] = $validated[ $fname ] === "1" ? "0" : "1";
                     }
                     
-                    if( !isset( $validated[ $fname ] ) || $validated[ $fname ] == $orig ) {
+                    if( !isset( $validated[ $fname ] ) ) {
+                        continue;
+                    }
+
+                    if( ( $fconfig[ 'rules' ] ?? null ) === 'boolean' ) {
+                        $value = filter_var( $validated[ $fname ], FILTER_VALIDATE_BOOLEAN );
+
+                        if( $value === (bool)$orig ) {
+                            continue;
+                        }
+
+                        $validated[ $fname ] = $value ? 'true' : 'false';
+                    } else if( $validated[ $fname ] == $orig ) {
                         continue;
                     }
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -84,7 +84,8 @@ class SettingsController extends Controller
     protected function index(): View
     {
         try {
-            $readOnly = !$this->checkIfDotEnvIsCompatible();
+            $this->checkIfDotEnvIsCompatible();
+            $readOnly = !$this->isDotEnvWritable();
         } catch( Exception $e ) {
             
             AlertContainer::push( $e->getMessage(), Alert::DANGER );
@@ -111,7 +112,7 @@ class SettingsController extends Controller
      * @throws DotEnvParserException
      * @throws Exception
      */
-    private function checkIfDotEnvIsCompatible(): bool
+    private function checkIfDotEnvIsCompatible(): void
     {
         if( !file_exists( base_path( '.env' ) ) ) {
             throw new Exception( "The .env file is missing. Please create it and try again." );
@@ -122,7 +123,13 @@ class SettingsController extends Controller
         }
         
         new DotEnvParser( $env )->parse();
+    }
 
+    /**
+     * Check whether the .env settings can be changed through the UI.
+     */
+    private function isDotEnvWritable(): bool
+    {
         return is_writable( base_path( '.env' ) );
     }
     
@@ -141,7 +148,7 @@ class SettingsController extends Controller
         }
         
         
-        return new DotEnvContainer( new DotEnvParser( $env )->parse()->settings() );
+        return new DotEnvContainer( new DotEnvParser( $env )->parse()->settings( true ) );
     }
     
     /**

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -148,7 +148,7 @@ class SettingsController extends Controller
         }
         
         
-        return new DotEnvContainer( new DotEnvParser( $env )->parse()->settings( true ) );
+        return new DotEnvContainer( new DotEnvParser( $env )->parse()->settings() );
     }
     
     /**

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -196,7 +196,7 @@ class SettingsController extends Controller
                         continue;
                     }
 
-                    if( ( $fconfig[ 'rules' ] ?? null ) === 'boolean' ) {
+                    if( $fconfig[ 'type' ] === 'radio' ) {
                         $value = filter_var( $validated[ $fname ], FILTER_VALIDATE_BOOLEAN );
 
                         if( $value === (bool)$orig ) {

--- a/app/Utils/DotEnv/DotEnvParser.php
+++ b/app/Utils/DotEnv/DotEnvParser.php
@@ -67,8 +67,16 @@ class DotEnvParser
         return $this;
     }
 
-    public function settings(): array {
-        return $this->settings;
+    public function settings( bool $includeMetadata = false ): array
+    {
+        if( $includeMetadata ) {
+            return $this->settings;
+        }
+
+        return array_map( function( array $setting ): array {
+            unset( $setting['raw'] );
+            return $setting;
+        }, $this->settings );
     }
 
     /**
@@ -84,9 +92,8 @@ class DotEnvParser
 
         $lines = preg_split( '/\r\n|\r|\n/', $this->content() );
 
-        // The last empty element represents the file's final newline rather
-        // than a blank line. Preserve any additional trailing blank lines.
-        if( end( $lines ) === "" ) {
+        // remove trailing blank lines
+        while( end( $lines ) === "" ) {
             array_pop( $lines );
         }
 
@@ -98,7 +105,8 @@ class DotEnvParser
 
         foreach( $lines as $line ) {
 
-            $line = ltrim( $line );
+            $rawLine = $line;
+            $line = trim($line);
 
             if( mb_strlen( $line ) && mb_strpos( $line, '#' ) !== 0 ) {
 
@@ -146,12 +154,14 @@ class DotEnvParser
                         "key"     => null,
                         "value"   => null,
                         "comment" => "",
+                        "raw"     => $rawLine,
                     ];
                 } else {
                     $this->settings[] = [
                         "key"     => null,
                         "value"   => null,
-                        "comment" => mb_substr( $line, 1 ),
+                        "comment" => trim( mb_substr( $line, 1 ) ),
+                        "raw"     => $rawLine,
                     ];
                 }
             } else if( mb_strlen( $line ) === 0 ) {
@@ -217,7 +227,7 @@ class DotEnvParser
             if( $character === '#' ) {
                 return [
                     substr( $valueElement, 0, $i ),
-                    substr( $valueElement, $i + 1 ),
+                    trim( substr( $valueElement, $i + 1 ) ),
                 ];
             }
         }

--- a/app/Utils/DotEnv/DotEnvParser.php
+++ b/app/Utils/DotEnv/DotEnvParser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace IXP\Utils\DotEnv;
 
 /*
- * Copyright (C) 2009 - 2025 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * IXP Manager is free software: you can redistribute it and/or modify it
@@ -84,8 +84,9 @@ class DotEnvParser
 
         $lines = preg_split( '/\r\n|\r|\n/', $this->content() );
 
-        // remove trailing blank lines
-        while( end( $lines ) === "" ) {
+        // The last empty element represents the file's final newline rather
+        // than a blank line. Preserve any additional trailing blank lines.
+        if( end( $lines ) === "" ) {
             array_pop( $lines );
         }
 
@@ -97,7 +98,7 @@ class DotEnvParser
 
         foreach( $lines as $line ) {
 
-            $line = trim($line);
+            $line = ltrim( $line );
 
             if( mb_strlen( $line ) && mb_strpos( $line, '#' ) !== 0 ) {
 
@@ -125,27 +126,8 @@ class DotEnvParser
                         throw new DotEnvParserException( "Invalid key name: " . $key );
                     }
 
-                    // is there a comment at the end of the line?
-                    $values = explode( '#', $valueElement );
-
-                    $value = $this->parseValue( array_shift( $values ) );
-
-                    $comment = '';
-                    if( count( $values ) === 0 ) {
-                        $comment = null;
-                    } else if( count( $values ) === 1 ) {
-                        $comment = trim( $values[ 0 ] );
-                    } else {
-                        // multiple hashes in the comment element
-                        while( ( $a = array_shift( $values ) ) !== null ) {
-                            if( $a === '' ) {
-                                $comment .= '#';
-                            } else {
-                                $comment .= $a;
-                            }
-                        }
-                        $comment = trim( $comment );
-                    }
+                    [ $valueElement, $comment ] = $this->splitValueAndComment( $valueElement );
+                    $value = $this->parseValue( $valueElement );
 
                     $this->settings[] = [
                         "key"     => trim( $key ),
@@ -169,7 +151,7 @@ class DotEnvParser
                     $this->settings[] = [
                         "key"     => null,
                         "value"   => null,
-                        "comment" => trim( mb_substr( $line, 1 ) ),
+                        "comment" => mb_substr( $line, 1 ),
                     ];
                 }
             } else if( mb_strlen( $line ) === 0 ) {
@@ -194,6 +176,53 @@ class DotEnvParser
         }
 
         return $this;
+    }
+
+    /**
+     * Split a value from its inline comment without treating hashes inside
+     * quoted values as comment delimiters.
+     *
+     * @return array{0: string, 1: string|null}
+     */
+    private function splitValueAndComment( string $valueElement ): array
+    {
+        $quote = null;
+        $escaped = false;
+
+        for( $i = 0, $length = strlen( $valueElement ); $i < $length; $i++ ) {
+            $character = $valueElement[ $i ];
+
+            if( $escaped ) {
+                $escaped = false;
+                continue;
+            }
+
+            if( $character === '\\' && $quote === '"' ) {
+                $escaped = true;
+                continue;
+            }
+
+            if( $quote !== null ) {
+                if( $character === $quote ) {
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if( $character === '"' || $character === "'" ) {
+                $quote = $character;
+                continue;
+            }
+
+            if( $character === '#' ) {
+                return [
+                    substr( $valueElement, 0, $i ),
+                    substr( $valueElement, $i + 1 ),
+                ];
+            }
+        }
+
+        return [ $valueElement, null ];
     }
 
     /**

--- a/app/Utils/DotEnv/DotEnvParser.php
+++ b/app/Utils/DotEnv/DotEnvParser.php
@@ -189,7 +189,13 @@ class DotEnvParser
      */
     private function splitValueAndComment( string $valueElement ): array
     {
+        // avoid loop if there's no inline comment
+        if( !str_contains($valueElement, "#") ) {
+            return [ $valueElement, null ];
+        }
+
         $quote = null;
+        /** @var bool $escaped */
         $escaped = false;
 
         for( $i = 0, $length = strlen( $valueElement ); $i < $length; $i++ ) {
@@ -197,27 +203,15 @@ class DotEnvParser
 
             if( $escaped ) {
                 $escaped = false;
-                continue;
-            }
-
-            if( $character === '\\' && $quote === '"' ) {
+            } else if( $character === '\\' && $quote === '"' ) {
                 $escaped = true;
-                continue;
-            }
-
-            if( $quote !== null ) {
+            } else if( $quote !== null ) {
                 if( $character === $quote ) {
                     $quote = null;
                 }
-                continue;
-            }
-
-            if( $character === '"' || $character === "'" ) {
+            } else if( $character === '"' || $character === "'" ) {
                 $quote = $character;
-                continue;
-            }
-
-            if( $character === '#' ) {
+            } else if( $character === '#' ) {
                 return [
                     substr( $valueElement, 0, $i ),
                     trim( substr( $valueElement, $i + 1 ) ),

--- a/app/Utils/DotEnv/DotEnvParser.php
+++ b/app/Utils/DotEnv/DotEnvParser.php
@@ -67,16 +67,9 @@ class DotEnvParser
         return $this;
     }
 
-    public function settings( bool $includeMetadata = false ): array
+    public function settings(): array
     {
-        if( $includeMetadata ) {
-            return $this->settings;
-        }
-
-        return array_map( function( array $setting ): array {
-            unset( $setting['raw'] );
-            return $setting;
-        }, $this->settings );
+        return $this->settings;
     }
 
     /**

--- a/app/Utils/DotEnv/DotEnvWriter.php
+++ b/app/Utils/DotEnv/DotEnvWriter.php
@@ -83,9 +83,14 @@ class DotEnvWriter
             }
 
             if( $l['comment'] !== null ) {
-                $content .= ( $lineStarted ? ' ' : '' ) . '#'
-                    . ( !strlen( trim( $l['comment'] ) ) || trim( $l['comment'] )[0] === '#' ? '' : ' ' )
-                    . $l['comment'];
+                if( !$lineStarted ) {
+                    $content .= '#' . $l['comment'];
+                } else {
+                    $content .= ' #'
+                        . ( !strlen( trim( $l['comment'] ) ) || trim( $l['comment'] )[0] === '#'
+                            || preg_match( '/^\s/', $l['comment'] ) ? '' : ' ' )
+                        . $l['comment'];
+                }
             }
 
             $content .= "\n";

--- a/app/Utils/DotEnv/DotEnvWriter.php
+++ b/app/Utils/DotEnv/DotEnvWriter.php
@@ -62,6 +62,11 @@ class DotEnvWriter
 
         foreach( $this->settings as $l ) {
 
+            if( array_key_exists( 'raw', $l ) ) {
+                $content .= $l['raw'] . "\n";
+                continue;
+            }
+
             $lineStarted = false;
 
             if( $l['key'] !== null ) {
@@ -83,14 +88,9 @@ class DotEnvWriter
             }
 
             if( $l['comment'] !== null ) {
-                if( !$lineStarted ) {
-                    $content .= '#' . $l['comment'];
-                } else {
-                    $content .= ' #'
-                        . ( !strlen( trim( $l['comment'] ) ) || trim( $l['comment'] )[0] === '#'
-                            || preg_match( '/^\s/', $l['comment'] ) ? '' : ' ' )
-                        . $l['comment'];
-                }
+                $content .= ( $lineStarted ? ' ' : '' ) . '#'
+                    . ( !strlen( trim( $l['comment'] ) ) || trim( $l['comment'] )[0] === '#' ? '' : ' ' )
+                    . $l['comment'];
             }
 
             $content .= "\n";

--- a/resources/views/settings/index.foil.php
+++ b/resources/views/settings/index.foil.php
@@ -151,9 +151,13 @@ IXP Manager Settings
 
                     <?=
                         Former::actions(
-                            Former::primary_submit( 'Save Changes' )->id('updateButton')->class( "mb-2 mb-sm-0" )
+                            Former::primary_submit( 'Save Changes' )->id('updateButton')->class( "mb-2 mb-sm-0" )->disabled( $t->readOnly )
                         )
                    ?>
+
+                    <div class="text-muted small mt-2">
+                        <code>.env</code> last modified: <?= $t->lastModified ?>
+                    </div>
 
                    <?= Former::close() ?>
 

--- a/tests/Browser/SettingsControllerTest.php
+++ b/tests/Browser/SettingsControllerTest.php
@@ -76,7 +76,8 @@ class SettingsControllerTest extends DuskTestCase
                 ->waitForLocation( '/admin/dashboard' );
 
             $browser->visit( route( 'settings@index' ) )
-                ->assertSee( 'IXP Manager Settings' );
+                ->assertSee( 'IXP Manager Settings' )
+                ->assertSee( '.env last modified: ' );
             
             $browser->driver->executeScript( 'window.scrollTo(0, 3000);' );
             
@@ -121,7 +122,41 @@ class SettingsControllerTest extends DuskTestCase
             
             $this->assertStringNotContainsString( 'IXP_RPKI_RTR1_PORT=3323', $nenv );
             $this->assertStringContainsString( 'IXP_RPKI_RTR1_PORT=12345', $nenv );
-            
+
+            // Test out changing a boolean setting, since we write true/false to config now
+            $this->assertStringContainsString( 'IXP_FE_FRONTEND_DISABLED_APP_PASSWORD=0', $nenv );
+
+            $browser->uncheck('app-passwords')
+                ->driver->executeScript( 'window.scrollTo(0, 3000);' );
+            $browser->press( 'Save Changes' )
+                ->waitForText( 'Settings have been successfully updated' );
+
+            $nenv = file_get_contents( __DIR__ . '/../../.env' );
+            $this->assertStringContainsString( 'IXP_FE_FRONTEND_DISABLED_APP_PASSWORD=true', $nenv );
+
+            $browser->check('app-passwords')
+                ->driver->executeScript( 'window.scrollTo(0, 3000);' );
+            $browser->press( 'Save Changes' )
+                ->waitForText( 'Settings have been successfully updated' );
+
+            $nenv = file_get_contents( __DIR__ . '/../../.env' );
+            $this->assertStringContainsString( 'IXP_FE_FRONTEND_DISABLED_APP_PASSWORD=false', $nenv );
+
+            // Test not-writable warning, and that form submit is disabled
+            $originalMode = fileperms( __DIR__ . '/../../.env' ) & 0777;
+
+            chmod(__DIR__ . '/../../.env', $originalMode & ~0222); # remove readable bit from permissions
+            sleep(1);
+
+            $browser->visit( route( 'settings@index' ) )
+                ->assertSee( 'Server has no write permissions for .env file. Changes disabled.' );
+
+            $this->assertEquals("true", $browser->element("#envForm #updateButton")->getAttribute("disabled"), "expect form to be disabled when .env is not writable");
+
+            chmod(__DIR__ . '/../../.env', $originalMode); # restore original permissions, whatever they were
+
+            $browser->visit( route( 'settings@index' ) )
+                ->assertDontSee( 'Server has no write permissions for .env file. Changes disabled.' );
         } );
     }
 }

--- a/tests/Utils/DotEnv/DotEnvComplexTest.php
+++ b/tests/Utils/DotEnv/DotEnvComplexTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Tests\Utils\DotEnv;
 
 /*
- * Copyright (C) 2009 - 2025 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * This file is part of IXP Manager.
@@ -52,6 +52,41 @@ final class DotEnvComplexTest extends TestCase
         $container = new DotEnvContainer( new DotEnvParser( file_get_contents( self::ENV_FILE ) )->parse()->settings() );
         
         $this->assertEquals( file_get_contents( self::ENV_FILE ), new DotEnvWriter( $container->settings() )->generateContent() );
+    }
+
+    /**
+     * @throws DotEnvParserException
+     */
+    public function testQuotedHashValueRoundTrip(): void
+    {
+        $env = 'DB_PASSWORD="&k3RUT@5PFPeE%A#qv^NUgsC7"' . "\n";
+        $container = new DotEnvContainer( new DotEnvParser( $env )->parse()->settings() );
+
+        $this->assertSame( $env, new DotEnvWriter( $container->settings() )->generateContent() );
+    }
+
+    /**
+     * @throws DotEnvParserException
+     */
+    public function testCommentWhitespaceRoundTrip(): void
+    {
+        $env = "# A comment with trailing whitespace \n"
+            . "#       An indented comment\n"
+            . "#   - An indented list item\n";
+        $container = new DotEnvContainer( new DotEnvParser( $env )->parse()->settings() );
+
+        $this->assertSame( $env, new DotEnvWriter( $container->settings() )->generateContent() );
+    }
+
+    /**
+     * @throws DotEnvParserException
+     */
+    public function testTrailingBlankLineRoundTrip(): void
+    {
+        $env = "TEST=true\n\n";
+        $container = new DotEnvContainer( new DotEnvParser( $env )->parse()->settings() );
+
+        $this->assertSame( $env, new DotEnvWriter( $container->settings() )->generateContent() );
     }
 
 

--- a/tests/Utils/DotEnv/DotEnvComplexTest.php
+++ b/tests/Utils/DotEnv/DotEnvComplexTest.php
@@ -68,23 +68,13 @@ final class DotEnvComplexTest extends TestCase
     /**
      * @throws DotEnvParserException
      */
-    public function testCommentWhitespaceRoundTrip(): void
+    public function testStandaloneCommentFormattingRoundTrip(): void
     {
         $env = "# A comment with trailing whitespace \n"
             . "#       An indented comment\n"
             . "#   - An indented list item\n";
-        $container = new DotEnvContainer( new DotEnvParser( $env )->parse()->settings() );
-
-        $this->assertSame( $env, new DotEnvWriter( $container->settings() )->generateContent() );
-    }
-
-    /**
-     * @throws DotEnvParserException
-     */
-    public function testTrailingBlankLineRoundTrip(): void
-    {
-        $env = "TEST=true\n\n";
-        $container = new DotEnvContainer( new DotEnvParser( $env )->parse()->settings() );
+        $parser = new DotEnvParser( $env )->parse();
+        $container = new DotEnvContainer( $parser->settings( true ) );
 
         $this->assertSame( $env, new DotEnvWriter( $container->settings() )->generateContent() );
     }

--- a/tests/Utils/DotEnv/DotEnvComplexTest.php
+++ b/tests/Utils/DotEnv/DotEnvComplexTest.php
@@ -74,7 +74,7 @@ final class DotEnvComplexTest extends TestCase
             . "#       An indented comment\n"
             . "#   - An indented list item\n";
         $parser = new DotEnvParser( $env )->parse();
-        $container = new DotEnvContainer( $parser->settings( true ) );
+        $container = new DotEnvContainer( $parser->settings() );
 
         $this->assertSame( $env, new DotEnvWriter( $container->settings() )->generateContent() );
     }

--- a/tests/Utils/DotEnv/DotEnvParserTest.php
+++ b/tests/Utils/DotEnv/DotEnvParserTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Tests\Utils\DotEnv;
 
 /*
- * Copyright (C) 2009 - 2025 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * This file is part of IXP Manager.
@@ -158,7 +158,7 @@ final class DotEnvParserTest extends TestCase
                 [ 0 => [
                     "key"     => null,
                     "value"   => null,
-                    "comment" => "",
+                    "comment" => mb_substr( rtrim( $line, "\r\n" ), 1 ),
                 ] ],
                 $p->settings()
             );
@@ -172,15 +172,15 @@ final class DotEnvParserTest extends TestCase
     {
         foreach(
                 [
-                    "# comment \n" => "comment",
-                    "# comment comment \r\n" => "comment comment",
-                    "# this is at !! comment   \r" => "this is at !! comment",
-                    "# hey \$ho yolo\tthhe\n\r" => "hey \$ho yolo\tthhe",
-                    "#    thesis yo\r\n\r" => "thesis yo",
-                    "#  yes, sisko was the best star trek captain! \n" => "yes, sisko was the best star trek captain!",
-                    "#     no, it was't kirk. or picard. <====\r\n" => "no, it was't kirk. or picard. <====",
-                    "#yes the defiant WAS a cool ship     \r" => "yes the defiant WAS a cool ship",
-                    "#\tncc1701\t   \n\r" => "ncc1701",
+                    "# comment \n" => " comment ",
+                    "# comment comment \r\n" => " comment comment ",
+                    "# this is at !! comment   \r" => " this is at !! comment   ",
+                    "# hey \$ho yolo\tthhe\n\r" => " hey \$ho yolo\tthhe",
+                    "#    thesis yo\r\n\r" => "    thesis yo",
+                    "#  yes, sisko was the best star trek captain! \n" => "  yes, sisko was the best star trek captain! ",
+                    "#     no, it was't kirk. or picard. <====\r\n" => "     no, it was't kirk. or picard. <====",
+                    "#yes the defiant WAS a cool ship     \r" => "yes the defiant WAS a cool ship     ",
+                    "#\tncc1701\t   \n\r" => "\tncc1701\t   ",
                 ] as $line => $expected ) {
 
 
@@ -242,7 +242,7 @@ final class DotEnvParserTest extends TestCase
      */
     public function testBlankLines(): void
     {
-        // leading and trailing blank lines should be removed, but those in the middle should not
+        // leading blank lines should be removed; middle and trailing blank lines should be preserved
         $content = implode("\n", [
             '',
             '',
@@ -270,7 +270,7 @@ final class DotEnvParserTest extends TestCase
             "comment" => null,
         ];
 
-        $this->assertCount( 10, $p->settings() );
+        $this->assertCount( 11, $p->settings() );
         $this->assertNotEquals( $blankLine, $p->settings()[0] );
         $this->assertEquals( $blankLine, $p->settings()[1] );
         $this->assertEquals( $blankLine, $p->settings()[2] );
@@ -280,6 +280,8 @@ final class DotEnvParserTest extends TestCase
         $this->assertNotEquals( $blankLine, $p->settings()[6] );
         $this->assertEquals( $blankLine, $p->settings()[7] );
         $this->assertEquals( $blankLine, $p->settings()[8] );
+        $this->assertNotEquals( $blankLine, $p->settings()[9] );
+        $this->assertEquals( $blankLine, $p->settings()[10] );
     }
 
 
@@ -298,10 +300,12 @@ final class DotEnvParserTest extends TestCase
             [ "TEST= \t \t  \n", "TEST", '', null ],
             [ "TEST=qwerty\n", "TEST", "qwerty", null ],
             [ "TEST_VAR=\"there once was a \"\n", "TEST_VAR", '"there once was a "', null ],
-            [ "TEST_VAR=\"there once was a \"    # comment  \n", "TEST_VAR", '"there once was a "', "comment" ],
+            [ "TEST_VAR=\"there once was a \"    # comment  \n", "TEST_VAR", '"there once was a "', " comment  " ],
             [ "TEST=\"true false something else\"\n", "TEST", '"true false something else"', null ],
             [ "TEST_VAR=\"there once was a \"   ### comment\n", "TEST_VAR", '"there once was a "', "## comment" ],
             [ "APP_KEY=\"base64:01234567899876543210abcdefghijjihgfedcba123=\"", "APP_KEY", '"base64:01234567899876543210abcdefghijjihgfedcba123="', null ],
+            [ 'DB_PASSWORD="&k3RUT@5PFPeE%A#qv^NUgsC7"', "DB_PASSWORD", '"&k3RUT@5PFPeE%A#qv^NUgsC7"', null ],
+            [ 'DB_PASSWORD="&k3RUT@5PFPeE%A#qv^NUgsC7" # database password', "DB_PASSWORD", '"&k3RUT@5PFPeE%A#qv^NUgsC7"', " database password" ],
         ];
     }
 

--- a/tests/Utils/DotEnv/DotEnvParserTest.php
+++ b/tests/Utils/DotEnv/DotEnvParserTest.php
@@ -312,6 +312,7 @@ final class DotEnvParserTest extends TestCase
             [ "TEST=\"true false something else\"\n", "TEST", '"true false something else"', null ],
             [ "TEST_VAR=\"there once was a \"   ### comment\n", "TEST_VAR", '"there once was a "', "## comment" ],
             [ "APP_KEY=\"base64:01234567899876543210abcdefghijjihgfedcba123=\"", "APP_KEY", '"base64:01234567899876543210abcdefghijjihgfedcba123="', null ],
+            [ 'API_RESPONSE="{\"status\": \"ok\"}" # API payload default', "API_RESPONSE", '"{\"status\": \"ok\"}"', "API payload default" ],
         ];
     }
 

--- a/tests/Utils/DotEnv/DotEnvParserTest.php
+++ b/tests/Utils/DotEnv/DotEnvParserTest.php
@@ -144,59 +144,69 @@ final class DotEnvParserTest extends TestCase
     }
 
 
-    /**
-     * @throws DotEnvParserException
-     */
-    public function testParseContentBlankCommentLines(): void
+    public static function blankLineCommentDataProvider(): array
     {
-        foreach( [ "#\n", "#\r\n", "#\r", "#\n\r", "#\r\n\r", "#   \n", "#  \r\n", "#     \r", "#\t   \n\r", "#   \t\r\n\r" ] as $line ) {
-            $p = $this->makeParser()
-                ->setContent( $line )
-                ->parse();
+        return [
+            ["#\n"], ["#\r\n"], ["#\r"], ["#\n\r"], ["#\r\n\r"], ["#   \n"], ["#  \r\n"], ["#     \r"], ["#\t   \n\r"], ["#   \t\r\n\r"],
+        ];
 
-            $this->assertEquals(
-                [ 0 => [
-                    "key"     => null,
-                    "value"   => null,
-                    "comment" => "",
-                ] ],
-                $p->settings()
-            );
-        }
     }
 
     /**
      * @throws DotEnvParserException
      */
-    public function testParseContentCommentLines(): void
+    #[DataProvider('blankLineCommentDataProvider')]
+    public function testParseContentBlankCommentLines($line): void
     {
-        foreach(
-                [
-                    "# comment \n" => "comment",
-                    "# comment comment \r\n" => "comment comment",
-                    "# this is at !! comment   \r" => "this is at !! comment",
-                    "# hey \$ho yolo\tthhe\n\r" => "hey \$ho yolo\tthhe",
-                    "#    thesis yo\r\n\r" => "thesis yo",
-                    "#  yes, sisko was the best star trek captain! \n" => "yes, sisko was the best star trek captain!",
-                    "#     no, it was't kirk. or picard. <====\r\n" => "no, it was't kirk. or picard. <====",
-                    "#yes the defiant WAS a cool ship     \r" => "yes the defiant WAS a cool ship",
-                    "#\tncc1701\t   \n\r" => "ncc1701",
-                ] as $line => $expected ) {
+        $p = $this->makeParser()
+            ->setContent( $line )
+            ->parse();
 
+        $this->assertEquals(
+            [ 0 => [
+                "key"     => null,
+                "value"   => null,
+                "comment" => "",
+                "raw"     => rtrim($line, "\r\n"),  ## Lines are split by \r|\n so they will not be found in raw
+            ] ],
+            $p->settings()
+        );
+    }
 
-            $p = $this->makeParser()
-                ->setContent( $line )
-                ->parse();
+    public static function contentCommentLinesDataProvider(): array
+    {
+        return [
+            ["# comment \n", "comment"],
+            ["# comment comment \r\n", "comment comment"],
+            ["# this is at !! comment   \r", "this is at !! comment"],
+            ["# hey \$ho yolo\tthhe\n\r", "hey \$ho yolo\tthhe"],
+            ["#    thesis yo\r\n\r", "thesis yo"],
+            ["#  yes, sisko was the best star trek captain! \n", "yes, sisko was the best star trek captain!"],
+            ["#     no, it was't kirk. or picard. <====\r\n", "no, it was't kirk. or picard. <===="],
+            ["#yes the defiant WAS a cool ship     \r", "yes the defiant WAS a cool ship"],
+            ["#\tncc1701\t   \n\r", "ncc1701"],
+        ];
+    }
 
-            $this->assertEquals(
-                [ 0 => [
-                    "key"     => null,
-                    "value"   => null,
-                    "comment" => $expected,
-                ] ],
-                $p->settings()
-            );
-        }
+    /**
+     * @throws DotEnvParserException
+     */
+    #[DataProvider('contentCommentLinesDataProvider')]
+    public function testParseContentCommentLines($line, $expected): void
+    {
+        $p = $this->makeParser()
+            ->setContent( $line )
+            ->parse();
+
+        $this->assertEquals(
+            [ 0 => [
+                "key"     => null,
+                "value"   => null,
+                "comment" => $expected,
+                "raw"     => rtrim($line, "\r\n"), ## Lines are split by \r|\n so they will not be found in raw
+            ] ],
+            $p->settings()
+        );
     }
 
     public static function unparsableValuesProvider(): array

--- a/tests/Utils/DotEnv/DotEnvParserTest.php
+++ b/tests/Utils/DotEnv/DotEnvParserTest.php
@@ -158,7 +158,7 @@ final class DotEnvParserTest extends TestCase
                 [ 0 => [
                     "key"     => null,
                     "value"   => null,
-                    "comment" => mb_substr( rtrim( $line, "\r\n" ), 1 ),
+                    "comment" => "",
                 ] ],
                 $p->settings()
             );
@@ -172,15 +172,15 @@ final class DotEnvParserTest extends TestCase
     {
         foreach(
                 [
-                    "# comment \n" => " comment ",
-                    "# comment comment \r\n" => " comment comment ",
-                    "# this is at !! comment   \r" => " this is at !! comment   ",
-                    "# hey \$ho yolo\tthhe\n\r" => " hey \$ho yolo\tthhe",
-                    "#    thesis yo\r\n\r" => "    thesis yo",
-                    "#  yes, sisko was the best star trek captain! \n" => "  yes, sisko was the best star trek captain! ",
-                    "#     no, it was't kirk. or picard. <====\r\n" => "     no, it was't kirk. or picard. <====",
-                    "#yes the defiant WAS a cool ship     \r" => "yes the defiant WAS a cool ship     ",
-                    "#\tncc1701\t   \n\r" => "\tncc1701\t   ",
+                    "# comment \n" => "comment",
+                    "# comment comment \r\n" => "comment comment",
+                    "# this is at !! comment   \r" => "this is at !! comment",
+                    "# hey \$ho yolo\tthhe\n\r" => "hey \$ho yolo\tthhe",
+                    "#    thesis yo\r\n\r" => "thesis yo",
+                    "#  yes, sisko was the best star trek captain! \n" => "yes, sisko was the best star trek captain!",
+                    "#     no, it was't kirk. or picard. <====\r\n" => "no, it was't kirk. or picard. <====",
+                    "#yes the defiant WAS a cool ship     \r" => "yes the defiant WAS a cool ship",
+                    "#\tncc1701\t   \n\r" => "ncc1701",
                 ] as $line => $expected ) {
 
 
@@ -242,7 +242,7 @@ final class DotEnvParserTest extends TestCase
      */
     public function testBlankLines(): void
     {
-        // leading blank lines should be removed; middle and trailing blank lines should be preserved
+        // leading and trailing blank lines should be removed, but those in the middle should not
         $content = implode("\n", [
             '',
             '',
@@ -270,7 +270,7 @@ final class DotEnvParserTest extends TestCase
             "comment" => null,
         ];
 
-        $this->assertCount( 11, $p->settings() );
+        $this->assertCount( 10, $p->settings() );
         $this->assertNotEquals( $blankLine, $p->settings()[0] );
         $this->assertEquals( $blankLine, $p->settings()[1] );
         $this->assertEquals( $blankLine, $p->settings()[2] );
@@ -280,8 +280,6 @@ final class DotEnvParserTest extends TestCase
         $this->assertNotEquals( $blankLine, $p->settings()[6] );
         $this->assertEquals( $blankLine, $p->settings()[7] );
         $this->assertEquals( $blankLine, $p->settings()[8] );
-        $this->assertNotEquals( $blankLine, $p->settings()[9] );
-        $this->assertEquals( $blankLine, $p->settings()[10] );
     }
 
 
@@ -300,12 +298,10 @@ final class DotEnvParserTest extends TestCase
             [ "TEST= \t \t  \n", "TEST", '', null ],
             [ "TEST=qwerty\n", "TEST", "qwerty", null ],
             [ "TEST_VAR=\"there once was a \"\n", "TEST_VAR", '"there once was a "', null ],
-            [ "TEST_VAR=\"there once was a \"    # comment  \n", "TEST_VAR", '"there once was a "', " comment  " ],
+            [ "TEST_VAR=\"there once was a \"    # comment  \n", "TEST_VAR", '"there once was a "', "comment" ],
             [ "TEST=\"true false something else\"\n", "TEST", '"true false something else"', null ],
             [ "TEST_VAR=\"there once was a \"   ### comment\n", "TEST_VAR", '"there once was a "', "## comment" ],
             [ "APP_KEY=\"base64:01234567899876543210abcdefghijjihgfedcba123=\"", "APP_KEY", '"base64:01234567899876543210abcdefghijjihgfedcba123="', null ],
-            [ 'DB_PASSWORD="&k3RUT@5PFPeE%A#qv^NUgsC7"', "DB_PASSWORD", '"&k3RUT@5PFPeE%A#qv^NUgsC7"', null ],
-            [ 'DB_PASSWORD="&k3RUT@5PFPeE%A#qv^NUgsC7" # database password', "DB_PASSWORD", '"&k3RUT@5PFPeE%A#qv^NUgsC7"', " database password" ],
         ];
     }
 
@@ -327,6 +323,32 @@ final class DotEnvParserTest extends TestCase
             ] ],
             $p->settings()
         );
+    }
+
+    /**
+     * @throws DotEnvParserException
+     */
+    public function testQuotedHashIsPartOfValue(): void
+    {
+        $p = $this->makeParser()
+            ->setContent( 'DB_PASSWORD="&k3RUT@5PFPeE%A#qv^NUgsC7"' )
+            ->parse();
+
+        $this->assertSame( '"&k3RUT@5PFPeE%A#qv^NUgsC7"', $p->settings()[0]['value'] );
+        $this->assertNull( $p->settings()[0]['comment'] );
+    }
+
+    /**
+     * @throws DotEnvParserException
+     */
+    public function testQuotedHashValueWithInlineComment(): void
+    {
+        $p = $this->makeParser()
+            ->setContent( 'DB_PASSWORD="&k3RUT@5PFPeE%A#qv^NUgsC7" # database password' )
+            ->parse();
+
+        $this->assertSame( '"&k3RUT@5PFPeE%A#qv^NUgsC7"', $p->settings()[0]['value'] );
+        $this->assertSame( 'database password', $p->settings()[0]['comment'] );
     }
 
     public function testParserWithNoContent()


### PR DESCRIPTION
*Longer description*

This PR updates the settings UI/DotEnvParser as follows:-

### Bugfixes

- Preserve # characters inside quoted values, such as MySQL passwords.
- Preserve comment indentation and trailing whitespace.
- Preserve trailing blank lines.
- Write boolean settings as true/false instead of 1/0.

#### 1. Don't break settings if config value contains "#"

Example:

```
DB_PASSWORD="&k3RUT@5PFPeE%A#qv^NUgsC7"
```

Would get written as:

```
DB_PASSWORD=""&k3RUT@5PFPeE%A" # qv^NUgsC7
```

...Breaking IXP Manager as it can no longer access the database.

#### 2. Write `true` or `false` settings (boolean) back as `true/false` not `1/0`

Example:

```
IXP_FE_FRONTEND_DISABLED_APP_PASSWORD=true
```

Would get written as:

```
IXP_FE_FRONTEND_DISABLED_APP_PASSWORD=1
```

#### 3. Better handling of comment lines.

Preserve comment lines in their original form, not add/strip spaces etc.


### Improvements

- Display readable but unwritable .env files in read-only mode.
  If no write permissions for .env but can be read,  display the current settings anyway instead of throwing exception.
  Change warning to non-fatal: "Server has no write permissions for .env file. Changes disabled." 
- Disable "Save Changes" when .env is read-only and show a warning.
- Show the .env file’s last-modified timestamp.
- Improved handling for quoted hashes, comment whitespace, and trailing blank lines.

In addition to the above, I have:

 - [x] ensured unit tests all run without error
 - [x] ran psalm and corrected any static analysis issues
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  