### PR TITLE
[BF] Don't select first member in member dropdown on editing XC. Avoid ajax errors on reset/update

### DIFF
--- a/resources/views/patch-panel-port/edit.foil.php
+++ b/resources/views/patch-panel-port/edit.foil.php
@@ -174,8 +174,8 @@ $this->layout( 'layouts/ixpv4' );
                 <div class="mr-auto col-lg-11 col-md-10">
                     <?= Former::select( 'customer_id' )
                         ->label( ucfirst( config( 'ixp_fe.lang.customer.one' ) ) )
+                        ->addOption( 'Choose a ' . config( 'ixp_fe.lang.customer.one' ), '', [ 'disabled' => 'disabled' ] )
                         ->fromQuery( $t->customers , fn ( $model ) => $t->ee( $model->name ) )
-                        ->placeholder( 'Choose a ' . config( 'ixp_fe.lang.customer.one' ) )
                         ->addClass( 'chzn-select' )
                         ->append(  $ppp->customer ? "<span class='badge badge-info'> Was " . $t->ee( $ppp->customer->name ). " </span>" : '' );
                     ?>

--- a/resources/views/patch-panel-port/js/edit.foil.php
+++ b/resources/views/patch-panel-port/js/edit.foil.php
@@ -189,6 +189,11 @@
         let switchId  = dd_switch.val();
         let sptypes    = <?= json_encode( \IXP\Models\SwitchPort::$TYPES ) ?> ;
 
+        if( !switchId ) {
+            dd_switch_port.html( "<option value=\"\">Choose a Switch Port</option>" ).trigger( "change.select2" );
+            return;
+        }
+
         let currentSId          = false;
         let currentSpId         = false;
         let spOption            = false;
@@ -300,7 +305,7 @@
      * set data to the customer dropdown
      */
     function setCustomer() {
-        if( dd_switch.val() !== '') {
+        if( dd_switch.val() && dd_switch_port.val() ) {
             let switchPortId = dd_switch_port.val();
             let option = '';
             dd_customer.html( `<option value=''>Loading please wait</option>` ).trigger('change.select2');
@@ -326,14 +331,14 @@
      * reset the customer dropdown
      */
     function resetCustomer() {
-        let options = `<option value=''> Choose a <?= config( 'ixp_fe.lang.customer.one' ) ?></option>`;
+        let options = `<option value='' disabled selected> Choose a <?= config( 'ixp_fe.lang.customer.one' ) ?></option>`;
 
         <?php foreach ( $t->customers as $c ): ?>
             options += `<option value='<?= $c->id ?>'><?= $t->ee( $c->name ) ?></option>`;
         <?php endforeach; ?>
         dd_customer.html( options ).trigger('change.select2');
 
-        if( dd_switch.val() !== '' && dd_switch_port.val() === '' ){
+        if( dd_switch.val() && !dd_switch_port.val() ){
             setSwitchPort();
         }
     }


### PR DESCRIPTION
*Longer description*

When editing an unassigned crossconnect, the first member is selected by default in the Member dropdown instead of "Choose a (member/customer)" placeholder.

For some reason I cannot get:

```
->placeholder( 'Choose a ' . config( 'ixp_fe.lang.customer.one' ) )
```

to work. Just seems to get ignored.

```
->addOption( 'Choose a ' . config( 'ixp_fe.lang.customer.one' ), '', [ 'disabled' => 'disabled' ] )
```

Works, and disabled to prevent selecting it and causing ajax error for blank value using the "Reset" button.

```
Error running ajax query for  https://portal..../admin/api/v4/customer//switches
Error running ajax query for https://portal..../admin/api/v4/switch/null/switch-port-for-ppp
```
 


In addition to the above, I have:

 - [x] ensured unit tests all run without error
 - [x] ran psalm and corrected any static analysis issues
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
