### PR TITLE
SwitchUserController: disallow using 'login as' while already logged in as another user

### DIFF
--- a/app/Http/Controllers/Auth/SwitchUserController.php
+++ b/app/Http/Controllers/Auth/SwitchUserController.php
@@ -71,6 +71,11 @@ class SwitchUserController extends Controller
             return redirect()->to( "/" );
         }
 
+        if( session()->exists( "switched_user_from" ) ) {
+            AlertContainer::push( "You are already logged in as another user. If you want to login as someone else, switch back first.", Alert::DANGER );
+            return redirect()->to( "/" );
+        }
+
         $user = $c2u->user;
 
         if( $user->disabled ){

--- a/resources/views/layouts/menus/associate.foil.php
+++ b/resources/views/layouts/menus/associate.foil.php
@@ -158,7 +158,7 @@ use PragmaRX\Google2FALaravel\Support\Authenticator as GoogleAuthenticator;
 
             <li class="nav-item">
                 <?php if( session()->exists( "switched_user_from" ) ): ?>
-                    <a class="nav-link" href="<?= route( 'switch-user@switchBack' ) ?>">
+                    <a id="nav-item-switch-user-back" class="nav-link" href="<?= route( 'switch-user@switchBack' ) ?>">
                         Switch Back
                     </a>
                 <?php else: ?>

--- a/resources/views/layouts/menus/custadmin.foil.php
+++ b/resources/views/layouts/menus/custadmin.foil.php
@@ -249,7 +249,7 @@ use PragmaRX\Google2FALaravel\Support\Authenticator as GoogleAuthenticator;
 
             <li class="nav-item">
                 <?php if( session()->exists( "switched_user_from" ) ): ?>
-                    <a class="nav-link" href="<?= route( 'switch-user@switchBack' ) ?>">
+                    <a id="nav-item-switch-user-back" class="nav-link" href="<?= route( 'switch-user@switchBack' ) ?>">
                         Switch Back
                     </a>
                 <?php else: ?>

--- a/resources/views/layouts/menus/custuser.foil.php
+++ b/resources/views/layouts/menus/custuser.foil.php
@@ -233,7 +233,7 @@ use PragmaRX\Google2FALaravel\Support\Authenticator as GoogleAuthenticator;
 
             <li class="nav-item">
                 <?php if( session()->exists( "switched_user_from" ) ): ?>
-                    <a class="nav-link" href="<?= route( 'switch-user@switchBack' ) ?>">
+                    <a id="nav-item-switch-user-back" class="nav-link" href="<?= route( 'switch-user@switchBack' ) ?>">
                         Switch Back
                     </a>
                 <?php else: ?>

--- a/resources/views/layouts/menus/superuser.foil.php
+++ b/resources/views/layouts/menus/superuser.foil.php
@@ -205,7 +205,7 @@
 
             <li class="nav-item">
                 <?php if( session()->exists( "switched_user_from" ) ): ?>
-                    <a class="nav-link" href="<?= route( 'switch-user@switchBack' ) ?>">
+                    <a id="nav-item-switch-user-back" class="nav-link" href="<?= route( 'switch-user@switchBack' ) ?>">
                         Switch Back
                     </a>
                 <?php endif; ?>

--- a/resources/views/user/index.foil.php
+++ b/resources/views/user/index.foil.php
@@ -140,7 +140,7 @@
                                                 Login history
                                             </a>
                                             <?php if( $u['c2uid'] ): ?>
-                                                <a id="d2f-option-login-as-<?= $u[ 'id' ] ?>" class="dropdown-item <?= $u[ 'disabled' ] || $authId  === $u['id'] ? "disabled" : "" ?>" href="<?= route( "switch-user@switch", [ "c2u" => $u['c2uid'] ] ) ?>">
+                                                <a id="d2f-option-login-as-<?= $u[ 'id' ] ?>" class="dropdown-item <?= $u[ 'disabled' ] || $authId  === $u['id'] || session()->exists('switched_user_from') ? "disabled" : "" ?>" href="<?= route( "switch-user@switch", [ "c2u" => $u['c2uid'] ] ) ?>">
                                                     Login as
                                                 </a>
                                             <?php endif; ?>

--- a/resources/views/user/js/common.foil.php
+++ b/resources/views/user/js/common.foil.php
@@ -25,6 +25,7 @@
 
         let buttons = {
             cancel: {
+                id: "btn-delete-user-cancel",
                 label: 'Close',
                 className: 'btn-secondary',
                 callback: function () {
@@ -36,6 +37,7 @@
 
         if ( superUser && !$(this).hasClass( "btn-delete-user"  ) && !$(this).hasClass( "btn-delete-c2u"  ) ){
             buttons.seeC2U = {
+                id: "btn-delete-user-see-links",
                 label: `See <?= config( 'ixp_fe.lang.customer.one' )  ?> links`,
                 display: 'none',
                 className: 'btn-warning',
@@ -46,6 +48,7 @@
         }
 
         buttons.submit = {
+            id: "btn-delete-user-submit",
             label: 'Delete',
             className: 'btn-danger',
             callback: function () {

--- a/tests/Browser/SwitchUserControllerTest.php
+++ b/tests/Browser/SwitchUserControllerTest.php
@@ -1,0 +1,156 @@
+<?php
+/*
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GpNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+declare(strict_types=1);
+
+namespace Tests\Browser;
+
+use IXP\Models\User;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class SwitchUserControllerTest extends DuskTestCase
+{
+
+    /**
+     * A Dusk test example.
+     *
+     * @return void
+     *
+     * @throws Throwable
+     */
+    public function testLoginAs(): void
+    {
+        $this->browse( function( Browser $browser ) {
+
+            $browser->resize( 1600, 1200 )
+                ->visit( '/logout' )
+                ->visit( '/login' )
+                ->type( 'username', 'travis' )
+                ->type( 'password', 'travisci' )
+                ->press( '#login-btn' )
+                ->waitForLocation( '/admin/dashboard' );
+
+            // 1. Login as CUSTUSER successfully, then switch back
+            $custUser = User::whereUsername( "hecustuser" )->get()->first();
+
+            $browser->visit( 'user/list' )
+                ->waitForText("Users")
+                ->click( "#d2f-more-options-" . $custUser->id )
+                ->click( '#d2f-option-login-as-' . $custUser->id )
+                ->assertPathIs( "/dashboard" )
+                ->assertSee("Switch Back")
+                ->assertSee("You are now logged in as " . $custUser->username . " (" . $custUser->name . ") for the ".config('ixp_fe.lang.customer.one')." " . $custUser->customer->name)
+                ->click("#nav-item-switch-user-back")
+                ->waitForText("Users")
+                ->assertRouteIs("user@list");
+
+            // 2. Attempt to login as disabled user? denied
+            $custUser->disabled = 1;
+            $custUser->save();
+
+            $browser->click( "#d2f-more-options-" . $custUser->id )
+                ->click( '#d2f-option-login-as-' . $custUser->id )
+                ->assertPathIs( "/admin/dashboard" )
+                ->assertSee("You cannot login as this user");
+
+            $custUser->disabled = 0;
+            $custUser->save();
+
+            // 3. Login as CUSTADMIN successfully, then switch back
+            $custAdmin = User::whereUsername( "hecustadmin" )->get()->first();
+
+            $browser->visit( 'user/list' )
+                ->waitForText("Users")
+                ->click( "#d2f-more-options-" . $custAdmin->id )
+                ->click( '#d2f-option-login-as-' . $custAdmin->id )
+                ->assertPathIs( "/dashboard" )
+                ->assertSee("Switch Back")
+                ->assertSee("You are now logged in as " . $custAdmin->username . " (" . $custAdmin->name . ") for the ".config('ixp_fe.lang.customer.one')." " . $custAdmin->customer->name)
+                ->click("#nav-item-switch-user-back")
+                ->waitForText("Users")
+                ->assertRouteIs("user@list");
+
+            // Add superuser from non-existing user
+            $browser->visit( 'user/list' )
+                ->click( "#add-user" )
+                ->waitForText( 'Users / Create' )
+                ->type( "#email", "test13@example.com" )
+                ->click( '.btn-primary' )
+                ->waitForText( 'Privilege' )
+                ->type( 'name', 'Test User 13' )
+                ->type( 'username', 'testuser13' )
+                ->select( 'privs', 3 )
+                ->select( 'custid', 1 )
+                ->check( 'disabled' )
+                ->type( 'authorisedMobile', '12125551000' )
+                ->press( 'Create' )
+                ->waitForText("Please note that you have given this user full administrative access" );
+
+            // 4. Test we can login as a super user successfully
+            $testSuperUser = User::whereUsername( "testuser13" )->get()->first();
+
+            $browser->visit( 'user/list' )
+                ->waitForText("Users")
+                ->click( "#d2f-more-options-" . $testSuperUser->id )
+                ->click( '#d2f-option-login-as-' . $testSuperUser->id )
+                ->assertPathIs( "/admin/dashboard" )
+                ->assertSee("Switch Back")
+                ->assertSee("You are now logged in as " . $testSuperUser->username . " (" . $testSuperUser->name . ") for the ".config('ixp_fe.lang.customer.one')." " . $testSuperUser->customer->name);
+
+            // 5. While already logged in as a different SUPERUSER user, denied login to a different user, then logout from that user
+            $browser->visit( 'user/list' )
+                ->waitForText("Users")
+                ->click( "#d2f-more-options-" . $custUser->id )
+                ->waitForText("Login as");
+
+            // Frontend has link disabled
+            $class = $browser->element( '#d2f-option-login-as-' . $custUser->id)->getAttribute( 'class' );
+            $this->assertTrue(in_array("disabled", explode(" ", $class)), "a href class contains disabled class") ;
+
+            // and backend rejects
+            $browser->visit( "/admin/switch-user/" . $custUser->customerToUser()->first()->id)
+                ->assertPathIs( "/admin/dashboard" )
+                ->assertSee( "Switch Back" )
+                ->assertSee( "You are already logged in as another user. If you want to login as someone else, switch back first." );
+
+            $browser->click("#nav-item-switch-user-back")
+                ->assertRouteIs("user@list");
+
+            // 6. Error visiting switch-back-user when not logged in as another user
+            $travis = User::whereUsername( "travis" )->get()->first();
+
+            $browser->visit( "/admin/switch-user-back")
+                ->assertPathIs( "/admin/dashboard" )
+                ->screenshot("shotty")
+                ->assertSee( "You are not currently logged in as another user. You are logged in as: " . $travis->username . "( " . $travis->name . ")" );
+
+            // cleanup tests
+            $browser->visit( 'user/list' )
+                ->click( "#btn-delete-" . $testSuperUser->id )
+                ->waitForText("Are you sure you want to delete this user")
+                ->click('#btn-delete-user-submit')
+                ->waitForText("Users")
+                ->assertRouteIs("user@list");
+        } );
+    }
+
+}


### PR DESCRIPTION
If you "login as" another superuser (user A) and then user "login as" on any other user, when you 'switch back' you are soft locked logged in as user A. The only way to get back to your profile is to logout and log back in.

So disallowing this possibility in `SwitchUserController`, and adding some dusk tests for the controller
