### PR TITLE
[BF] Always copy address -> billing address fields even if blank.

### DIFF
--- a/resources/views/customer/billing-registration.foil.php
+++ b/resources/views/customer/billing-registration.foil.php
@@ -312,12 +312,12 @@
              * set the address information to the billing address info
              */
             $( "#copy-address" ).click( () => {
-                $( "#address1" ).val(  ) !== ''   ? $( "#billingAddress1"   ).val( $( "#address1" ).val() ) : '';
-                $( "#address2" ).val(  ) !== ''   ? $( "#billingAddress2"   ).val( $( "#address2" ).val() ) : '';
-                $( "#address3" ).val(  ) !== ''   ? $( "#billingAddress3"   ).val( $( "#address3" ).val() ) : '';
-                $( "#townCity" ).val(  ) !== ''   ? $( "#billingTownCity"   ).val( $( "#townCity" ).val() ): '';
-                $( "#postcode" ).val(  ) !== ''   ? $( "#billingPostcode"   ).val( $( "#postcode" ).val() ): '';
-                $( "#country" ).val(  )  !== ''   ? $( "#billingCountry"    ).val( $( "#country"  ).val() ).trigger('change.select2') : '';
+                $( "#billingAddress1" ).val( $( "#address1" ).val() );
+                $( "#billingAddress2" ).val( $( "#address2" ).val() );
+                $( "#billingAddress3" ).val( $( "#address3" ).val() );
+                $( "#billingTownCity" ).val( $( "#townCity" ).val() );
+                $( "#billingPostcode" ).val( $( "#postcode" ).val() );
+                $( "#billingCountry" ).val( $( "#country" ).val() ).trigger('change.select2');
             } );
 
 


### PR DESCRIPTION
[BF] Always copy address -> billing address fields even if blank.

*Longer description*

If a company changes registered office address and you use the "copy to billing address" button,
only non-blank values were copied. If the new address has fewer lines than the old address, you end up
with a weird merged billing address because it wasn't also populating blank fields.

### Example

| Field | Old Address | New Address | Copied Billing Address
| --- | --- | --- | --- |
|address1 | Unit 2, Grim Industrial Estate | 483 Green Lanes | 483 Green Lanes  |
|address2 | Thwackbottom Lane|  | **Thwackbottom Lane** |
|address3 | Great Smackbottom |  | **Great Smackbottom** |
|townCity | SPANKLEY| LONDON | LONDON |
|postcode | SP01 1ZZ| N13 4BS | N13 4BS  |
|country | United Kingdom| United Kingdom | United Kingdom  |


In addition to the above, I have:

 - [x] ensured unit tests all run without error
 - [x] ran psalm and corrected any static analysis issues
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
