### PR TITLE
Import IRR source from PeeringDB irr_as_set if not already known

### DIFF
--- a/app/Http/Controllers/Api/V4/IrrdbConfigController.php
+++ b/app/Http/Controllers/Api/V4/IrrdbConfigController.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+declare(strict_types=1);
+
+namespace IXP\Http\Controllers\Api\V4;
+
+use Illuminate\Http\JsonResponse;
+use IXP\Http\Requests\Api\V4\IrrdbConfig\Store as StoreIrrdbConfig;
+use IXP\Models\IrrdbConfig;
+
+class IrrdbConfigController
+{
+    public function store( StoreIrrdbConfig $request ): JsonResponse
+    {
+        $irrdbConfig = new IrrdbConfig();
+        $irrdbConfig->source = $request->source;
+        $irrdbConfig->host = $request->host ?? "whois.radb.net";
+        $irrdbConfig->notes = $request->notes;
+        $irrdbConfig->save();
+
+        return response()->json( [
+            'id' => $irrdbConfig->id,
+            'host' => $irrdbConfig->host,
+            'source' => $irrdbConfig->source,
+            'notes' => $irrdbConfig->notes,
+        ] );
+    }
+}

--- a/app/Http/Requests/Api/V4/IrrdbConfig/Store.php
+++ b/app/Http/Requests/Api/V4/IrrdbConfig/Store.php
@@ -57,8 +57,16 @@ final class Store extends FormRequest
     {
         return [
             'host' => 'nullable|string|max:255',
-            'source' => 'required|string|max:255',
+            'source' => 'required|string|max:255|regex:/[A-Z0-9-]+/',
             'notes' => 'nullable|string',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+
+            'source.regex' => 'The source must only contain uppercase letters and numbers and the - character.',
         ];
     }
 }

--- a/app/Http/Requests/Api/V4/IrrdbConfig/Store.php
+++ b/app/Http/Requests/Api/V4/IrrdbConfig/Store.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+declare(strict_types=1);
+
+namespace IXP\Http\Requests\Api\V4\IrrdbConfig;
+
+use Auth;
+use Illuminate\Foundation\Http\FormRequest;
+use IXP\Models\PatchPanelPort;
+use IXP\Models\User;
+
+/**
+ * @property-read string|null $source
+ * @property-read string|null $host
+ * @property-read string|null $notes
+ */
+final class Store extends FormRequest
+{
+    /**
+     * Determine if the user is authorised to make this request.
+     */
+    public function authorize(): bool
+    {
+        /** @var User $us */
+        $us = Auth::user();
+        return $us->isSuperUser();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return string[]
+     *
+     * @psalm-return array{host: 'nullable|string|max:255', source: 'required|string|max:255', notes: 'nullable|string'}
+     */
+    public function rules(): array
+    {
+        return [
+            'host' => 'nullable|string|max:255',
+            'source' => 'required|string|max:255',
+            'notes' => 'nullable|string',
+        ];
+    }
+}

--- a/resources/views/customer/edit.foil.php
+++ b/resources/views/customer/edit.foil.php
@@ -65,7 +65,7 @@ $this->layout( 'layouts/ixpv4' );
 
                 <?= Former::text( 'name' )
                     ->label( 'Name' )
-                    ->placeholder( "Acme Intermet Access" )
+                    ->placeholder( "Acme Internet Access" )
                     ->blockHelp( "The customer's name as you/they typically want it to appear in IXP Manager. It is not necessarily "
                         . "their full legal entity name (that goes elsewhere). The <em>abbreviated name</em> is a shorter version "
                         . "of the name that is used in space constrained areas such as graph labels." );

--- a/resources/views/customer/js/edit.foil.php
+++ b/resources/views/customer/js/edit.foil.php
@@ -116,10 +116,27 @@
 
                                 if (irrdbSelectOption.length > 0) {
                                     dd_irrdb.val( irrdbSelectOption.val() ).select2().trigger('change.select2');
+                                    input_peeringmacro.val( asSet );
+                                } else {
+                                    $.ajax( "<?= route("irrdb-config-api@create") ?>", {
+                                        type: "POST",
+                                        data: {
+                                            "source": irr,
+                                            "host": "whois.radb.net",
+                                            "notes": "Created during customer import from PeeringDB",
+                                        },
+                                    } )
+                                        .done( function( response ) {
+                                            dd_irrdb.append( $( '<option>', {
+                                                value: response.id,
+                                                text: irr,
+                                                selected: 'selected',
+                                            } ) );
+                                            input_peeringmacro.val( asSet );
+                                        });
                                 }
-                                input_peeringmacro.val( asSet );
                             } else {
-                                input_peeringmacro.val(     response.net.irr_as_set ).addClass( 'is-valid' );
+                                input_peeringmacro.val( response.net.irr_as_set ).addClass( 'is-valid' );
                             }
                         }
 

