### PR TITLE
Extract methods for recording logins (CustomerToUser and UserLoginHistory), and remove fillable columns

### DIFF
--- a/app/Console/Commands/SetupWizard.php
+++ b/app/Console/Commands/SetupWizard.php
@@ -245,11 +245,12 @@ class SetupWizard extends Command
             $user->email = $data['admin-email'];
             $user->save();
 
-            CustomerToUser::create( [
-                'customer_id' => $cust->id,
-                'user_id'     => $user->id,
-                'privs'       => User::AUTH_SUPERUSER,
-            ] );
+
+            $c2u = new CustomerToUser();
+            $c2u->customer_id = $cust->id;
+            $c2u->user_id = $user->id;
+            $c2u->privs = User::AUTH_SUPERUSER;
+            $c2u->save();
 
             DB::commit();
 

--- a/app/Console/Commands/SetupWizard.php
+++ b/app/Console/Commands/SetupWizard.php
@@ -250,6 +250,7 @@ class SetupWizard extends Command
             $c2u->customer_id = $cust->id;
             $c2u->user_id = $user->id;
             $c2u->privs = User::AUTH_SUPERUSER;
+            $c2u->extra_attributes = [ "created_by" => [ "type" => "artisan" , "user_id" => $user->id ] ];
             $c2u->save();
 
             DB::commit();

--- a/app/Http/Controllers/Auth/SwitchCustomerController.php
+++ b/app/Http/Controllers/Auth/SwitchCustomerController.php
@@ -27,6 +27,8 @@ use Auth;
 
 use Illuminate\Http\RedirectResponse;
 
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use IXP\Http\Controllers\Controller;
 
 use IXP\Models\{
@@ -76,14 +78,19 @@ class SwitchCustomerController extends Controller
         }
 
         $ip = $this->getIp();
-        $c2u->updateLastLoginInfo( $ip, 'SwitchCustomer' );
+        $oldCustomer = $user->customer;
+        DB::transaction( function () use ( $c2u, $user, $cust, $ip ) {
+            $c2u->updateLastLoginInfo( $ip, 'SwitchCustomer' );
 
-        if( config( "ixp_fe.login_history.enabled" ) ) {
-            UserLoginHistory::recordLogin( $c2u, $ip, 'SwitchCustomer' );
-        }
+            if( config( "ixp_fe.login_history.enabled" ) ) {
+                UserLoginHistory::recordLogin( $c2u, $ip, 'SwitchCustomer' );
+            }
 
-        $user->custid = $cust->id;
-        $user->save();
+            $user->custid = $cust->id;
+            $user->save();
+        });
+
+        Log::notice( Auth::getUser()->username . '(' . Auth::getUser()->name . ') has changed customer from  ' . $oldCustomer->name . ' to ' . $cust->name  );
 
         AlertContainer::push( "You are now logged in for {$cust->name}.", Alert::SUCCESS );
         return redirect()->to( "/" );

--- a/app/Http/Controllers/Auth/SwitchCustomerController.php
+++ b/app/Http/Controllers/Auth/SwitchCustomerController.php
@@ -64,29 +64,22 @@ class SwitchCustomerController extends Controller
         $user = Auth::getUser();
 
         // Check if the selected customer is associated with the current user
-         if( !( $c2u = CustomerToUser::where( 'customer_id', $cust->id )->where( 'user_id', $user->id )->first() ) ){
+        if( !( $c2u = CustomerToUser::where( 'customer_id', $cust->id )->where( 'user_id', $user->id )->first() ) ){
             AlertContainer::push( "You are not allowed to access to this " . config( "ixp_fe.lang.customer.one" ) . ".", Alert::DANGER );
             return redirect()->to( "/" );
         }
 
-         // Check if the selected customer is active
+        // Check if the selected customer is active
         if( $c2u->customer()->active()->notDeleted()->get()->isEmpty() ){
             AlertContainer::push( "You are not allowed to access to this " . config( "ixp_fe.lang.customer.one" ) . ".", Alert::DANGER );
             return redirect()->to( "/" );
         }
 
-        $c2u->update([
-            'last_login_date' => now(),
-            'last_login_from' => $this->getIp(),
-        ]);
+        $ip = $this->getIp();
+        $c2u->updateLastLoginInfo( $ip, 'SwitchCustomer' );
 
         if( config( "ixp_fe.login_history.enabled" ) ) {
-            UserLoginHistory::create( [
-                'ip'                    => $this->getIp(),
-                'at'                    => now(),
-                'customer_to_user_id'   => $c2u->id,
-                'via'                   => 'SwitchCustomer'
-            ] );
+            UserLoginHistory::recordLogin( $c2u, $ip, 'SwitchCustomer' );
         }
 
         $user->custid = $cust->id;

--- a/app/Listeners/Auth/LoginSuccessful.php
+++ b/app/Listeners/Auth/LoginSuccessful.php
@@ -54,19 +54,12 @@ class LoginSuccessful
         Log::notice( 'Login successful for user "' . $user->username. '" from IP ' . ixp_get_client_ip() . '.' );
 
         if( !session()->exists( "switched_user_from" ) && ( $c2u = $user->currentCustomerToUser ) ) {
-            $c2u->update( [
-                'last_login_date'   => now(),
-                'last_login_from'   => ixp_get_client_ip(),
-                'last_login_via'    => Auth::viaRemember() ?  'RememberMe' : 'Login',
-            ] );
+            $ip = ixp_get_client_ip();
+            $via = Auth::viaRemember() ? 'RememberMe' : 'Login';
+            $c2u->updateLastLoginInfo( $ip, $via );
 
             if( config( "ixp_fe.login_history.enabled" ) ) {
-                UserLoginHistory::create( [
-                    'ip'                    => ixp_get_client_ip(),
-                    'at'                    => now(),
-                    'via'                   => Auth::viaRemember() ?  'RememberMe' : 'Login',
-                    'customer_to_user_id'   => $c2u->id,
-                ] );
+                UserLoginHistory::recordLogin( $c2u, $ip, $via );
             }
         }
     }

