### PR TITLE
Revert recent changes to atlas migrations #1013

### DIFF
--- a/database/migrations/2021_03_30_124916_create_atlas_probes.php
+++ b/database/migrations/2021_03_30_124916_create_atlas_probes.php
@@ -14,7 +14,7 @@ class CreateAtlasProbes extends Migration
     public function up(): void
     {
         Schema::create('atlas_probes', function (Blueprint $table) {
-            $table->bigIncrements('id')->unsigned();
+            $table->bigIncrements('id')->unsigned(false);
             $table->integer('cust_id');
             $table->string('address_v4', 15)->nullable();
             $table->string('address_v6', 39)->nullable();

--- a/database/migrations/2021_03_30_125238_create_atlas_runs.php
+++ b/database/migrations/2021_03_30_125238_create_atlas_runs.php
@@ -14,7 +14,7 @@ class CreateAtlasRuns extends Migration
     public function up()
     {
         Schema::create('atlas_runs', function (Blueprint $table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id')->unsigned(false);
             $table->integer('vlan_id' )->nullable();
             $table->integer('protocol' )->nullable();
             $table->dateTime('scheduled_at' )->nullable();

--- a/database/migrations/2021_03_30_125422_create_atlas_measurements.php
+++ b/database/migrations/2021_03_30_125422_create_atlas_measurements.php
@@ -14,7 +14,7 @@ class CreateAtlasMeasurements extends Migration
     public function up()
     {
         Schema::create('atlas_measurements', function (Blueprint $table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id')->unsigned(false);
             $table->integer('run_id' );
             $table->integer('cust_source' )->nullable();
             $table->integer('cust_dest' )->nullable();

--- a/database/migrations/2021_03_30_125723_create_atlas_results.php
+++ b/database/migrations/2021_03_30_125723_create_atlas_results.php
@@ -14,7 +14,7 @@ class CreateAtlasResults extends Migration
     public function up()
     {
         Schema::create('atlas_results', function (Blueprint $table) {
-            $table->increments('id')->unsigned();
+            $table->increments('id')->unsigned(false);
             $table->integer('measurement_id' )->nullable()->unique();
             $table->string('routing', 255)->nullable();
             $table->longText('path' )->nullable();


### PR DESCRIPTION
The unsigned(false) call was there to undo the fact that increments() creates an UNSIGNED INT column, making it just an INT. (for some reason, who knows why)

So the recent deleting the parameter was not a no-op. (the `unsigned` method didn't have any documented args and relied on __call magic)

https://github.com/laravel/framework/blob/12.x/src/Illuminate/Support/Fluent.php#L305


