### PR TITLE
Test covering virtual interface wizard's new form fields

### DIFF
--- a/app/Http/Requests/StoreVirtualInterfaceWizard.php
+++ b/app/Http/Requests/StoreVirtualInterfaceWizard.php
@@ -3,7 +3,7 @@
 namespace IXP\Http\Requests;
 
 /*
- * Copyright (C) 2009 - 2021 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * This file is part of IXP Manager.
@@ -62,7 +62,7 @@ class StoreVirtualInterfaceWizard extends FormRequest
      *
      * @return ((IdnValidate|string)[]|string)[]
      *
-     * @psalm-return array{custid: 'required|integer|exists:cust,id', vlanid: 'required|integer|exists:vlan,id', trunk: 'boolean', switch: 'required|integer|exists:switch,id', switchportid: 'required|integer|exists:switchport,id', status: string, speed: string, duplex: string, ipv4maxbgpprefix: 'integer|nullable', ipv6maxbgpprefix: 'integer|nullable', mcastenabled: 'boolean', rsclient: 'boolean', irrdbfilter: 'boolean', rsmorespecifics: 'boolean', as112client: 'boolean', ipv4enabled: 'boolean', ipv4address: 'ipv4|nullable'|'ipv4|required', ipv4hostname: list{'string', 'max:255', 'nullable'|'required', IdnValidate}, ipv4bgpmd5secret: 'string|max:255|nullable', ipv4canping: 'boolean', ipv4monitorrcbgp: 'boolean', ipv6enabled: 'boolean', ipv6address: 'ipv6|nullable'|'ipv6|required', ipv6hostname: list{'string', 'max:255', 'nullable'|'required', IdnValidate}, ipv6bgpmd5secret: 'string|max:255|nullable', ipv6canping: 'boolean', ipv6monitorrcbgp: 'boolean'}
+     * @psalm-return array{custid: 'required|integer|exists:cust,id', vlanid: 'required|integer|exists:vlan,id', trunk: 'boolean', switch: 'required|integer|exists:switch,id', switchportid: 'required|integer|exists:switchport,id', status: string, speed: string, duplex: string, rate_limit: 'nullable|integer|min:0', autoneg: 'boolean', ipv4maxbgpprefix: 'integer|nullable', ipv6maxbgpprefix: 'integer|nullable', mcastenabled: 'boolean', rsclient: 'boolean', irrdbfilter: 'boolean', rsmorespecifics: 'boolean', as112client: 'boolean', ipv4enabled: 'boolean', ipv4address: 'ipv4|nullable'|'ipv4|required', ipv4hostname: list{'string', 'max:255', 'nullable'|'required', IdnValidate}, ipv4bgpmd5secret: 'string|max:255|nullable', ipv4canping: 'boolean', ipv4monitorrcbgp: 'boolean', ipv6enabled: 'boolean', ipv6address: 'ipv6|nullable'|'ipv6|required', ipv6hostname: list{'string', 'max:255', 'nullable'|'required', IdnValidate}, ipv6bgpmd5secret: 'string|max:255|nullable', ipv6canping: 'boolean', ipv6monitorrcbgp: 'boolean'}
      */
     public function rules(): array
     {
@@ -76,6 +76,8 @@ class StoreVirtualInterfaceWizard extends FormRequest
             'status'                => 'required|integer|in:' . implode( ',', array_keys( PhysicalInterface::$STATES ) ),
             'speed'                 => 'required|integer|in:' . implode( ',', array_keys( PhysicalInterface::$SPEED ) ),
             'duplex'                => 'required|string|in:' . implode( ',', array_keys( PhysicalInterface::$DUPLEX ) ),
+            'rate_limit'            => 'nullable|integer|min:0',
+            'autoneg'               => 'boolean',
 
             'mcastenabled'          => 'boolean',
             'rsclient'              => 'boolean',

--- a/resources/views/interfaces/virtual/wizard.foil.php
+++ b/resources/views/interfaces/virtual/wizard.foil.php
@@ -155,6 +155,19 @@ $this->layout( 'layouts/ixpv4' );
                             ->value(1)
                             ->blockHelp( '' );
                         ?>
+
+                        <?= Former::number( 'rate_limit' )
+                            ->label( 'Rate Limit <u>(Mbps)</u>' )
+                            ->blockHelp( 'Enter the provisioned speed if the port has been rate limited below its line rate. <strong>Enter in Mbps!</strong> Leave blank if port is not rate limited. Zero will be converted to null (blank - not rate limited).');
+                        ?>
+
+                        <?= Former::checkbox( 'autoneg' )
+                            ->label( '&nbsp;' )
+                            ->text( 'Auto-Negotiation Enabled' )
+                            ->value( 1 )
+                            ->inline()
+                            ->blockHelp( "Unless you are provisioning switches from IXP Manager, this is informational." );
+                        ?>
                     </div>
 
                     <div class="col-md-12 col-lg-4 mt-4 mt-md-4">

--- a/resources/views/interfaces/virtual/wizard.foil.php
+++ b/resources/views/interfaces/virtual/wizard.foil.php
@@ -165,6 +165,7 @@ $this->layout( 'layouts/ixpv4' );
                             ->label( '&nbsp;' )
                             ->text( 'Auto-Negotiation Enabled' )
                             ->value( 1 )
+                            ->check()
                             ->inline()
                             ->blockHelp( "Unless you are provisioning switches from IXP Manager, this is informational." );
                         ?>

--- a/tests/Browser/VirtualInterfaceControllerTest.php
+++ b/tests/Browser/VirtualInterfaceControllerTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Browser;
 
 /*
- * Copyright (C) 2009 - 2025 Internet Neutral Exchange Association Company Limited By Guarantee.
+ * Copyright (C) 2009 - 2026 Internet Neutral Exchange Association Company Limited By Guarantee.
  * All Rights Reserved.
  *
  * This file is part of IXP Manager.
@@ -949,4 +949,179 @@ class VirtualInterfaceControllerTest extends DuskTestCase
                 ->assertSee('Virtual interface deleted.' );
         });
     }
+
+    public function testViRateLimitAndAutoneg()
+    {
+        $this->browse( function ( Browser $browser ) {
+            $browser->maximize()
+                ->visit('/logout' )
+                ->visit('/login' )
+                ->type('username', 'travis' )
+                ->type('password', 'travisci' )
+                ->press('#login-btn' )
+                ->waitForLocation('/admin/dashboard' );
+
+            // Create a new Virtual interface Via wizard form
+            // Test default case when autoneg / rate_limit not changed?
+            $browser->visit( route( 'virtual-interface@create-wizard-for-cust', 5 ) )
+                ->assertSee('Virtual Interface Settings' )
+                ->select('vlanid',  '2' )
+                ->check( 'ipv4enabled' )
+                ->waitFor( "#ipv4-area" )
+                ->check( 'ipv6enabled' )
+                ->waitFor( "#ipv6-area" )
+                ->select( 'switch', '2' )
+                ->waitUntilMissing( "Choose a switch port" )
+                ->waitForText( "Choose a switch port" )
+                ->select( 'switchportid','28'    )
+                ->select( 'status',     '4'     )
+                ->select( 'speed',      '1000'  )
+                ->select( 'duplex',     'full'  )
+                ->check( 'rsclient'     )
+                ->check( 'irrdbfilter'  )
+                ->check( 'as112client'  )
+                ->select( 'ipv4address',   '10.2.0.22'         )
+                ->select( 'ipv6address',   '2001:db8:2::22'    )
+                ->type( 'ipv4hostname',    'v4.example.com'    )
+                ->type( 'ipv6hostname',    'v6.example.com'    )
+                ->type( 'ipv4bgpmd5secret', 'soopersecret'   )
+                ->type( 'ipv6bgpmd5secret', 'soopersecret'   )
+                ->type( 'ipv4maxbgpprefix', '200'   )
+                ->type( 'ipv6maxbgpprefix', '100'   )
+                ->check( 'ipv4canping'        )
+                ->check( 'ipv6canping'        )
+                ->check( 'ipv4monitorrcbgp'   )
+                ->check( 'ipv6monitorrcbgp'        )
+                ->press( 'Create' )
+                ->waitForText('Virtual interface created', 10000 );
+
+            $url = explode( '/', $browser->driver->getCurrentURL() );
+
+            /** @var $vi VirtualInterface */
+            $this->assertInstanceOf( VirtualInterface::class , $vi = VirtualInterface::find( array_pop($url) ) );
+
+            $this->assertEquals(1, $vi->physicalInterfaces()->count());
+            $pi = $vi->physicalInterfaces()->firstOrFail();
+            $this->assertNull($pi->rate_limit);
+            $this->assertTrue($pi->autoneg);
+
+            $browser
+                ->press('#advanced-options')
+                ->press( "#delete-vi-" . $vi->id )
+                ->waitForText( 'Do you really want to delete this Virtual Interface?' )
+                ->press( "Delete" )
+                ->waitForLocation( route( 'customer@overview', [ 'cust' => $vi->custid, 'tab' => 'ports' ] ) )
+                ->assertSee('Virtual interface deleted.' );
+
+            // Create a new Virtual interface Via wizard form
+            // Test case when autoneg / rate_limit are definitely both set
+            $browser->visit( route( 'virtual-interface@create-wizard-for-cust', 5 ) )
+                ->assertSee('Virtual Interface Settings' )
+                ->select('vlanid',  '2' )
+                ->check( 'ipv4enabled' )
+                ->waitFor( "#ipv4-area" )
+                ->check( 'ipv6enabled' )
+                ->waitFor( "#ipv6-area" )
+                ->select( 'switch', '2' )
+                ->waitUntilMissing( "Choose a switch port" )
+                ->waitForText( "Choose a switch port" )
+                ->select( 'switchportid','28'    )
+                ->select( 'status',     '4'     )
+                ->select( 'speed',      '1000'  )
+                ->select( 'duplex',     'full'  )
+                ->type( 'rate_limit', '1000' )
+                ->check( 'autoneg'      )
+                ->check( 'rsclient'     )
+                ->check( 'irrdbfilter'  )
+                ->check( 'as112client'  )
+                ->select( 'ipv4address',   '10.2.0.22'         )
+                ->select( 'ipv6address',   '2001:db8:2::22'    )
+                ->type( 'ipv4hostname',    'v4.example.com'    )
+                ->type( 'ipv6hostname',    'v6.example.com'    )
+                ->type( 'ipv4bgpmd5secret', 'soopersecret'   )
+                ->type( 'ipv6bgpmd5secret', 'soopersecret'   )
+                ->type( 'ipv4maxbgpprefix', '200'   )
+                ->type( 'ipv6maxbgpprefix', '100'   )
+                ->check( 'ipv4canping'        )
+                ->check( 'ipv6canping'        )
+                ->check( 'ipv4monitorrcbgp'   )
+                ->check( 'ipv6monitorrcbgp'        )
+                ->press( 'Create' )
+                ->waitForText('Virtual interface created', 10000 );
+
+            $url = explode( '/', $browser->driver->getCurrentURL() );
+
+            /** @var $vi VirtualInterface */
+            $this->assertInstanceOf( VirtualInterface::class , $vi = VirtualInterface::find( array_pop( $url ) ) );
+
+            $this->assertEquals(1, $vi->physicalInterfaces()->count());
+            $pi = $vi->physicalInterfaces()->firstOrFail();
+            $this->assertEquals("1000", $pi->rate_limit);
+            $this->assertTrue($pi->autoneg);
+
+            $browser
+                ->press('#advanced-options')
+                ->press( "#delete-vi-" . $vi->id )
+                ->waitForText( 'Do you really want to delete this Virtual Interface?' )
+                ->press( "Delete" )
+                ->waitForLocation( route( 'customer@overview', [ 'cust' => $vi->custid, 'tab' => 'ports' ] ) )
+                ->assertSee('Virtual interface deleted.' );
+
+
+            // Create a new Virtual interface Via wizard form
+            // Test case unsetting autoneg
+            $browser->visit( route( 'virtual-interface@create-wizard-for-cust', 5 ) )
+                ->assertSee('Virtual Interface Settings' )
+                ->select('vlanid',  '2' )
+                ->check( 'ipv4enabled' )
+                ->waitFor( "#ipv4-area" )
+                ->check( 'ipv6enabled' )
+                ->waitFor( "#ipv6-area" )
+                ->select( 'switch', '2' )
+                ->waitUntilMissing( "Choose a switch port" )
+                ->waitForText( "Choose a switch port" )
+                ->select( 'switchportid','28'    )
+                ->select( 'status',     '4'     )
+                ->select( 'speed',      '1000'  )
+                ->select( 'duplex',     'full'  )
+                ->clear( 'rate_limit' )
+                ->uncheck( 'autoneg'    )
+                ->check( 'rsclient'     )
+                ->check( 'irrdbfilter'  )
+                ->check( 'as112client'  )
+                ->select( 'ipv4address',   '10.2.0.22'         )
+                ->select( 'ipv6address',   '2001:db8:2::22'    )
+                ->type( 'ipv4hostname',    'v4.example.com'    )
+                ->type( 'ipv6hostname',    'v6.example.com'    )
+                ->type( 'ipv4bgpmd5secret', 'soopersecret'   )
+                ->type( 'ipv6bgpmd5secret', 'soopersecret'   )
+                ->type( 'ipv4maxbgpprefix', '200'   )
+                ->type( 'ipv6maxbgpprefix', '100'   )
+                ->check( 'ipv4canping'        )
+                ->check( 'ipv6canping'        )
+                ->check( 'ipv4monitorrcbgp'   )
+                ->check( 'ipv6monitorrcbgp'        )
+                ->press( 'Create' )
+                ->waitForText('Virtual interface created', 10000 );
+
+            $url = explode( '/', $browser->driver->getCurrentURL() );
+
+            /** @var $vi VirtualInterface */
+            $this->assertInstanceOf( VirtualInterface::class , $vi = VirtualInterface::find( array_pop( $url ) ) );
+
+            $this->assertEquals(1, $vi->physicalInterfaces()->count());
+            $pi = $vi->physicalInterfaces()->firstOrFail();
+            $this->assertNull($pi->rate_limit);
+            $this->assertFalse($pi->autoneg);
+
+            $browser
+                ->press('#advanced-options')
+                ->press( "#delete-vi-" . $vi->id )
+                ->waitForText( 'Do you really want to delete this Virtual Interface?' )
+                ->press( "Delete" )
+                ->waitForLocation( route( 'customer@overview', [ 'cust' => $vi->custid, 'tab' => 'ports' ] ) )
+                ->assertSee('Virtual interface deleted.' );
+        });
+    }
+
 }


### PR DESCRIPTION
Follow up to #1027, adding autoneg checked by default (match how form worked previously), add test covering new form fields

Rebased over main

NOTE: dusk tests failing currently - wait for #1037 to go in then rebase. Passes in isolation, the test before modifies an env var that interferes with this test. #1037 magically undoes stuff like that, so wait for that. 