### PR TITLE
Follow up to disabling per-VLAN-interface max prefixes setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,7 +141,6 @@ IXP_AS112_UI_ACTIVE=false
 # See: https://docs.ixpmanager.org/latest/usage/customers/#customer-logos
 IXP_FE_FRONTEND_DISABLED_LOGO=false
 
-
 # Send email notifications when a customer's billing details are updated.
 # See: https://docs.ixpmanager.org/latest/usage/customers/#notification-of-billing-details-changed
 # IXP_FE_CUSTOMER_BILLING_UPDATES_NOTIFY="mail@example.com"
@@ -152,6 +151,25 @@ IXP_FE_FRONTEND_DISABLED_LOGO=false
 
 # Enable the UI for route server community-based filtering by uncommenting this line:
 # IXP_FE_FRONTEND_DISABLED_RS_FILTERS=false
+
+# Enable/Disable per-VLAN-interface maximum prefix configuration.
+# If you only operate a single peering LAN / infrastructure in
+# a single geographic location, you may want to disable
+# per-VLAN interface maximum prefix setting and use only the global
+# max prefix settings for each member.
+#
+# Setting this to false disables editing in the frontend. It does not disable
+# the per-VLAN interface max prefix logic if a value is set in the database.
+#
+# Before disabling, ensure all existing per-VLAN max prefixes have been checked
+# and the global max prefix updated if needed before clearing all
+# per-VLAN-interface max prefix settings.
+#
+# Run: php ./artisan update:max-prefixes-7.1.0
+#
+
+IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED=true
+
 
 #######################################################################################
 ### Graphing - see https://docs.ixpmanager.org/latest/grapher/introduction

--- a/.env.example
+++ b/.env.example
@@ -152,23 +152,9 @@ IXP_FE_FRONTEND_DISABLED_LOGO=false
 # Enable the UI for route server community-based filtering by uncommenting this line:
 # IXP_FE_FRONTEND_DISABLED_RS_FILTERS=false
 
-# Enable/Disable per-VLAN-interface maximum prefix configuration.
-# If you only operate a single peering LAN / infrastructure in
-# a single geographic location, you may want to disable
-# per-VLAN interface maximum prefix setting and use only the global
-# max prefix settings for each member.
-#
-# Setting this to false disables editing in the frontend. It does not disable
-# the per-VLAN interface max prefix logic if a value is set in the database.
-#
-# Before disabling, ensure all existing per-VLAN max prefixes have been checked
-# and the global max prefix updated if needed before clearing all
-# per-VLAN-interface max prefix settings.
-#
-# Run: php ./artisan update:max-prefixes-7.1.0
-#
-
-IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED=true
+# Enable/Disable per-VLAN-interface maximum prefix configuration. (Default is enabled)
+# See: https://docs.ixpmanager.org/latest/usage/interfaces/#ipv4ipv6-details
+# IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED=true
 
 
 #######################################################################################

--- a/app/Console/Commands/Customer/UpdateGlobalMaxPrefixes.php
+++ b/app/Console/Commands/Customer/UpdateGlobalMaxPrefixes.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Copyright (C) 2009 - 2025 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+declare(strict_types=1);
+
+namespace IXP\Console\Commands\Customer;
+
+use IXP\Console\Commands\Upgrade\MaxPrefixes_7_1_0;
+
+/**
+ * Tool to update customer global max prefixes based on values from
+ * vlaninterfaces ipv4maxbgpprefix and ipv6maxbgpprefix settings.
+ * The corresponding VLAN interfaces setting will then be cleared.
+ *
+ * Alias of `update:max-prefixes-7.1.0`
+ */
+class UpdateGlobalMaxPrefixes extends MaxPrefixes_7_1_0
+{
+    protected $signature = 'customer:update-global-max-prefixes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This tool guides an operator through updating a customers global max prefixes ' .
+        'setting to reflect any per VLAN max prefixes overrides, and then clears the per VLAN max prefixes override.';
+}