--- a/resources/views/customer/js/edit.foil.php
+++ b/resources/views/customer/js/edit.foil.php
@@ -19,6 +19,7 @@
 
     const dd_type                   = $( '#type' );
     const dd_peering_policy         = $( '#peeringpolicy' );
+    const dd_irrdb                  = $( '#irrdb' );
 
     const cb_isResold               = $( '#isResold' );
     const div_reseller_area         = $( '#reseller-area' );
@@ -103,7 +104,24 @@
                         input_datejoin.val(         getCurrentDate() ).addClass( 'is-valid' );
                         input_corp_www.val(         response.net.website ).addClass( 'is-valid' );
                         input_autsys.val(           response.net.asn ).addClass( 'is-valid' );
-                        input_peeringmacro.val(     response.net.irr_as_set ).addClass( 'is-valid' );
+
+                        if ( typeof response.net.irr_as_set == "string" && response.net.irr_as_set.length > 0 ) {
+                            // https://docs.peeringdb.com/blog/data_quality_for_networks/
+                            if (response.net.irr_as_set.includes("::")) {
+                                const [irr, asSet] = response.net.irr_as_set.split('::');
+
+                                let irrdbSelectOption = dd_irrdb.find('option:not(:selected)').filter(function () {
+                                    return $(this).text() === irr;
+                                });
+
+                                if (irrdbSelectOption.length > 0) {
+                                    dd_irrdb.val( irrdbSelectOption.val() ).select2().trigger('change.select2');
+                                }
+                                input_peeringmacro.val( asSet );
+                            } else {
+                                input_peeringmacro.val(     response.net.irr_as_set ).addClass( 'is-valid' );
+                            }
+                        }
 
                         if( typeof response.net.info_prefixes4 !== "undefined" ) {
                             input_maxprefixes.val( Math.ceil( response.net.info_prefixes4 ) ).addClass( 'is-valid' );

--- a/routes/apiv4-auth-superuser.php
+++ b/routes/apiv4-auth-superuser.php
@@ -146,3 +146,10 @@ Route::group( [ 'namespace' => 'Customer\Note', 'prefix' => 'customer-note' ], f
 //    Route::get(  'measurement/{atlasid}/info',   'RipeAtlasController@getAtlasMeasurementDetail' )->name( 'ripe-atlas@measurement-info' );
 //    Route::get(  'probe/{atlasid}/info',         'RipeAtlasController@getAtlasProbeDetail'       )->name( 'ripe-atlas@probe-info'       );
 //});
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IRRDB Config
+//
+Route::group( [ 'prefix' => '' ], function() {
+    Route::post(    'store',      'IrrdbConfigController@store'             )->name( 'irrdb-config-api@create');
+});

--- a/tests/Http/Controllers/Api/V4/IrrdbConfigControllerTest.php
+++ b/tests/Http/Controllers/Api/V4/IrrdbConfigControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+/*
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+declare(strict_types=1);
+
+namespace Http\Controllers\Api\V4;
+
+use IXP\Models\IrrdbConfig;
+use Tests\TestCase;
+
+class IrrdbConfigControllerTest extends TestCase
+{
+
+    public function testStore()
+    {
+        $this->actingAs($this->getSuperUser());
+
+        // Only required field is missing
+        $response = $this
+            ->withHeader('X-Requested-With', 'XMLHttpRequest')
+            ->withHeader('Accept', '*/*')
+            ->post(route("irrdb-config-api@create", []))
+            ->assertStatus(422);
+        $this->assertEquals("The source field is required.", $response->json('message'));
+        $this->assertEquals("The source field is required.", $response->json('errors.source.0'));
+
+        // Provide only required field, succeeds
+        $response = $this
+            ->withHeader('X-Requested-With', 'XMLHttpRequest')
+            ->withHeader('Accept', '*/*')
+            ->post(route("irrdb-config-api@create", [
+                "source" => "testsource"
+            ]))
+            ->assertStatus(200);
+        $this->assertArrayHasKey("id", $response->json());
+
+        $config = IrrdbConfig::findOrFail( $response->json( "id" ) );
+        $this->assertEquals("testsource",     $config->source);
+        $this->assertEquals("whois.radb.net", $config->host);
+        $this->assertNull($config->notes);
+
+        $config->delete();
+
+        // Can also set host and notes
+        $response = $this
+            ->withHeader('X-Requested-With', 'XMLHttpRequest')
+            ->withHeader('Accept', '*/*')
+            ->post(route("irrdb-config-api@create", [
+                "source" => "testsource",
+                "host"   => "whois.whatis.net",
+                "notes"  => "got my notes",
+            ]))
+            ->assertStatus(200);
+        $this->assertArrayHasKey("id", $response->json());
+
+        $config = IrrdbConfig::findOrFail( $response->json( "id" ) );
+        $this->assertEquals("testsource",       $config->source);
+        $this->assertEquals("whois.whatis.net", $config->host);
+        $this->assertEquals("got my notes",     $config->notes);
+
+        $config->delete();
+    }
+}

