### PR TITLE
Extract per test method .env file modification code into `ModifiesEnv` trait

### DIFF
--- a/tests/Browser/SettingsControllerTest.php
+++ b/tests/Browser/SettingsControllerTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Browser;
 
 /*
- * Copyright (C) 2009 - 2025 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * This file is part of IXP Manager.
@@ -26,6 +26,7 @@ namespace Tests\Browser;
 use Laravel\Dusk\Browser;
 
 use Tests\DuskTestCase;
+use Tests\Trait\ModifiesEnv;
 use Throwable;
 
 /**
@@ -39,7 +40,8 @@ use Throwable;
  */
 class SettingsControllerTest extends DuskTestCase
 {
-    
+    use ModifiesEnv;
+
     /**
      * The expected .env file contents before we go messing with it
      * @var string|null
@@ -47,33 +49,16 @@ class SettingsControllerTest extends DuskTestCase
     private ?string $test_env = null;
 
     /**
-     * The user's existing .env file that we want to preserve
-     * @var string|null
-     */
-    private ?string $user_env = null;
-
-
-    /**
      * @throws
      */
+    #[\Override]
     public function setUp(): void
     {
-        $this->user_env = file_get_contents( __DIR__ . '/../../.env' );
         $this->test_env = file_get_contents( __DIR__ . '/../../.env.ci' );
+        $this->overwriteEnvFile($this->test_env);
+        $this->awaitArtisanEnvReload();
 
-        file_put_contents( __DIR__ . '/../../.env', $this->test_env );
-        usleep( 1_000_000 );
         parent::setUp();
-    }
-
-    /**
-     * @throws
-     */
-    public function tearDown(): void
-    {
-        file_put_contents( __DIR__ . '/../../.env', $this->user_env );
-        usleep( 1_000_000 );
-        parent::tearDown();
     }
     
     /**

--- a/tests/Browser/User2FAControllerTest.php
+++ b/tests/Browser/User2FAControllerTest.php
@@ -29,6 +29,7 @@ use Laravel\Dusk\Browser;
 use PragmaRX\Google2FALaravel\Google2FA;
 
 use Tests\DuskTestCase;
+use Tests\Trait\ModifiesEnv;
 
 /**
  * Test User2FA Controller
@@ -42,29 +43,27 @@ use Tests\DuskTestCase;
  */
 class User2FAControllerTest extends DuskTestCase
 {
+    use ModifiesEnv;
 
-
+    #[\Override]
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->replaceEnvAttr( '2FA_ENFORCE_FOR_USERS="1"','2FA_ENFORCE_FOR_USERS="4"' );
-        $this->replaceEnvAttr( '2FA_ENABLED=false','2FA_ENABLED=true' );
+        $this->replaceEnvAttr( '2FA_ENFORCE_FOR_USERS="1"', '2FA_ENFORCE_FOR_USERS="4"' );
+        $this->replaceEnvAttr( '2FA_ENABLED=false', '2FA_ENABLED=true' );
         // changing the environment causes the server to restart
         // Environment modified. Restarting server...
-        sleep(2);
+        $this->awaitArtisanEnvReload();
 
     }
+
+    #[\Override]
     public function tearDown(): void
     {
         if( $u2fa = User2FA::whereUserId( 1 )->first() ) {
             $u2fa->delete();
         }
-
-        $this->replaceEnvAttr( '2FA_ENABLED=true','2FA_ENABLED=false' );
-        // changing the environment causes the server to restart
-        // Environment modified. Restarting server...
-        sleep(2);
 
         parent::tearDown();
     }

--- a/tests/Browser/VirtualInterfaceControllerTest.php
+++ b/tests/Browser/VirtualInterfaceControllerTest.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Tests\Browser;
-
 /*
- * Copyright (C) 2009 - 2025 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * This file is part of IXP Manager.
@@ -22,6 +19,10 @@ namespace Tests\Browser;
  *
  * http://www.gnu.org/licenses/gpl-2.0.html
  */
+declare(strict_types=1);
+
+namespace Tests\Browser;
+
 use IXP\Models\{
     PhysicalInterface,
     VirtualInterface,
@@ -31,6 +32,7 @@ use IXP\Models\{
 use Laravel\Dusk\Browser;
 
 use Tests\DuskTestCase;
+use Tests\Trait\ModifiesEnv;
 
 /**
  * Test Virtual interface Controller
@@ -44,6 +46,8 @@ use Tests\DuskTestCase;
  */
 class VirtualInterfaceControllerTest extends DuskTestCase
 {
+    use ModifiesEnv;
+
     /**
      * Test the whole Interfaces functionalities (virtuel, physical, vlan)
      *
@@ -792,7 +796,7 @@ class VirtualInterfaceControllerTest extends DuskTestCase
         // Removes UI elements on create and edit, unless the
         // VLI being edited has the setting set, then it'll be shown
         $this->overrideEnv( [ "IXP_FE_VLANINTERFACES_MAX_PREFIX_ENABLED" => 'false' ] );
-        sleep(1);
+        $this->awaitArtisanEnvReload();
 
         $this->browse( function ( Browser $browser ) {
             $browser->resize( 1600, 1200 )

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Tests;
-
 /*
- * Copyright (C) 2009 - 2021 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * This file is part of IXP Manager.
@@ -23,6 +20,10 @@ namespace Tests;
  * http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+declare(strict_types=1);
+
+namespace Tests;
+
 use Laravel\Dusk\TestCase as BaseTestCase;
 
 use Facebook\WebDriver\Chrome\ChromeOptions;
@@ -30,7 +31,6 @@ use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\{
     DesiredCapabilities,
     RemoteWebDriver,
-
 };
 use PHPUnit\Framework\Attributes\BeforeClass;
 
@@ -51,7 +51,6 @@ abstract class DuskTestCase extends BaseTestCase
     /**
      * Prepare for Dusk test execution.
      *
-     * @beforeClass
      * @return void
      */
     #[BeforeClass]
@@ -67,6 +66,7 @@ abstract class DuskTestCase extends BaseTestCase
      *
      * @return RemoteWebDriver
      */
+    #[\Override]
     protected function driver(): RemoteWebDriver
     {
         $options = (new ChromeOptions)->addArguments([
@@ -81,101 +81,5 @@ abstract class DuskTestCase extends BaseTestCase
                 ChromeOptions::CAPABILITY, $options
             )
         );
-    }
-
-    /**
-     * Overrides any .env files for dusk tests
-     *
-     * @param array $variables
-     */
-    protected function overrideEnv( array $variables = []): void
-    {
-        $path = '.env';
-
-        if (file_exists($path)) {
-
-            // The environment variables to prepend
-            $prepend = '';
-
-            // Convert all new parameters to expected format
-            foreach ($variables as $key => $value) {
-                $prepend .= PHP_EOL . $key . '="' . $value . '"' ;
-            }
-
-            // Grab original .env file contents
-            $original = file_get_contents($path);
-
-            // Write all to .env file for dusk test
-            file_put_contents($path, $original . $prepend);
-        }
-    }
-
-    /**
-     * Replace any .env file attribute for dusk tests
-     * If there are no attribute find, add it at the end of file
-     *
-     * @param string $fromAttribute
-     * @param string $toAttribute
-     */
-    protected function replaceEnvAttr( string $fromAttribute, string $toAttribute): void
-    {
-        $path = '.env';
-
-        if (file_exists($path)) {
-
-            // Grab original .env file contents
-            $original = explode("\n", file_get_contents( $path ) );
-            $output = '';
-            $replaced = false;
-            $exist = false;
-            // Iterate through the attributes
-            foreach ( $original as $value ) {
-                if ( $value == $toAttribute ) {
-                    $exist = true;
-                }
-                if ( $value != $fromAttribute ) {
-                    // write in the rest of the values
-                    $output .= $value . PHP_EOL;
-                } else {
-                    // Replace the Attribute
-                    $output .= $toAttribute . PHP_EOL;
-                    $replaced = true;
-                }
-            }
-
-            //if not replaced, and doesn't exist the attribute, add it
-            if ( !$replaced && !$exist ) {
-                $output .= $toAttribute . PHP_EOL;
-            }
-
-            // Write all to .env file for dusk test
-            file_put_contents($path, $output );
-        }
-    }
-
-    /**
-     * Delete a value in .env files for dusk tests
-     *
-     * @param string $attribute
-     */
-    protected function deleteEnvValue( string $attribute): void
-    {
-        $path = '.env';
-
-        if ( file_exists( $path ) ) {
-
-            // Grab original .env file contents
-            $original = explode("\n", file_get_contents( $path ) );
-            $output = '';
-            // Iterate through the attributes
-            foreach ( $original as $value ) {
-                if ( $value != $attribute ) {
-                    $output .= $value . PHP_EOL;
-                }
-            }
-
-            // Write all to .env file for dusk test
-            file_put_contents($path, $output );
-        }
     }
 }

--- a/tests/Trait/ModifiesEnv.php
+++ b/tests/Trait/ModifiesEnv.php
@@ -1,0 +1,214 @@
+<?php
+/*
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GpNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Trait;
+
+use Tests\DuskTestCase;
+
+/**
+ * ModifiesEnv is a trait used to help with test classes, mostly dusk test cases
+ * where the .env file is the only way to influence the applications configuration
+ *
+ * Its aim is to make it easy to make a change to the env file, and to automatically
+ * restore it's contents after the test completes.
+ *
+ * The one place where there is a risk we'd miss a change is if a test overwrites
+ * the env file in a setUp method_before_ calling parent::setUp
+ */
+trait ModifiesEnv
+{
+    /**
+     * Store the original env file so it can be restored later
+     */
+    protected ?string $originalEnvBeforeModification = null;
+
+    /**
+     * This method will copy the .env file before a test method is run
+     */
+    public function setUpModifiesEnv(): void
+    {
+        $file = $this->ensureFileExists( $this->getEnvFileLocation() );
+        $this->ensureEnvFileCopiedBeforeModification( $file );
+    }
+
+    /**
+     * This copies the .env file if we have not already done so. This code can't
+     * live in setUpModifiesEnv as in one test case, we modify the .env before we
+     * call any setUp methods! So, we should aim to be robust against this, and
+     * make sure our env modification methods also call this too
+     */
+    protected function ensureEnvFileCopiedBeforeModification( string $file ): void
+    {
+        if (null === $this->originalEnvBeforeModification) {
+            $this->originalEnvBeforeModification = file_get_contents( $file );
+        }
+    }
+
+    /**
+     * This method will check if the env file has different contents to when we made
+     * a copy, and if so, reverts it back to the copy we made.
+     * If the class using this trait inherits from DuskTestCase we'll call
+     * awaitArtisanEnvReload.
+     */
+    public function tearDownModifiesEnv(): void
+    {
+        $file = $this->ensureFileExists( $this->getEnvFileLocation() );
+        if( file_get_contents( $file ) !== $this->originalEnvBeforeModification ) {
+            file_put_contents( $file, $this->originalEnvBeforeModification );
+            if( array_key_exists( DuskTestCase::class, class_parents( static::class ) ) ) {
+                $this->awaitArtisanEnvReload();
+            }
+        }
+    }
+
+    /**
+     * sleep for some time, allowing ./artisan serve to catch up with changes to the .env file
+     * (this was 1s in SettingsControllerTest, 2s in User2FAControllerTest, be optimistic and
+     * take 1s for now)
+     */
+    protected function awaitArtisanEnvReload(): void
+    {
+        usleep( 1_000_000 );
+    }
+
+    /**
+     * Return the location for the .env file
+     */
+    protected function getEnvFileLocation(): string
+    {
+        return __DIR__ . "/../../.env";
+    }
+
+    /**
+     * Checks if the file exists, and if so returns the path. Otherwise raises an exception.
+     */
+    protected function ensureFileExists( string $file ): string
+    {
+        if ( !file_exists( $file ) ) {
+            throw new \RuntimeException( "Path to env file does not exist: " . $file );
+        }
+        return $file;
+    }
+
+    /**
+     * Takes provided $envFileContents and completely overwrites the .env file
+     */
+    protected function overwriteEnvFile( string $envFileContents ): void
+    {
+        $path = $this->ensureFileExists( $this->getEnvFileLocation() );
+        $this->ensureEnvFileCopiedBeforeModification( $path );
+        file_put_contents( $path, $envFileContents );
+    }
+
+    /**
+     * Overrides any .env files for dusk tests.
+     * Variables consists of key => value pairs.
+     *
+     * @param array $variables
+     */
+    protected function overrideEnv( array $variables = [] ): void
+    {
+        $path = $this->ensureFileExists( $this->getEnvFileLocation() );
+        $this->ensureEnvFileCopiedBeforeModification( $path );
+
+        // The environment variables to prepend
+        $prepend = '';
+
+        // Convert all new parameters to expected format
+        foreach ($variables as $key => $value) {
+            $prepend .= PHP_EOL . $key . '="' . $value . '"' ;
+        }
+
+        // Grab original .env file contents
+        $original = file_get_contents( $path );
+
+        // Write all to .env file for dusk test
+        file_put_contents( $path, $original . $prepend );
+    }
+
+    /**
+     * Replace any .env file attribute for dusk tests
+     * If there are no attribute find, add it at the end of file
+     *
+     * @param string $fromAttribute
+     * @param string $toAttribute
+     */
+    protected function replaceEnvAttr( string $fromAttribute, string $toAttribute ): void
+    {
+        $path = $this->ensureFileExists( $this->getEnvFileLocation() );
+        $this->ensureEnvFileCopiedBeforeModification( $path );
+
+        // Grab original .env file contents
+        $original = explode( "\n", file_get_contents( $path ) );
+        $output = '';
+        $replaced = false;
+        $exist = false;
+        // Iterate through the attributes
+        foreach ( $original as $value ) {
+            if ( $value == $toAttribute ) {
+                $exist = true;
+            }
+            if ( $value != $fromAttribute ) {
+                // write in the rest of the values
+                $output .= $value . PHP_EOL;
+            } else {
+                // Replace the Attribute
+                $output .= $toAttribute . PHP_EOL;
+                $replaced = true;
+            }
+        }
+
+        //if not replaced, and doesn't exist the attribute, add it
+        if ( !$replaced && !$exist ) {
+            $output .= $toAttribute . PHP_EOL;
+        }
+
+        // Write all to .env file for dusk test
+        file_put_contents( $path, $output );
+    }
+
+    /**
+     * Delete a value in .env files for dusk tests
+     *
+     * @param string $attribute
+     */
+    protected function deleteEnvValue( string $attribute ): void
+    {
+        $path = $this->ensureFileExists( $this->getEnvFileLocation() );
+        $this->ensureEnvFileCopiedBeforeModification( $path );
+
+        // Grab original .env file contents
+        $original = explode("\n", file_get_contents( $path ) );
+        $output = '';
+        // Iterate through the attributes
+        foreach ( $original as $value ) {
+            if ( $value != $attribute ) {
+                $output .= $value . PHP_EOL;
+            }
+        }
+
+        // Write all to .env file for dusk test
+        file_put_contents( $path, $output );
+    }
+}


### PR DESCRIPTION
I had forgotten to undo a change to the env file in a recent test, which prompted this refactoring

 - Extracts .env file modifying methods from `DuskTestCase`
 - Adds hooks into PHPUnit test lifecycle ensuring we always have a copy of the .env file from before the test began, and that we always restore the previous contents if modified, so we don't have to remember to do it in our own test code.
 - Refactors tests which mess with the .env file to use this trait