--- a/app/Models/Aggregators/UserAggregator.php
+++ b/app/Models/Aggregators/UserAggregator.php
@@ -252,12 +252,12 @@ class UserAggregator extends User
                     continue;
                 }
 
-                $c2u = CustomerToUser::create([
-                    'customer_id'       => $cust->id,
-                    'user_id'           => $user->id,
-                    'privs'             => $priv,
-                    'extra_attributes'  => [ "created_by" => [ "type" => "PeeringDB"  ] ],
-                ]);
+                $c2u = new CustomerToUser();
+                $c2u->customer_id = $cust->id;
+                $c2u->user_id = $user->id;
+                $c2u->privs = $priv;
+                $c2u->extra_attributes = [ "created_by" => [ "type" => "PeeringDB"  ] ];
+                $c2u->save();
 
                 $result['added_to'][] = $c2u->customer;
                 Log::info( 'PeeringDB OAuth: user ' . $user->id . '/' . $user->username . ' linked with with ' . $cust->getFormattedName() );

--- a/app/Models/CustomerToUser.php
+++ b/app/Models/CustomerToUser.php
@@ -144,6 +144,14 @@ class CustomerToUser extends Model
         return $query->where('privs', User::AUTH_CUSTADMIN );
     }
 
+    public function updateLastLoginInfo( string $ip, string $via ): bool
+    {
+        $this->last_login_date = now();
+        $this->last_login_from = $ip;
+        $this->last_login_via = $via;
+        return $this->save();
+    }
+
     /**
      * String to describe the model being updated / deleted / created
      *

--- a/app/Models/CustomerToUser.php
+++ b/app/Models/CustomerToUser.php
@@ -68,20 +68,6 @@ use IXP\Traits\Observable;
 class CustomerToUser extends Model
 {
     use Observable;
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
-    protected $fillable = [
-        'customer_id',
-        'user_id',
-        'privs',
-        'extra_attributes',
-        'last_login_date',
-        'last_login_from',
-        'last_login_via',
-    ];
 
     /**
      * The attributes that should be cast.

--- a/app/Models/CustomerToUser.php
+++ b/app/Models/CustomerToUser.php
@@ -130,6 +130,10 @@ class CustomerToUser extends Model
         return $query->where('privs', User::AUTH_CUSTADMIN );
     }
 
+    /**
+     * Called during a login or a switch customer operation to reflect the last time
+     * the customer account was accessed, and how
+     */
     public function updateLastLoginInfo( string $ip, string $via ): bool
     {
         $this->last_login_date = now();

--- a/app/Models/UserLoginHistory.php
+++ b/app/Models/UserLoginHistory.php
@@ -1,7 +1,4 @@
 <?php
-
-namespace IXP\Models;
-
 /*
  * Copyright (C) 2009 - 2021 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
@@ -22,6 +19,10 @@ namespace IXP\Models;
  *
  * http://www.gnu.org/licenses/gpl-2.0.html
  */
+
+declare(strict_types=1);
+
+namespace IXP\Models;
 
 use Illuminate\Database\Eloquent\{
     Builder,
@@ -62,18 +63,6 @@ class UserLoginHistory extends Model
      * @var string
      */
     protected $table = 'user_logins';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
-    protected $fillable = [
-        'ip',
-        'at',
-        'customer_to_user_id',
-        'via',
-    ];
 
     /**
      * Get the customer to user

--- a/app/Models/UserLoginHistory.php
+++ b/app/Models/UserLoginHistory.php
@@ -84,4 +84,15 @@ class UserLoginHistory extends Model
     {
         return $this->belongsTo(CustomerToUser::class, 'customer_to_user_id');
     }
+
+    public static function recordLogin( CustomerToUser $c2u, string $ip, string $via ): self
+    {
+        $loginHistory = new self();
+        $loginHistory->customer_to_user_id = $c2u->id;
+        $loginHistory->ip = $ip;
+        $loginHistory->via = $via;
+        $loginHistory->at = now();
+        $loginHistory->save();
+        return $loginHistory;
+    }
 }

--- a/tests/Api/PublicControllerTest.php
+++ b/tests/Api/PublicControllerTest.php
@@ -30,7 +30,7 @@ class PublicControllerTest extends TestCase
         $this->user->custid = $this->customer->id;
         $this->user->save();
 
-        $this->c2u = $this->user->customerToUser()->create( [
+        $this->c2u = $this->user->customerToUser()->forceCreate( [
             'customer_id' => $this->customer->id ,
             'privs' => User::AUTH_CUSTUSER,
         ] );

--- a/tests/Http/Controllers/ApiKeyControllerTest.php
+++ b/tests/Http/Controllers/ApiKeyControllerTest.php
@@ -43,7 +43,7 @@ class ApiKeyControllerTest extends TestCase
         $user1->username = "API Test User";
         $user1->custid = $customer->id;
         $user1->save();
-        $user1->customerToUser()->create( [
+        $user1->customerToUser()->forceCreate( [
             'customer_id' => $customer->id,
             'privs'       => User::AUTH_CUSTADMIN
         ] );
@@ -52,7 +52,7 @@ class ApiKeyControllerTest extends TestCase
         $user2->username = "API Test User 2";
         $user2->custid = $customer->id;
         $user2->save();
-        $user2->customerToUser()->create( [
+        $user2->customerToUser()->forceCreate( [
             'customer_id' => $customer->id,
             'privs'       => User::AUTH_CUSTADMIN
         ] );

--- a/tests/Http/Controllers/AppPasswordTest.php
+++ b/tests/Http/Controllers/AppPasswordTest.php
@@ -44,7 +44,7 @@ class AppPasswordTest extends TestCase
         $user1->username = "App Password Test User";
         $user1->custid = $customer->id;
         $user1->save();
-        $user1->customerToUser()->create( [
+        $user1->customerToUser()->forceCreate( [
             'customer_id' => $customer->id,
             'privs'       => User::AUTH_SUPERUSER
         ] );
@@ -53,7 +53,7 @@ class AppPasswordTest extends TestCase
         $user2->username = "App Password Test User 2";
         $user2->custid = $customer->id;
         $user2->save();
-        $user2->customerToUser()->create( [
+        $user2->customerToUser()->forceCreate( [
             'customer_id' => $customer->id,
             'privs'       => User::AUTH_SUPERUSER
         ] );

--- a/tests/Http/Controllers/Irrdb/IrrdbControllerTest.php
+++ b/tests/Http/Controllers/Irrdb/IrrdbControllerTest.php
@@ -57,7 +57,7 @@ class IrrdbControllerTest extends TestCase
         $this->user = User::create();
         $this->user->custid = $this->customer->id;
         $this->user->save();
-        $this->cust2User = CustomerToUser::create([
+        $this->cust2User = CustomerToUser::forceCreate([
             'user_id' => $this->user->id,
             'customer_id' => $this->customer->id,
             'privs' => User::AUTH_CUSTUSER,

--- a/tests/Http/Controllers/User/CustomerToUser/UpdatePrivsTest.php
+++ b/tests/Http/Controllers/User/CustomerToUser/UpdatePrivsTest.php
@@ -65,7 +65,7 @@ class UpdatePrivsTest extends TestCase
     public function testChangeExternalFromCustAdminToCustUser()
     {
         // Associate with external Customer
-        $this->c2u = $this->user->customerToUser()->create( [
+        $this->c2u = $this->user->customerToUser()->forceCreate( [
             'customer_id' => $this->externalCustomer->id,
             'privs'       => User::AUTH_CUSTADMIN
         ] );
@@ -98,7 +98,7 @@ class UpdatePrivsTest extends TestCase
     public function testChangeExternalFromCustUserToCustAdmin()
     {
         // Associate with external Customer
-        $this->c2u = $this->user->customerToUser()->create( [
+        $this->c2u = $this->user->customerToUser()->forceCreate( [
             'customer_id' => $this->externalCustomer->id,
             'privs'       => User::AUTH_CUSTUSER,
         ] );
@@ -131,7 +131,7 @@ class UpdatePrivsTest extends TestCase
     public function testExternalCustomerCannotHaveSuperUser()
     {
         // Associate with external Customer
-        $this->c2u = $this->user->customerToUser()->create( [
+        $this->c2u = $this->user->customerToUser()->forceCreate( [
             'customer_id' => $this->externalCustomer->id ,
             'privs' => User::AUTH_CUSTUSER,
         ] );
@@ -160,7 +160,7 @@ class UpdatePrivsTest extends TestCase
     public function testInternalPromoteToSuperUser()
     {
         // Associate with the internal Customer
-        $this->c2uInternal = $this->user->customerToUser()->create( [
+        $this->c2uInternal = $this->user->customerToUser()->forceCreate( [
             'customer_id' => $this->internalCustomer->id ,
             'privs' => User::AUTH_CUSTUSER,
         ] );
@@ -193,7 +193,7 @@ class UpdatePrivsTest extends TestCase
     public function testInternalRemoveSuperUser(): void
     {
         // Associate with the internal Customer
-        $this->c2uInternal = $this->user->customerToUser()->create( [
+        $this->c2uInternal = $this->user->customerToUser()->forceCreate( [
             'customer_id' => $this->internalCustomer->id ,
             'privs' => User::AUTH_SUPERUSER,
         ] );
@@ -229,7 +229,7 @@ class UpdatePrivsTest extends TestCase
     public function testCannotRemoveOnlySuperUser()
     {
         // Associate with the internal Customer
-        $this->c2uInternal = $this->user->customerToUser()->create( [
+        $this->c2uInternal = $this->user->customerToUser()->forceCreate( [
             'customer_id' => $this->internalCustomer->id ,
             'privs' => User::AUTH_SUPERUSER,
         ] );
@@ -263,7 +263,7 @@ class UpdatePrivsTest extends TestCase
         $this->secondaryUser->disabled = false;
         $this->secondaryUser->save();
 
-        $this->secondaryC2u = $this->secondaryUser->customerToUser()->create([
+        $this->secondaryC2u = $this->secondaryUser->customerToUser()->forceCreate([
             'customer_id' => $this->internalCustomer->id,
             'privs'       => User::AUTH_SUPERUSER,
         ] );
@@ -289,7 +289,7 @@ class UpdatePrivsTest extends TestCase
     public function testInvalidPrivsRejected()
     {
         // Associate with external Customer
-        $this->c2u = $this->user->customerToUser()->create( [
+        $this->c2u = $this->user->customerToUser()->forceCreate( [
             'customer_id' => $this->externalCustomer->id,
             'privs'       => User::AUTH_CUSTUSER,
         ] );

--- a/tests/Jobs/UpdateIrrdbTest.php
+++ b/tests/Jobs/UpdateIrrdbTest.php
@@ -40,7 +40,7 @@ class UpdateIrrdbTest extends TestCase
         $this->user = User::create();
         $this->user->custid = $this->customer->id;
         $this->user->save();
-        $this->cust2User = CustomerToUser::create([
+        $this->cust2User = CustomerToUser::forceCreate([
             'user_id' => $this->user->id,
             'customer_id' => $this->customer->id,
             'privs' => User::AUTH_CUSTUSER,

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -21,7 +21,7 @@ class UserModelTest extends TestCase
             'status' => Customer::STATUS_NORMAL,
             'type' => Customer::TYPE_FULL,
         ] );
-        $c2u1 = CustomerToUser::create( [
+        $c2u1 = CustomerToUser::forceCreate( [
             'user_id' => $user->id,
             'customer_id' => $customer1->id,
             'privs' => User::AUTH_CUSTADMIN,
@@ -33,7 +33,7 @@ class UserModelTest extends TestCase
             'status' => Customer::STATUS_NORMAL,
             'type' => Customer::TYPE_INTERNAL,
         ] );
-        $c2u2 = CustomerToUser::create( [
+        $c2u2 = CustomerToUser::forceCreate( [
             'user_id' => $user->id,
             'customer_id' => $customer2->id,
             'privs' => User::AUTH_SUPERUSER,


### PR DESCRIPTION
1. Extract code that updates `CustomerToUser` last login info, and that creates `UserLoginHistory` records into a method on each model. (see note below) Another bonus from this is we can remove the fillable columns from `UserLoginHistory`
1. `SetupWizard` & `UserAggregator`: rewrite `CustomerToUser::create()` call to instance creation instead. After this (and updating tests) we can remove all fillable columns from `CustomerToUser`

note for 1: 
This extract step would be 100% a move-only / no-new-side-effects operation, except `SwitchCustomerController` - which didn't update last_login_via on `CustomerToUser`. I'm not sure if that was on purpose.. but since we're updating `last_login_date` + `last_login_from`, doesn't feel incorrect to update `last_login_via` also