--- a/tests/Http/Controllers/Api/V4/IrrdbConfigControllerTest.php
+++ b/tests/Http/Controllers/Api/V4/IrrdbConfigControllerTest.php
@@ -30,37 +30,56 @@ use Tests\TestCase;
 class IrrdbConfigControllerTest extends TestCase
 {
 
-    public function testStore()
+    public function testStoreSourceRequired()
     {
-        $this->actingAs($this->getSuperUser());
+        $this->actingAs( $this->getSuperUser() );
 
         // Only required field is missing
         $response = $this
-            ->withHeader('X-Requested-With', 'XMLHttpRequest')
-            ->withHeader('Accept', '*/*')
-            ->post(route("irrdb-config-api@create", []))
-            ->assertStatus(422);
-        $this->assertEquals("The source field is required.", $response->json('message'));
-        $this->assertEquals("The source field is required.", $response->json('errors.source.0'));
+            ->withHeader( 'X-Requested-With', 'XMLHttpRequest' )
+            ->withHeader( 'Accept', '*/*' )
+            ->post( route( "irrdb-config-api@create", [] ) )
+            ->assertStatus( 422 );
+        $this->assertEquals( "The source field is required.", $response->json( 'message' ) );
+        $this->assertEquals( "The source field is required.", $response->json( 'errors.source.0' ) );
 
         // Provide only required field, succeeds
         $response = $this
             ->withHeader('X-Requested-With', 'XMLHttpRequest')
             ->withHeader('Accept', '*/*')
             ->post(route("irrdb-config-api@create", [
-                "source" => "testsource"
+                "source" => "TESTSOURCE"
             ]))
             ->assertStatus(200);
         $this->assertArrayHasKey("id", $response->json());
 
         $config = IrrdbConfig::findOrFail( $response->json( "id" ) );
-        $this->assertEquals("testsource",     $config->source);
+        $this->assertEquals("TESTSOURCE",     $config->source);
         $this->assertEquals("whois.radb.net", $config->host);
         $this->assertNull($config->notes);
 
         $config->delete();
 
-        // Can also set host and notes
+        // Can also set host and notes, and accepts - and numbers in source
+        $response = $this
+            ->withHeader('X-Requested-With', 'XMLHttpRequest')
+            ->withHeader('Accept', '*/*')
+            ->post(route("irrdb-config-api@create", [
+                "source" => "TESTSOURCE-222",
+                "host"   => "whois.whatis.net",
+                "notes"  => "got my notes",
+            ]))
+            ->assertStatus(200);
+        $this->assertArrayHasKey("id", $response->json());
+
+        $config = IrrdbConfig::findOrFail( $response->json( "id" ) );
+        $this->assertEquals("TESTSOURCE-222",       $config->source);
+        $this->assertEquals("whois.whatis.net", $config->host);
+        $this->assertEquals("got my notes",     $config->notes);
+
+        $config->delete();
+
+        // source must be capitalized
         $response = $this
             ->withHeader('X-Requested-With', 'XMLHttpRequest')
             ->withHeader('Accept', '*/*')
@@ -69,14 +88,8 @@ class IrrdbConfigControllerTest extends TestCase
                 "host"   => "whois.whatis.net",
                 "notes"  => "got my notes",
             ]))
-            ->assertStatus(200);
-        $this->assertArrayHasKey("id", $response->json());
-
-        $config = IrrdbConfig::findOrFail( $response->json( "id" ) );
-        $this->assertEquals("testsource",       $config->source);
-        $this->assertEquals("whois.whatis.net", $config->host);
-        $this->assertEquals("got my notes",     $config->notes);
-
-        $config->delete();
+            ->assertStatus(422);
+        $this->assertEquals( "The source must only contain uppercase letters and numbers and the - character.", $response->json( 'message' ) );
+        $this->assertEquals( "The source must only contain uppercase letters and numbers and the - character.", $response->json( 'errors.source.0' ) );
     }
 }


### PR DESCRIPTION
PeeringDB has started returning AS-SETs which specify the IRR source, eg, RIPE::AS-PCH

Since IXP Manager mostly utilizes bgpq3 for IRR queries, this format isn't supported yet, and probably spells the end of support for bgpq3

In the mean time, extract the IRR and AS-SET separately. 

Highlights:
 - Starts to populate IRRDB Source if the source is provided
 - Adds an API endpoint to add a source if we don't have it already

Fixes inex/ixp-manager#933 and islandbridgenetworks/ibn-ixp-manager#81