### PR TITLE
[BF] Fix 500 server error during login if "Remember me" is ticked and AUTH_TOKEN_EXPIRE is set in .env 

### DIFF
--- a/app/Services/Auth/EloquentUserProvider.php
+++ b/app/Services/Auth/EloquentUserProvider.php
@@ -115,7 +115,7 @@ class EloquentUserProvider implements IlluminateUserProvider
             'token'     => Str::random(60),
             'device'    => $browser->getPlatform() . " " . $browser->getPlatformVersion(true) . " / " . $browser->getName() . " " . $browser->getVersion() ,
             'ip'        => IpAddress::getIp(),
-            'expires'   => now()->addMinutes( config('auth.guards.web.expire', 60) ),
+            'expires'   => now()->addMinutes( (int) config('auth.guards.web.expire', 60) ),
         ]);
     }
 


### PR DESCRIPTION
[BF] Fix 500 server error during login if "Remember me" is ticked and `AUTH_TOKEN_EXPIRE` is set in .env 

*Longer description*

if `AUTH_TOKEN_EXPIRE` is set in .env, and "Remember me" is ticked on login, IXP Manager crashes with 500 error:

```
2026-07-23T10:36:52.406531+01:00 ixpmanager i-x-p-manager[114591]: [2026-07-23 10:36:52] production.ERROR: Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given, called in /srv/ixpmanager-v7.3.1/vendor/nesbot/carbon/src/Carbon/Traits/Units.php on line 376 {"userId":2,"exception":"[object] (TypeError(code: 0): Carbon\\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given, called in /srv/ixpmanager-v7.3.1/vendor/nesbot/carbon/src/Carbon/Traits/Units.php on line 376 at /srv/ixpmanager-v7.3.1/vendor/nesbot/carbon/src/Carbon/Traits/Units.php:556)
2026-07-23T10:36:52.407691+01:00 ixpmanager i-x-p-manager[114591]: [stacktrace]
2026-07-23T10:36:52.407855+01:00 ixpmanager i-x-p-manager[114591]: #0 /srv/ixpmanager-v7.3.1/vendor/nesbot/carbon/src/Carbon/Traits/Units.php(376): Carbon\\Carbon::rawAddUnit()
2026-07-23T10:36:52.408055+01:00 ixpmanager i-x-p-manager[114591]: #1 /srv/ixpmanager-v7.3.1/vendor/nesbot/carbon/src/Carbon/Traits/Date.php(2975): Carbon\\Carbon->addUnit()
2026-07-23T10:36:52.408188+01:00 ixpmanager i-x-p-manager[114591]: #2 /srv/ixpmanager-v7.3.1/vendor/nesbot/carbon/src/Carbon/Traits/Date.php(2658): Carbon\\Carbon->callModifierMethod()
2026-07-23T10:36:52.408310+01:00 ixpmanager i-x-p-manager[114591]: #3 /srv/ixpmanager-v7.3.1/app/Services/Auth/EloquentUserProvider.php(118): Carbon\\Carbon->__call()
2026-07-23T10:36:52.408477+01:00 ixpmanager i-x-p-manager[114591]: #4 /srv/ixpmanager-v7.3.1/app/Services/Auth/SessionGuard.php(159): IXP\\Services\\Auth\\EloquentUserProvider->addRememberToken()
[...]
```
It seems .env was being returned as a string when it's expecting an integer.

EloquentUserProvider.php:

```php
'expires'  => now()->addMinutes(config('auth.guards.web.expire', 60))
```

changed to:

```php
'expires'   => now()->addMinutes( (int) config('auth.guards.web.expire', 60) ),
```

In addition to the above, I have:

 - [x] ensured unit tests all run without error
 - [x] ran psalm and corrected any static analysis issues
 - [x] ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - [x] ensured appropriate checks against user privilege / resources accessed
 - [x] API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
