### PR TITLE
[IM] Add rate limit and auto-neg to Provision New Port wizard.

### DIFF
--- a/app/Http/Requests/StoreVirtualInterfaceWizard.php
+++ b/app/Http/Requests/StoreVirtualInterfaceWizard.php
@@ -3,7 +3,7 @@
 namespace IXP\Http\Requests;
 
 /*
- * Copyright (C) 2009 - 2021 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * This file is part of IXP Manager.
@@ -62,7 +62,7 @@ class StoreVirtualInterfaceWizard extends FormRequest
      *
      * @return ((IdnValidate|string)[]|string)[]
      *
-     * @psalm-return array{custid: 'required|integer|exists:cust,id', vlanid: 'required|integer|exists:vlan,id', trunk: 'boolean', switch: 'required|integer|exists:switch,id', switchportid: 'required|integer|exists:switchport,id', status: string, speed: string, duplex: string, ipv4maxbgpprefix: 'integer|nullable', ipv6maxbgpprefix: 'integer|nullable', mcastenabled: 'boolean', rsclient: 'boolean', irrdbfilter: 'boolean', rsmorespecifics: 'boolean', as112client: 'boolean', ipv4enabled: 'boolean', ipv4address: 'ipv4|nullable'|'ipv4|required', ipv4hostname: list{'string', 'max:255', 'nullable'|'required', IdnValidate}, ipv4bgpmd5secret: 'string|max:255|nullable', ipv4canping: 'boolean', ipv4monitorrcbgp: 'boolean', ipv6enabled: 'boolean', ipv6address: 'ipv6|nullable'|'ipv6|required', ipv6hostname: list{'string', 'max:255', 'nullable'|'required', IdnValidate}, ipv6bgpmd5secret: 'string|max:255|nullable', ipv6canping: 'boolean', ipv6monitorrcbgp: 'boolean'}
+     * @psalm-return array{custid: 'required|integer|exists:cust,id', vlanid: 'required|integer|exists:vlan,id', trunk: 'boolean', switch: 'required|integer|exists:switch,id', switchportid: 'required|integer|exists:switchport,id', status: string, speed: string, duplex: string, rate_limit: 'nullable|integer|min:0', autoneg: 'boolean', ipv4maxbgpprefix: 'integer|nullable', ipv6maxbgpprefix: 'integer|nullable', mcastenabled: 'boolean', rsclient: 'boolean', irrdbfilter: 'boolean', rsmorespecifics: 'boolean', as112client: 'boolean', ipv4enabled: 'boolean', ipv4address: 'ipv4|nullable'|'ipv4|required', ipv4hostname: list{'string', 'max:255', 'nullable'|'required', IdnValidate}, ipv4bgpmd5secret: 'string|max:255|nullable', ipv4canping: 'boolean', ipv4monitorrcbgp: 'boolean', ipv6enabled: 'boolean', ipv6address: 'ipv6|nullable'|'ipv6|required', ipv6hostname: list{'string', 'max:255', 'nullable'|'required', IdnValidate}, ipv6bgpmd5secret: 'string|max:255|nullable', ipv6canping: 'boolean', ipv6monitorrcbgp: 'boolean'}
      */
     public function rules(): array
     {
@@ -76,6 +76,8 @@ class StoreVirtualInterfaceWizard extends FormRequest
             'status'                => 'required|integer|in:' . implode( ',', array_keys( PhysicalInterface::$STATES ) ),
             'speed'                 => 'required|integer|in:' . implode( ',', array_keys( PhysicalInterface::$SPEED ) ),
             'duplex'                => 'required|string|in:' . implode( ',', array_keys( PhysicalInterface::$DUPLEX ) ),
+            'rate_limit'            => 'nullable|integer|min:0',
+            'autoneg'               => 'boolean',
 
             'mcastenabled'          => 'boolean',
             'rsclient'              => 'boolean',

--- a/resources/views/interfaces/virtual/wizard.foil.php
+++ b/resources/views/interfaces/virtual/wizard.foil.php
@@ -155,6 +155,19 @@ $this->layout( 'layouts/ixpv4' );
                             ->value(1)
                             ->blockHelp( '' );
                         ?>
+
+                        <?= Former::number( 'rate_limit' )
+                            ->label( 'Rate Limit <u>(Mbps)</u>' )
+                            ->blockHelp( 'Enter the provisioned speed if the port has been rate limited below its line rate. <strong>Enter in Mbps!</strong> Leave blank if port is not rate limited. Zero will be converted to null (blank - not rate limited).');
+                        ?>
+
+                        <?= Former::checkbox( 'autoneg' )
+                            ->label( '&nbsp;' )
+                            ->text( 'Auto-Negotiation Enabled' )
+                            ->value( 1 )
+                            ->inline()
+                            ->blockHelp( "Unless you are provisioning switches from IXP Manager, this is informational." );
+                        ?>
                     </div>
 
                     <div class="col-md-12 col-lg-4 mt-4 mt-md-4">


### PR DESCRIPTION
[IM] Add rate limit and auto-neg to Provision New Port wizard.

*Longer description*
 
- Add rate limit / auto-neg to the provision new port wizard for consistency with physical interface settings page.
- (...Because we keep forgetting to go back and set rate limit in a separate page when provisioning new ports, and this leads to billing discrepancies later when we discover someone has unlimited port which should have been rate-limited.)

In addition to the above, I have:

 - [x] ensured unit tests all run without error
 - [x] ran psalm and corrected any static analysis issues
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