--- a/config/ixp_fe.php
+++ b/config/ixp_fe.php
@@ -282,6 +282,7 @@ return [
     */
     'vlaninterfaces' => [
         'hostname_required'  => env( 'IXP_FE_VLANINTERFACES_HOSTNAME_REQUIRED', true ),
+        'max_prefix_enabled' => env( 'IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED', true ),
     ],
 
     /*

--- a/config/ixp_fe_settings.php
+++ b/config/ixp_fe_settings.php
@@ -217,6 +217,21 @@ return [
                                         target="_blank">BGP detector</a> running.',
                 ],
 
+                'vlaninterfaces-max-prefix-enabled' => [
+                    'config_key' => 'ixp_fe.vlaninterfaces.max_prefix_enabled',
+                    'dotenv_key' => 'IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED',
+                    'type'       => 'radio',
+                    'invert'     => false,
+                    'rules'      => 'boolean',
+                    'name'       => 'Per-VLAN Interface Maximum Prefixes',
+                    'docs_url'   => null,
+                    'help'       => 'Allow maximum prefixes to be set per VLAN interface.
+                                        If you only operate a single peering VLAN or infrastructure in one geographic location,
+                                        you may want to disable this and only use the global maximum prefix settings for each
+                                        member. Before disabling, run <code>php ./artisan update:max-prefixes-7.1.0</code>',
+                ],
+
+
                 'phpinfo'                   => [
                     'config_key' => 'ixp_fe.frontend.disabled.phpinfo',
                     'dotenv_key' => 'IXP_FE_FRONTEND_DISABLED_PHPINFO',

--- a/config/ixp_fe_settings.php
+++ b/config/ixp_fe_settings.php
@@ -228,7 +228,7 @@ return [
                     'help'       => 'Allow maximum prefixes to be set per VLAN interface.
                                         If you only operate a single peering VLAN or infrastructure in one geographic location,
                                         you may want to disable this and only use the global maximum prefix settings for each
-                                        member. Before disabling, run <code>php ./artisan update:max-prefixes-7.1.0</code>',
+                                        member. Before disabling, run <code>php ./artisan customer:update-global-max-prefixes</code>',
                 ],
 
 

--- a/resources/views/interfaces/common/vli/ipv4.foil.php
+++ b/resources/views/interfaces/common/vli/ipv4.foil.php
@@ -32,6 +32,10 @@
 
         <?= Former::number( 'ipv4maxbgpprefix' )
                 ->label( 'Max BGP Prefixes' )
+                ->disabled( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true ) )
+                ->title( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true )
+                    ? 'Per VLAN interface max. prefix disabled. Update via Edit ' . ucfirst(config( 'ixp_fe.lang.customer.one' )) . ' Details page.'
+                    : null )
                 ->blockHelp( 'The maximum IPv4 prefixes that any router configured via IXP Manager should accept for this endpoint. '
                         . 'See <a href="https://docs.ixpmanager.org/latest/usage/customers/#peering-details">the official documentation</a> for more details.' );
         ?>

--- a/resources/views/interfaces/common/vli/ipv4.foil.php
+++ b/resources/views/interfaces/common/vli/ipv4.foil.php
@@ -30,15 +30,14 @@
             ->blockHelp( 'MD5 secret for route server / collector / AS112 BGP sessions. If supported by your browser, it can be generated in a cryptographically secure manner by clicking the <em>refresh</em> button.' );
         ?>
 
-        <?= Former::number( 'ipv4maxbgpprefix' )
-                ->label( 'Max BGP Prefixes' )
-                ->disabled( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true ) )
-                ->title( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true )
-                    ? 'Per VLAN interface max. prefix disabled. Update via Edit ' . ucfirst(config( 'ixp_fe.lang.customer.one' )) . ' Details page.'
-                    : null )
-                ->blockHelp( 'The maximum IPv4 prefixes that any router configured via IXP Manager should accept for this endpoint. '
-                        . 'See <a href="https://docs.ixpmanager.org/latest/usage/customers/#peering-details">the official documentation</a> for more details.' );
-        ?>
+        <?php if( config('ixp_fe.vlaninterfaces.max_prefix_enabled') || ( $t->vli && $t->vli->ipv4maxbgpprefix ) ): ?>
+            <?= Former::number( 'ipv4maxbgpprefix' )
+                    ->label( 'Max BGP Prefixes' )
+                    ->title( 'Per VLAN interface max. prefix disabled. Update via Edit ' . ucfirst(config( 'ixp_fe.lang.customer.one' )) . ' Details page.' )
+                    ->blockHelp( 'The maximum IPv4 prefixes that any router configured via IXP Manager should accept for this endpoint. '
+                            . 'See <a href="https://docs.ixpmanager.org/latest/usage/customers/#peering-details">the official documentation</a> for more details.' );
+            ?>
+        <?php endif; ?>
 
         <?= Former::checkbox( 'ipv4canping' )
             ->label( '&nbsp;' )

--- a/resources/views/interfaces/common/vli/ipv6.foil.php
+++ b/resources/views/interfaces/common/vli/ipv6.foil.php
@@ -32,6 +32,10 @@
 
         <?= Former::number( 'ipv6maxbgpprefix' )
                 ->label( 'Max BGP Prefixes' )
+                ->disabled( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true ) )
+                ->title( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true )
+                    ? 'Per VLAN interface max. prefix disabled. Update via Edit ' . ucfirst(config( 'ixp_fe.lang.customer.one' )) . ' Details page.'
+                    : null )
                 ->blockHelp( 'The maximum IPv6 prefixes that any router configured via IXP Manager should accept for this endpoint. '
                         . 'See <a href="https://docs.ixpmanager.org/latest/usage/customers/#peering-details">the official documentation</a> for more details.' );
         ?>

--- a/resources/views/interfaces/common/vli/ipv6.foil.php
+++ b/resources/views/interfaces/common/vli/ipv6.foil.php
@@ -30,15 +30,14 @@
             ->blockHelp( 'MD5 secret for route server / collector / AS112 BGP sessions. Can be copied from the IPv4 version if set or (if supported by your browser), it can be generated in a cryptographically secure manner by clicking the <em>refresh</em> button.' );
         ?>
 
-        <?= Former::number( 'ipv6maxbgpprefix' )
-                ->label( 'Max BGP Prefixes' )
-                ->disabled( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true ) )
-                ->title( !config( 'ixp_fe.vlaninterfaces.max_prefix_enabled', true )
-                    ? 'Per VLAN interface max. prefix disabled. Update via Edit ' . ucfirst(config( 'ixp_fe.lang.customer.one' )) . ' Details page.'
-                    : null )
-                ->blockHelp( 'The maximum IPv6 prefixes that any router configured via IXP Manager should accept for this endpoint. '
-                        . 'See <a href="https://docs.ixpmanager.org/latest/usage/customers/#peering-details">the official documentation</a> for more details.' );
-        ?>
+        <?php if( config('ixp_fe.vlaninterfaces.max_prefix_enabled') || ( $t->vli && $t->vli->ipv6maxbgpprefix ) ): ?>
+            <?= Former::number( 'ipv6maxbgpprefix' )
+                    ->label( 'Max BGP Prefixes' )
+                    ->title( 'Per VLAN interface max. prefix disabled. Update via Edit ' . ucfirst(config( 'ixp_fe.lang.customer.one' )) . ' Details page.' )
+                    ->blockHelp( 'The maximum IPv6 prefixes that any router configured via IXP Manager should accept for this endpoint. '
+                            . 'See <a href="https://docs.ixpmanager.org/latest/usage/customers/#peering-details">the official documentation</a> for more details.' );
+            ?>
+        <?php endif; ?>
 
         <?= Former::checkbox( 'ipv6canping' )
             ->label( '&nbsp;' )

--- a/tests/Browser/VirtualInterfaceControllerTest.php
+++ b/tests/Browser/VirtualInterfaceControllerTest.php
@@ -780,4 +780,173 @@ class VirtualInterfaceControllerTest extends DuskTestCase
                 ->assertSee( 'VLAN Interface deleted' );
 
     }
+
+    /**
+     * Test VLI add/edit when the max prefix override is disabled
+     *
+     * @return void
+     */
+    public function testDisabledMaxPrefixesPerVlan(): void
+    {
+        // Disable per-VLAN max prefixes override for the test.
+        // Removes UI elements on create and edit, unless the
+        // VLI being edited has the setting set, then it'll be shown
+        $this->overrideEnv( [ "IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED" => 'false' ] );
+        sleep(1);
+
+        $this->browse( function ( Browser $browser ) {
+            $browser->resize( 1600, 1200 )
+                ->visit('/logout' )
+                ->visit('/login' )
+                ->type('username', 'travis' )
+                ->type('password', 'travisci' )
+                ->press('#login-btn' )
+                ->waitForLocation('/admin/dashboard' );
+
+            $browser->visit( route( 'virtual-interface@create-wizard-for-cust', 5 ) )
+                ->assertSee('Virtual Interface Settings' );
+
+            // Create a new Virtual interface Via wizard form - are the fields there?
+            $browser->select('vlanid',  '2' )
+                ->check( 'ipv4enabled' )
+                ->waitFor( "#ipv4-area" )
+                ->check( 'ipv6enabled' )
+                ->waitFor( "#ipv6-area" )
+                ->assertNotPresent( "#ipv6maxbgpprefix") //   <--
+                ->assertNotPresent( "#ipv4maxbgpprefix") //   <--
+                ->select( 'switch', '2' )
+                ->waitUntilMissing( "Choose a switch port" )
+                ->waitForText( "Choose a switch port" )
+                ->select( 'switchportid','28'    )
+                ->select( 'status',     '4'     )
+                ->select( 'speed',      '1000'  )
+                ->select( 'duplex',     'full'  )
+                ->check( 'rsclient'     )
+                ->check( 'irrdbfilter'  )
+                ->check( 'as112client'  )
+                ->select( 'ipv4address',   '10.2.0.22'         )
+                ->select( 'ipv6address',   '2001:db8:2::22'    )
+                ->type( 'ipv4hostname',    'v4.example.com'    )
+                ->type( 'ipv6hostname',    'v6.example.com'    )
+                ->type( 'ipv4bgpmd5secret', 'soopersecret'   )
+                ->type( 'ipv6bgpmd5secret', 'soopersecret'   )
+                ->check( 'ipv4canping'        )
+                ->check( 'ipv6canping'        )
+                ->check( 'ipv4monitorrcbgp'   )
+                ->check( 'ipv6monitorrcbgp'        )
+                ->press( 'Create' )
+                ->waitForText('Virtual interface created', 10000 );
+
+            $url = explode( '/', $browser->driver->getCurrentURL() );
+
+            /** @var $vi VirtualInterface */
+            $this->assertInstanceOf( VirtualInterface::class , $vi = VirtualInterface::find( array_pop( $url ) ) );
+            $firstVli = $vi->vlanInterfaces()->latest()->firstOrFail();
+            $this->assertNull($firstVli->ipv6maxbgpprefix);
+            $this->assertNull($firstVli->ipv4maxbgpprefix);
+
+            // Create a new vlan interface form - the fields are not on that form either
+            $browser->visit( route( 'virtual-interface@edit', $vi->id ) )
+                ->click( "#add-vli" )
+                ->waitForLocation( route( 'vlan-interface@create', $vi->id ) );
+
+            $browser->select('vlanid',  '2' )
+                ->check( "mcastenabled"     )
+                ->check( "busyhost"         )
+                ->check( "rsclient"         )
+                ->check( 'irrdbfilter'      )
+                ->check( 'rsmorespecifics'  )
+                ->check( 'ipv6enabled'     )
+                ->waitFor( "#ipv6-area"  )
+                ->check( 'ipv4enabled'     )
+                ->waitFor( "#ipv4-area")
+                ->select( 'ipv4address', "10.2.0.1"        )
+                ->select( 'ipv6address', '2001:db8:2::1'   )
+                ->type( 'ipv4hostname', 'v4.example.com'   )
+                ->type( 'ipv6hostname', 'v6.example.com'   )
+                ->type( 'ipv4bgpmd5secret', 'soopersecret' )
+                ->type( 'ipv6bgpmd5secret', 'soopersecret' )
+                ->check( 'ipv4canping' )
+                ->check( 'ipv6canping' )
+                ->check( 'ipv4monitorrcbgp' )
+                ->check( 'ipv6monitorrcbgp' )
+                ->assertNotPresent( "#ipv6maxbgpprefix") //  <--
+                ->assertNotPresent( "#ipv4maxbgpprefix") //  <--
+                ->press('Create')
+                ->waitForLocation( route( 'virtual-interface@edit', $vi->id ) )
+                ->assertSee('VLAN Interface created.');
+
+            $newVli = $vi->vlanInterfaces()->latest()->firstOrFail();
+            $this->assertNull($newVli->ipv6maxbgpprefix);
+            $this->assertNull($newVli->ipv4maxbgpprefix);
+
+            // Edit VLAN interface - neither field should be present as their values are null
+            $browser->click( "#edit-vli-" . $newVli->id )
+                ->waitForLocation( route( 'vlan-interface@edit-from-virtual-interface', [ 'vli' => $newVli->id,  'vi' => $vi->id ] ) )
+                ->assertSee( "Edit VLAN Interface" )
+                ->assertChecked('ipv4enabled')
+                ->assertChecked('ipv6enabled')
+                ->assertNotPresent( "#ipv6maxbgpprefix")     // <--
+                ->assertNotPresent( "#ipv4maxbgpprefix")     // <--
+                ->press('Save Changes')
+                ->waitForLocation( route( 'virtual-interface@edit', $vi->id ) )
+                ->assertSee('VLAN Interface updated');
+
+            $newVli->refresh();
+            $this->assertNull($newVli->ipv6maxbgpprefix);
+            $this->assertNull($newVli->ipv4maxbgpprefix);
+
+            $newVli->ipv4maxbgpprefix = 1024;
+            $newVli->ipv6maxbgpprefix = 2048;
+            $newVli->save();
+
+            // Edit VLAN interface - both settings have values so their fields should appear even though feature 'disabled'
+            $browser->click( "#edit-vli-" . $newVli->id )
+                ->waitForLocation( route( 'vlan-interface@edit-from-virtual-interface', [ 'vli' => $newVli->id,  'vi' => $vi->id ] ) )
+                ->assertSee( "Edit VLAN Interface" )
+                ->assertChecked('ipv4enabled')
+                ->assertChecked('ipv6enabled')
+                ->assertPresent( "#ipv6maxbgpprefix")      // <--
+                ->assertPresent( "#ipv4maxbgpprefix");     // <--
+
+            // values on the form match those in the database
+            $this->assertEquals(1024, $browser->element('input[name=ipv4maxbgpprefix]')->getAttribute('value'));
+            $this->assertEquals(2048, $browser->element('input[name=ipv6maxbgpprefix]')->getAttribute('value'));
+
+            $browser
+                ->type( 'ipv4maxbgpprefix', '100' )    // this changes the ipv4 max bgp prefix
+                ->type( 'ipv6maxbgpprefix', '' )       // this removes the ipv6 max bgp prefix setting
+                ->press('Save Changes')
+                ->waitForLocation( route( 'virtual-interface@edit', $vi->id ) )
+                ->assertSee('VLAN Interface updated');
+
+            // check database to make sure the form submission took effect
+            $newVli->refresh();
+            $this->assertEquals(100, $newVli->ipv4maxbgpprefix);
+            $this->assertNull($newVli->ipv6maxbgpprefix);
+
+            // Check the Edit Virtual Interface form - check the ipv6 field is gone as we just unset it
+            $browser->click( "#edit-vli-" . $newVli->id )
+                ->waitForLocation( route( 'vlan-interface@edit-from-virtual-interface', [ 'vli' => $newVli->id,  'vi' => $vi->id ] ) )
+                ->assertSee( "Edit VLAN Interface" )
+                ->assertPresent( "#ipv4maxbgpprefix")         // <--
+                ->assertNotPresent( "#ipv6maxbgpprefix");     // <--
+
+            // check form field matches the new value
+            $this->assertEquals(100, $browser->element('input[name=ipv4maxbgpprefix]')->getAttribute('value'));
+
+            // Delete Virtual interface
+            $browser->visit( route( 'virtual-interface@edit', $vi->id ) )
+                ->assertSee('Edit Virtual Interface');
+
+            $browser->press('#advanced-options')
+                ->waitForText('Delete Interface');
+
+            $browser->press( "#delete-vi-" . $vi->id )
+                ->waitForText( 'Do you really want to delete this Virtual Interface?' )
+                ->press( "Delete" )
+                ->waitForLocation( route( 'customer@overview', [ 'cust' => $vi->custid, 'tab' => 'ports' ] ) )
+                ->assertSee('Virtual interface deleted.' );
+        });
+    }
 }


### PR DESCRIPTION
Followup to https://github.com/inex/IXP-Manager/pull/1024

- Hides the fields on the edit form, unless they have a value, which can still be changed or even removed (in which case the fields will disappear)
- .env.example documents the feature and sends people to the docs. The url there will be correct as of next release, in the mean time it's https://docs.ixpmanager.org/dev/usage/interfaces/#ipv4ipv6-details
- Alias `customer:update-global-max-prefixes` to `update:max-prefixes-7.1.0` in case we decide to remove 7.1.0 upgrade scripts, it lives on under a different name
- Test the vlan edit form under the different cases, and that the create form doesn't have the fields when this feature is active

Rebased over master