### PR TITLE
[NF] Provisioning API: create members, users and connections over HTTP

### DIFF
--- a/app/Http/Controllers/Api/V4/Provisioning/ConnectionController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/ConnectionController.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace IXP\Http\Controllers\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Auth, Log;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+use IXP\Http\Controllers\Interfaces\Common;
+use IXP\Http\Requests\Api\V4\Provisioning\StoreConnection;
+
+use IXP\Models\{
+    Customer,
+    PhysicalInterface,
+    SwitchPort,
+    VirtualInterface,
+    Vlan,
+    VlanInterface
+};
+
+use IXP\Support\Provisioning\IpAllocationException;
+use IXP\Support\Provisioning\IpAllocator;
+
+/**
+ * Provisioning API - Connection Controller
+ *
+ * Creates and removes a member's connection to the exchange: the virtual interface, the
+ * physical interface on a switch port, the VLAN interface, and the addresses on it.
+ *
+ * Extends Interfaces\Common rather than Api\V4\Controller, which is the point of the class:
+ * setIp() and deletePi() are inherited, so the address assignment and the fanout-aware
+ * teardown exist once in the codebase and keep working when upstream changes them. What is
+ * reimplemented here is only the orchestration that VirtualInterfaceController::storeWizard()
+ * wraps in redirects and flash messages.
+ *
+ * @see \IXP\Http\Controllers\Interfaces\VirtualInterfaceController::storeWizard()
+ *
+ * @author     KleyReX
+ * @category   APIv4
+ * @package    IXP\Http\Controllers\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class ConnectionController extends Common
+{
+    /**
+     * Create a connection for a member.
+     *
+     * Everything happens in one transaction, including the address allocation: the row lock
+     * IpAllocator takes is only meaningful until commit, so two orders provisioned at the same
+     * moment cannot be handed the same address.
+     *
+     * Differences from the web wizard, all deliberate:
+     *
+     *   - `ipv4address`/`ipv6address` may be "auto".
+     *   - Addresses must already exist in the VLAN's pool. setIp() would happily create one on
+     *     the fly; for an unattended caller that turns a typo into a stray address record.
+     *     IpAllocator::claim() is therefore consulted first and rejects anything not in the
+     *     pool, so by the time setIp() runs the address is known to exist.
+     *   - LAG bookkeeping (setBundleDetails, and hence assignChannelGroup) is applied. The
+     *     wizard omits it, which is harmless there because it creates single-port interfaces
+     *     from a form that cannot request LAG framing.
+     *
+     * @param  StoreConnection  $r
+     * @param  Customer         $cust
+     *
+     * @return JsonResponse
+     */
+    public function store( StoreConnection $r, Customer $cust ): JsonResponse
+    {
+        $vlan = Vlan::findOrFail( $r->input( 'vlanid' ) );
+
+        // Reject a switch port which is taken, is not a member port, or sits on another
+        // switch, before anything is written:
+        if( $error = $this->rejectUnusableSwitchPort( $r ) ) {
+            return response()->json( [ 'message' => $error ], 422 );
+        }
+
+        try {
+            $vi = DB::transaction( function() use ( $r, $cust, $vlan ) {
+                $vi = VirtualInterface::create( array_merge( $r->validated(), [ 'custid' => $cust->id ] ) );
+
+                PhysicalInterface::create( array_merge( $r->validated(), [
+                    'virtualinterfaceid' => $vi->id,
+                ] ) );
+
+                SwitchPort::findOrFail( $r->input( 'switchportid' ) )
+                    ->update( [ 'type' => SwitchPort::TYPE_PEERING ] );
+
+                // resolve "auto" and verify explicit addresses against the pool, then hand the
+                // resolved values to the inherited setIp():
+                $resolved = $r->all();
+
+                foreach( [ false, true ] as $ipv6 ) {
+                    $field = ( $ipv6 ? 'ipv6' : 'ipv4' ) . 'address';
+
+                    $ip = ( new IpAllocator() )->claim( $vlan, $r->input( $field ), $ipv6 );
+
+                    $resolved[ $field ] = $ip?->address;
+                }
+
+                $ipRequest = Request::create( '/', 'POST', $resolved );
+
+                $vli = new VlanInterface( array_merge( $r->validated(), [
+                    'virtualinterfaceid' => $vi->id,
+                    'busyhost'           => $r->boolean( 'busyhost' ),
+                ] ) );
+
+                if( !$this->setIp( $ipRequest, $vlan, $vli, false ) || !$this->setIp( $ipRequest, $vlan, $vli, true ) ) {
+                    // setIp() only fails when an address is in use on this VLAN; claim() has
+                    // already ruled that out, so reaching here means someone took it in
+                    // between. Rolling back is the right answer either way.
+                    throw new IpAllocationException(
+                        'An address became unavailable while the connection was being created. Please retry.'
+                    );
+                }
+
+                $vli->save();
+
+                $vi->refresh();
+                $this->setBundleDetails( $vi );
+                $vi->save();
+
+                return $vi;
+            } );
+        } catch( IpAllocationException $e ) {
+            return response()->json( [ 'message' => $e->getMessage() ], 422 );
+        }
+
+        $this->warnIfIrrdbFilteringButNoIrrdbSourceSet( $vi->vlanInterfaces()->first() );
+
+        Log::notice( "Provisioning API: created connection {$vi->id} for {$cust->name} as "
+            . Auth::user()->username );
+
+        return response()->json( [ 'connection' => $this->connectionAsArray( $vi->fresh() ) ], 201 );
+    }
+
+    /**
+     * List a member's connections.
+     *
+     * @param  Customer  $cust
+     *
+     * @return JsonResponse
+     */
+    public function index( Customer $cust ): JsonResponse
+    {
+        $connections = $cust->virtualInterfaces->map(
+            fn( VirtualInterface $vi ) => $this->connectionAsArray( $vi )
+        )->values()->all();
+
+        return response()->json( [ 'connections' => $connections ] );
+    }
+
+    /**
+     * Remove a connection.
+     *
+     * Uses the inherited deletePi(), which handles the fanout and reseller cases. That method
+     * is not idempotent - it dereferences $pi->switchPort after having set switchportid to
+     * null - so a physical interface already detached is skipped rather than passed to it.
+     *
+     * @param  VirtualInterface  $vi
+     *
+     * @return JsonResponse
+     */
+    public function destroy( VirtualInterface $vi ): JsonResponse
+    {
+        if( $vi->getCoreBundle() ) {
+            return response()->json( [
+                'message' => 'This connection belongs to a core bundle. Delete the core bundle first.',
+            ], 409 );
+        }
+
+        $custName = $vi->customer?->name ?? 'unknown';
+        $request  = Request::create( '/', 'POST' );
+
+        DB::transaction( function() use ( $vi, $request ) {
+            foreach( $vi->physicalInterfaces as $pi ) {
+                if( $pi->switchportid === null ) {
+                    // already detached: deletePi() would fail on a null switch port
+                    $pi->delete();
+                    continue;
+                }
+
+                $this->deletePi( $request, $pi, false );
+            }
+
+            foreach( $vi->vlanInterfaces as $vli ) {
+                $vli->layer2addresses()->delete();
+                $vli->delete();
+            }
+
+            $vi->macAddresses()->delete();
+            $vi->delete();
+        } );
+
+        Log::notice( "Provisioning API: deleted connection {$vi->id} for {$custName} as "
+            . Auth::user()->username );
+
+        return response()->json( [ 'deleted' => true ] );
+    }
+
+    /**
+     * Reject a switch port which cannot be given to a member.
+     *
+     * @param  StoreConnection  $r
+     *
+     * @return string|null  an error message, or null when the port is usable
+     */
+    private function rejectUnusableSwitchPort( StoreConnection $r ): ?string
+    {
+        $sp = SwitchPort::find( $r->input( 'switchportid' ) );
+
+        if( !$sp ) {
+            return 'The switch port does not exist.';
+        }
+
+        if( (int)$sp->switchid !== (int)$r->input( 'switch' ) ) {
+            return "Switch port {$sp->name} does not belong to the switch given.";
+        }
+
+        if( $sp->physicalInterface ) {
+            return "Switch port {$sp->name} is already assigned to another connection.";
+        }
+
+        if( !in_array( (int)$sp->type, [ SwitchPort::TYPE_UNSET, SwitchPort::TYPE_PEERING ], true ) ) {
+            return "Switch port {$sp->name} is not a member port (type {$sp->type}).";
+        }
+
+        return null;
+    }
+
+    /**
+     * Representation of a connection for API responses.
+     *
+     * @param  VirtualInterface  $vi
+     *
+     * @return array
+     */
+    private function connectionAsArray( VirtualInterface $vi ): array
+    {
+        return [
+            'id'                    => $vi->id,
+            'custid'                => $vi->custid,
+            'name'                  => $vi->name,
+            'trunk'                 => (bool)$vi->trunk,
+            'lag_framing'           => (bool)$vi->lag_framing,
+            'channelgroup'          => $vi->channelgroup,
+            'physical_interfaces'   => $vi->physicalInterfaces->map( fn( PhysicalInterface $pi ) => [
+                'id'            => $pi->id,
+                'status'        => $pi->status,
+                'speed'         => $pi->speed,
+                'duplex'        => $pi->duplex,
+                'rate_limit'    => $pi->rate_limit,
+                'autoneg'       => (bool)$pi->autoneg,
+                'switchport'    => $pi->switchportid,
+                'switchport_name' => $pi->switchPort?->name,
+                'switch'        => $pi->switchPort?->switchid,
+                'switch_name'   => $pi->switchPort?->switcher?->name,
+            ] )->values()->all(),
+            'vlan_interfaces'       => $vi->vlanInterfaces->map( fn( VlanInterface $vli ) => [
+                'id'            => $vli->id,
+                'vlan'          => $vli->vlanid,
+                'ipv4enabled'   => (bool)$vli->ipv4enabled,
+                'ipv4address'   => $vli->ipv4address?->address,
+                'ipv4hostname'  => $vli->ipv4hostname,
+                'ipv6enabled'   => (bool)$vli->ipv6enabled,
+                'ipv6address'   => $vli->ipv6address?->address,
+                'ipv6hostname'  => $vli->ipv6hostname,
+                'rsclient'      => (bool)$vli->rsclient,
+                'irrdbfilter'   => (bool)$vli->irrdbfilter,
+                'as112client'   => (bool)$vli->as112client,
+                'maxbgpprefix'  => [ 'ipv4' => $vli->ipv4maxbgpprefix, 'ipv6' => $vli->ipv6maxbgpprefix ],
+            ] )->values()->all(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V4/Provisioning/ConnectionController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/ConnectionController.php
@@ -66,6 +66,20 @@ use IXP\Support\Provisioning\IpAllocator;
 class ConnectionController extends Common
 {
     /**
+     * Relations connectionAsArray() reads.
+     *
+     * Eager loaded so that listing a member's connections is a fixed number of queries rather
+     * than one per interface per relation.
+     *
+     * @var array<int,string>
+     */
+    private const array RESPONSE_RELATIONS = [
+        'physicalInterfaces.switchPort.switcher',
+        'vlanInterfaces.ipv4address',
+        'vlanInterfaces.ipv6address',
+    ];
+
+    /**
      * Create a connection for a member.
      *
      * Everything happens in one transaction, including the address allocation: the row lock
@@ -94,7 +108,7 @@ class ConnectionController extends Common
 
         // Reject a switch port which is taken, is not a member port, or sits on another
         // switch, before anything is written:
-        if( $error = $this->rejectUnusableSwitchPort( $r ) ) {
+        if( $error = self::switchPortRejection( $r->input( 'switch' ), $r->input( 'switchportid' ) ) ) {
             return response()->json( [ 'message' => $error ], 422 );
         }
 
@@ -154,7 +168,7 @@ class ConnectionController extends Common
         Log::notice( "Provisioning API: created connection {$vi->id} for {$cust->name} as "
             . Auth::user()->username );
 
-        return response()->json( [ 'connection' => $this->connectionAsArray( $vi->fresh() ) ], 201 );
+        return response()->json( [ 'connection' => $this->connectionAsArray( $vi->fresh( self::RESPONSE_RELATIONS ) ) ], 201 );
     }
 
     /**
@@ -166,9 +180,11 @@ class ConnectionController extends Common
      */
     public function index( Customer $cust ): JsonResponse
     {
-        $connections = $cust->virtualInterfaces->map(
-            fn( VirtualInterface $vi ) => $this->connectionAsArray( $vi )
-        )->values()->all();
+        $connections = $cust->virtualInterfaces()
+            ->with( self::RESPONSE_RELATIONS )
+            ->get()
+            ->map( fn( VirtualInterface $vi ) => $this->connectionAsArray( $vi ) )
+            ->values()->all();
 
         return response()->json( [ 'connections' => $connections ] );
     }
@@ -224,19 +240,23 @@ class ConnectionController extends Common
     /**
      * Reject a switch port which cannot be given to a member.
      *
-     * @param  StoreConnection  $r
+     * Static and parameter-driven so the onboarding endpoint applies the identical gate. When
+     * the two drifted apart, onboarding accepted a port belonging to a different switch.
+     *
+     * @param  mixed  $switchId
+     * @param  mixed  $switchPortId
      *
      * @return string|null  an error message, or null when the port is usable
      */
-    private function rejectUnusableSwitchPort( StoreConnection $r ): ?string
+    public static function switchPortRejection( mixed $switchId, mixed $switchPortId ): ?string
     {
-        $sp = SwitchPort::find( $r->input( 'switchportid' ) );
+        $sp = SwitchPort::find( $switchPortId );
 
         if( !$sp ) {
             return 'The switch port does not exist.';
         }
 
-        if( (int)$sp->switchid !== (int)$r->input( 'switch' ) ) {
+        if( (int)$sp->switchid !== (int)$switchId ) {
             return "Switch port {$sp->name} does not belong to the switch given.";
         }
 

--- a/app/Http/Controllers/Api/V4/Provisioning/ConnectionController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/ConnectionController.php
@@ -158,7 +158,7 @@ class ConnectionController extends Common
                 $vi->save();
 
                 return $vi;
-            } );
+            } , attempts: 3 );
         } catch( IpAllocationException $e ) {
             return response()->json( [ 'message' => $e->getMessage() ], 422 );
         }
@@ -262,6 +262,13 @@ class ConnectionController extends Common
 
         if( $sp->physicalInterface ) {
             return "Switch port {$sp->name} is already assigned to another connection.";
+        }
+
+        // A switch taken out of service between listing free ports and ordering: the
+        // connection would be created but appear in neither the switch configuration nor the
+        // grapher, with nothing raising an alarm.
+        if( !$sp->switcher || !$sp->switcher->active ) {
+            return "Switch port {$sp->name} is on a switch which is not active.";
         }
 
         if( !in_array( (int)$sp->type, [ SwitchPort::TYPE_UNSET, SwitchPort::TYPE_PEERING ], true ) ) {

--- a/app/Http/Controllers/Api/V4/Provisioning/IpController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/IpController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace IXP\Http\Controllers\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+use IXP\Http\Controllers\Api\V4\Controller;
+
+use IXP\Models\IPv4Address;
+use IXP\Models\IPv6Address;
+use IXP\Models\Vlan;
+
+/**
+ * Provisioning API - IP Controller
+ *
+ * Reports which addresses in a VLAN's pool are free.
+ *
+ * Note there is deliberately no "reserve an address" endpoint. An address held by nothing but
+ * a promise is a leak waiting to happen: if the caller then fails, the address stays out of
+ * circulation with no record of why. Allocation happens as part of creating a connection,
+ * inside the same transaction, where it either sticks or is rolled back with everything else.
+ * A caller that simply wants the next free address asks for `"auto"` there.
+ *
+ * @author     KleyReX
+ * @category   APIv4
+ * @package    IXP\Http\Controllers\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class IpController extends Controller
+{
+    /**
+     * List the addresses of a VLAN, marking each as free or in use.
+     *
+     * Query parameters:
+     *   protocol  4, 6 or both (default both)
+     *   free      1 to list only unassigned addresses
+     *   limit     cap per protocol (default 200, max 2000)
+     *
+     * @param  Request  $r
+     * @param  Vlan     $vlan
+     *
+     * @return JsonResponse
+     */
+    public function addresses( Request $r, Vlan $vlan ): JsonResponse
+    {
+        $validated = $r->validate( [
+            'protocol' => 'nullable|integer|in:4,6',
+            'free'     => 'nullable|boolean',
+            'limit'    => 'nullable|integer|min:1|max:2000',
+        ] );
+
+        $limit    = (int)( $validated[ 'limit' ] ?? 200 );
+        $freeOnly = (bool)( $validated[ 'free' ] ?? false );
+        $protocol = isset( $validated[ 'protocol' ] ) ? (int)$validated[ 'protocol' ] : null;
+
+        $out = [
+            'vlan' => [ 'id' => $vlan->id, 'name' => $vlan->name, 'number' => $vlan->number ],
+        ];
+
+        if( $protocol !== 6 ) {
+            $out[ 'ipv4' ] = $this->listFor( IPv4Address::class, 'INET_ATON', $vlan, $freeOnly, $limit );
+        }
+
+        if( $protocol !== 4 ) {
+            $out[ 'ipv6' ] = $this->listFor( IPv6Address::class, 'INET6_ATON', $vlan, $freeOnly, $limit );
+        }
+
+        return response()->json( $out );
+    }
+
+    /**
+     * Build the address list for one protocol.
+     *
+     * @param  class-string<IPv4Address|IPv6Address>  $model
+     * @param  string                                 $orderFn
+     * @param  Vlan                                   $vlan
+     * @param  bool                                   $freeOnly
+     * @param  int                                    $limit
+     *
+     * @return array
+     */
+    private function listFor( string $model, string $orderFn, Vlan $vlan, bool $freeOnly, int $limit ): array
+    {
+        $query = $model::where( 'vlanid', $vlan->id )
+            ->when( $freeOnly, fn( $q ) => $q->whereDoesntHave( 'vlanInterface' ) )
+            ->with( 'vlanInterface' )
+            ->orderByRaw( "{$orderFn}(address) ASC" );
+
+        $total = ( clone $query )->count();
+
+        $addresses = $query->limit( $limit )->get()->map( fn( $ip ) => [
+            'id'      => $ip->id,
+            'address' => $ip->address,
+            'free'    => $ip->vlanInterface === null,
+        ] )->values()->all();
+
+        return [
+            'addresses' => $addresses,
+            'total'     => $total,
+            'truncated' => $total > count( $addresses ),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V4/Provisioning/MemberController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/MemberController.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace IXP\Http\Controllers\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Auth, Cache, Hash, Log;
+
+use Carbon\Carbon;
+use DateTimeInterface;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+use IXP\Events\User\UserCreated as UserCreatedEvent;
+
+use IXP\Http\Controllers\Api\V4\Controller;
+
+use IXP\Http\Requests\Api\V4\Provisioning\{
+    StoreCustomer,
+    StoreUser
+};
+
+use IXP\Models\{
+    CompanyBillingDetail,
+    CompanyRegisteredDetail,
+    Customer,
+    CustomerToUser,
+    User
+};
+
+/**
+ * Provisioning API - Member Controller
+ *
+ * Creates members (customers) and their portal users.
+ *
+ * The two store methods mirror the web controllers rather than calling them: those return
+ * redirects and push flash messages, neither of which a machine caller can use. What matters
+ * is that the resulting database state is identical, which CustomerContractTest and
+ * UserContractTest assert directly by posting the same payload to both entry points and
+ * diffing the rows.
+ *
+ * @see \IXP\Http\Controllers\Customer\CustomerController::store()   the web equivalent
+ * @see \IXP\Http\Controllers\User\UserController::store()           the web equivalent
+ *
+ * @author     KleyReX
+ * @category   APIv4
+ * @package    IXP\Http\Controllers\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class MemberController extends Controller
+{
+    /**
+     * Create a member.
+     *
+     * Mirrors CustomerController@store, including the two detail records it creates
+     * alongside the customer, and wraps the three inserts in a transaction - the web path
+     * does not, so a failure there can leave orphaned detail rows behind.
+     *
+     * @param  StoreCustomer  $r
+     *
+     * @return JsonResponse
+     */
+    public function storeCustomer( StoreCustomer $r ): JsonResponse
+    {
+        $cust = DB::transaction( function() use ( $r ) {
+            $bdetail = CompanyBillingDetail::create( [ 'purchaseOrderRequired' => 0 ] );
+            $rdetail = CompanyRegisteredDetail::create( [ 'registeredName' => $r->input( 'name' ) ] );
+
+            return Customer::create( array_merge( $r->validated(), [
+                'reseller'                     => $r->boolean( 'isResold' ) ? $r->input( 'reseller' ) : null,
+                'company_registered_detail_id' => $rdetail->id,
+                'company_billing_details_id'   => $bdetail->id,
+                'creator'                      => Auth::id(),
+            ] ) );
+        } );
+
+        Cache::forget( 'admin_home_customers' );
+
+        Log::notice( 'Provisioning API: created ' . config( 'ixp_fe.lang.customer.one' )
+            . " {$cust->name} (id {$cust->id}) as " . Auth::user()->username );
+
+        return response()->json( [ 'member' => $this->memberAsArray( $cust ) ], 201 );
+    }
+
+    /**
+     * Read a member.
+     *
+     * @param  Customer  $cust
+     *
+     * @return JsonResponse
+     */
+    public function showCustomer( Customer $cust ): JsonResponse
+    {
+        return response()->json( [ 'member' => $this->memberAsArray( $cust ) ] );
+    }
+
+    /**
+     * Create a portal user for a member.
+     *
+     * Mirrors UserController@store. The password is random and never returned: the account is
+     * activated by the welcome email, which carries a password reset token. Firing
+     * UserCreatedEvent is therefore not optional - without it the user has no way in.
+     *
+     * @param  StoreUser  $r
+     * @param  Customer   $cust
+     *
+     * @return JsonResponse
+     */
+    public function storeUser( StoreUser $r, Customer $cust ): JsonResponse
+    {
+        $user = DB::transaction( function() use ( $r, $cust ) {
+            $user = new User;
+            $user->creator          = Auth::user()->username;
+            $user->password         = Hash::make( Str::random( 16 ) );
+            $user->name             = $r->input( 'name' );
+            $user->authorisedMobile = $r->input( 'authorisedMobile' );
+            $user->username         = strtolower( $r->string( 'username' )->toString() );
+            $user->email            = strtolower( $r->string( 'email' )->toString() );
+
+            // the web form posts `disabled` and inverts it; the API takes `enabled` and
+            // defaults to an enabled account, which is the only sensible default when the
+            // very next thing that happens is a welcome email:
+            $user->disabled         = $r->boolean( 'enabled', true ) ? 0 : 1;
+
+            $user->lastupdatedby    = Auth::id();
+            $user->custid           = $cust->id;
+            $user->save();
+
+            $c2u = new CustomerToUser;
+            $c2u->customer_id       = $cust->id;
+            $c2u->user_id           = $user->id;
+            $c2u->privs             = $r->input( 'privs' );
+            $c2u->extra_attributes  = [ 'created_by' => [ 'type' => 'api', 'user_id' => Auth::id() ] ];
+            $c2u->save();
+
+            return $user;
+        } );
+
+        // only once the transaction has committed, or a later failure would still have sent
+        // the welcome email:
+        event( new UserCreatedEvent( $user ) );
+
+        Log::notice( "Provisioning API: created user {$user->username} for {$cust->name} as "
+            . Auth::user()->username );
+
+        return response()->json( [ 'user' => $this->userAsArray( $user, (int)$r->input( 'privs' ) ) ], 201 );
+    }
+
+    /**
+     * Representation of a member for API responses.
+     *
+     * Deliberately an explicit field list rather than the model's toArray(): the response
+     * shape is a contract with the caller and should not change because a column was added.
+     *
+     * @param  Customer  $cust
+     *
+     * @return array
+     */
+    private function memberAsArray( Customer $cust ): array
+    {
+        return [
+            'id'                => $cust->id,
+            'name'              => $cust->name,
+            'shortname'         => $cust->shortname,
+            'abbreviatedName'   => $cust->abbreviatedName,
+            'type'              => $cust->type,
+            'status'            => $cust->status,
+            'autsys'            => $cust->autsys,
+            'maxprefixes'       => $cust->maxprefixes,
+            'maxprefixesv6'     => $cust->maxprefixesv6,
+            'peeringemail'      => $cust->peeringemail,
+            'peeringmacro'      => $cust->peeringmacro,
+            'peeringmacrov6'    => $cust->peeringmacrov6,
+            'peeringpolicy'     => $cust->peeringpolicy,
+            'irrdb'             => $cust->irrdb,
+            'datejoin'          => $this->asDate( $cust->datejoin ),
+            'dateleave'         => $this->asDate( $cust->dateleave ),
+            'reseller'          => $cust->reseller,
+            'isReseller'        => (bool)$cust->isReseller,
+        ];
+    }
+
+    /**
+     * Normalise a date attribute to Y-m-d for API responses.
+     *
+     * Customer declares datejoin/dateleave in $dates, which Laravel no longer honours - the
+     * attributes therefore arrive as raw strings, not Carbon instances. Accept either, so
+     * that this keeps working if upstream moves them to $casts.
+     *
+     * @param  mixed  $value
+     *
+     * @return string|null
+     */
+    private function asDate( mixed $value ): ?string
+    {
+        if( $value === null || $value === '' ) {
+            return null;
+        }
+
+        return $value instanceof DateTimeInterface
+            ? $value->format( 'Y-m-d' )
+            : Carbon::parse( $value )->format( 'Y-m-d' );
+    }
+
+    /**
+     * Representation of a user for API responses.
+     *
+     * @param  User  $user
+     * @param  int   $privs
+     *
+     * @return array
+     */
+    private function userAsArray( User $user, int $privs ): array
+    {
+        return [
+            'id'                => $user->id,
+            'name'              => $user->name,
+            'username'          => $user->username,
+            'email'             => $user->email,
+            'custid'            => $user->custid,
+            'privs'             => $privs,
+            'enabled'           => !$user->disabled,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V4/Provisioning/OnboardingController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/OnboardingController.php
@@ -99,15 +99,18 @@ class OnboardingController extends Common
         }
 
         try {
-            $result = DB::transaction( fn() => $this->provision( $r, $reference ) );
+            $result = DB::transaction( fn() => $this->provision( $r, $reference ) , attempts: 3 );
         } catch( IpAllocationException $e ) {
             return response()->json( [ 'message' => $e->getMessage() ], 422 );
         } catch( ValidationException $e ) {
             return response()->json( [ 'message' => $e->getMessage(), 'errors' => $e->errors() ], 422 );
         } catch( UniqueConstraintViolationException $e ) {
-            // Two retries of the same order arriving together: both got past the middleware
-            // before either committed, and the loser hits the unique index on the reference.
-            // By now the winner has committed, so the answer is the same one it received.
+            // Which unique index was hit matters. The reference index means a retry of the
+            // same order raced itself; anything else - most likely switchportid, which is
+            // unique on physicalinterface - means a different order took the resource first.
+            //
+            // Telling the second case "use a new reference" would be actively harmful: the
+            // caller would burn an order number and retry onto the same occupied port.
             if( $reference && ( $existing = ProvisioningReference::customerFor( $reference ) ) ) {
                 return response()->json( [
                     'created'   => false,
@@ -116,11 +119,18 @@ class OnboardingController extends Common
                 ] );
             }
 
-            // A reference whose customer no longer exists - deleted after the fact. Saying so
-            // is more use than a 500 with a SQL message in it.
+            if( $reference && str_contains( $e->getMessage(), 'provisioning_references' ) ) {
+                // The reference is taken but its customer is gone - deleted after the fact.
+                return response()->json( [
+                    'message' => 'This reference has been used before and the member it created no longer '
+                        . 'exists. Use a new reference.',
+                ], 409 );
+            }
+
             return response()->json( [
-                'message' => 'This reference has been used before and the member it created no longer exists. '
-                    . 'Use a new reference.',
+                'message' => 'Another request took one of the resources for this order while it was being '
+                    . 'processed - most likely the switch port. Nothing was created. Choose a different '
+                    . 'port and retry with the same reference.',
             ], 409 );
         }
 

--- a/app/Http/Controllers/Api/V4/Provisioning/OnboardingController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/OnboardingController.php
@@ -28,6 +28,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Validation\ValidationException;
 
 use IXP\Events\User\UserCreated as UserCreatedEvent;
@@ -89,7 +90,7 @@ class OnboardingController extends Common
     {
         $reference = $r->input( 'reference' );
 
-        if( $reference && ( $existing = $this->existingFor( $reference ) ) ) {
+        if( $reference && ( $existing = ProvisioningReference::customerFor( $reference ) ) ) {
             return response()->json( [
                 'created'   => false,
                 'reference' => $reference,
@@ -103,6 +104,24 @@ class OnboardingController extends Common
             return response()->json( [ 'message' => $e->getMessage() ], 422 );
         } catch( ValidationException $e ) {
             return response()->json( [ 'message' => $e->getMessage(), 'errors' => $e->errors() ], 422 );
+        } catch( UniqueConstraintViolationException $e ) {
+            // Two retries of the same order arriving together: both got past the middleware
+            // before either committed, and the loser hits the unique index on the reference.
+            // By now the winner has committed, so the answer is the same one it received.
+            if( $reference && ( $existing = ProvisioningReference::customerFor( $reference ) ) ) {
+                return response()->json( [
+                    'created'   => false,
+                    'reference' => $reference,
+                    'member'    => [ 'id' => $existing->id, 'shortname' => $existing->shortname ],
+                ] );
+            }
+
+            // A reference whose customer no longer exists - deleted after the fact. Saying so
+            // is more use than a 500 with a SQL message in it.
+            return response()->json( [
+                'message' => 'This reference has been used before and the member it created no longer exists. '
+                    . 'Use a new reference.',
+            ], 409 );
         }
 
         Cache::forget( 'admin_home_customers' );
@@ -137,9 +156,14 @@ class OnboardingController extends Common
      */
     private function provision( StoreOnboarding $r, ?string $reference ): array
     {
-        $cust = $this->createCustomer( $r );
-        $user = $r->has( 'user' ) ? $this->createUser( $r, $cust ) : null;
-        $vi   = $r->has( 'connection' ) ? $this->createConnection( $r, $cust ) : null;
+        // Only ever the validated payload: $r->all() would carry through anything the caller
+        // chose to send, and Customer, VirtualInterface and PhysicalInterface all have fillable
+        // columns with no rule attached - lastupdatedby, channelgroup, notes among them.
+        $validated = $r->validated();
+
+        $cust = $this->createCustomer( $validated[ 'member' ] );
+        $user = isset( $validated[ 'user' ] ) ? $this->createUser( $validated[ 'user' ], $cust ) : null;
+        $vi   = isset( $validated[ 'connection' ] ) ? $this->createConnection( $validated[ 'connection' ], $cust ) : null;
 
         if( $reference ) {
             ProvisioningReference::create( [
@@ -154,14 +178,12 @@ class OnboardingController extends Common
     }
 
     /**
-     * @param  StoreOnboarding  $r
+     * @param  array  $member  the validated member section
      *
      * @return Customer
      */
-    private function createCustomer( StoreOnboarding $r ): Customer
+    private function createCustomer( array $member ): Customer
     {
-        $member = $r->input( 'member' );
-
         $bdetail = CompanyBillingDetail::create( [ 'purchaseOrderRequired' => 0 ] );
         $rdetail = CompanyRegisteredDetail::create( [ 'registeredName' => $member[ 'name' ] ] );
 
@@ -174,15 +196,13 @@ class OnboardingController extends Common
     }
 
     /**
-     * @param  StoreOnboarding  $r
-     * @param  Customer         $cust
+     * @param  array     $input  the validated user section
+     * @param  Customer  $cust
      *
      * @return User
      */
-    private function createUser( StoreOnboarding $r, Customer $cust ): User
+    private function createUser( array $input, Customer $cust ): User
     {
-        $input = $r->input( 'user' );
-
         $user = new User;
         $user->creator          = Auth::user()->username;
         $user->password         = Hash::make( Str::random( 16 ) );
@@ -206,27 +226,24 @@ class OnboardingController extends Common
     }
 
     /**
-     * @param  StoreOnboarding  $r
-     * @param  Customer         $cust
+     * @param  array     $input  the validated connection section
+     * @param  Customer  $cust
      *
      * @return VirtualInterface
      *
      * @throws IpAllocationException
      */
-    private function createConnection( StoreOnboarding $r, Customer $cust ): VirtualInterface
+    private function createConnection( array $input, Customer $cust ): VirtualInterface
     {
-        $input = $r->input( 'connection' );
-        $vlan  = Vlan::findOrFail( $input[ 'vlanid' ] );
+        $vlan = Vlan::findOrFail( $input[ 'vlanid' ] );
 
-        $sp = SwitchPort::find( $input[ 'switchportid' ] );
-
-        if( !$sp || $sp->physicalInterface ) {
-            throw new IpAllocationException( 'The switch port is unknown or already in use.' );
+        // Same gate as ConnectionController, so both entry points accept exactly the same
+        // ports - including the check that the port belongs to the switch named:
+        if( $error = ConnectionController::switchPortRejection( $input[ 'switch' ] ?? null, $input[ 'switchportid' ] ?? null ) ) {
+            throw new IpAllocationException( $error );
         }
 
-        if( !in_array( (int)$sp->type, [ SwitchPort::TYPE_UNSET, SwitchPort::TYPE_PEERING ], true ) ) {
-            throw new IpAllocationException( "Switch port {$sp->name} is not a member port." );
-        }
+        $sp = SwitchPort::findOrFail( $input[ 'switchportid' ] );
 
         $vi = VirtualInterface::create( array_merge( $input, [ 'custid' => $cust->id ] ) );
 
@@ -269,17 +286,5 @@ class OnboardingController extends Common
         $vi->save();
 
         return $vi;
-    }
-
-    /**
-     * The customer a previous call with this reference produced, if any.
-     *
-     * @param  string  $reference
-     *
-     * @return Customer|null
-     */
-    private function existingFor( string $reference ): ?Customer
-    {
-        return ProvisioningReference::customerFor( $reference );
     }
 }

--- a/app/Http/Controllers/Api/V4/Provisioning/OnboardingController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/OnboardingController.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace IXP\Http\Controllers\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Auth, Cache, Hash, Log;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+use IXP\Events\User\UserCreated as UserCreatedEvent;
+
+use IXP\Http\Controllers\Interfaces\Common;
+
+use IXP\Http\Requests\Api\V4\Provisioning\StoreOnboarding;
+
+use IXP\Models\{
+    CompanyBillingDetail,
+    CompanyRegisteredDetail,
+    Customer,
+    CustomerToUser,
+    PhysicalInterface,
+    ProvisioningReference,
+    SwitchPort,
+    User,
+    VirtualInterface,
+    Vlan,
+    VlanInterface
+};
+
+use IXP\Support\Provisioning\IpAllocationException;
+use IXP\Support\Provisioning\IpAllocator;
+
+/**
+ * Provisioning API - Onboarding Controller
+ *
+ * Creates a member, an optional portal user and an optional connection in one transaction.
+ *
+ * The individual endpoints exist and can be called in sequence; this one exists because that
+ * sequence is not atomic. Customer creation and user creation are separate writes, so a caller
+ * whose second request fails is left with a half-provisioned member and no clean way back. Here
+ * either the whole order lands or none of it does.
+ *
+ * It does not orchestrate anything beyond the database. Switch configuration, route server
+ * config and reverse DNS are the caller's business - this endpoint only makes the IXP Manager
+ * side of an order indivisible.
+ *
+ * Idempotency: a caller which passes `reference` and then retries after a timeout gets the
+ * original result back rather than a duplicate member.
+ *
+ * @author     KleyReX
+ * @category   APIv4
+ * @package    IXP\Http\Controllers\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class OnboardingController extends Common
+{
+    /**
+     * Provision a member, and optionally a user and a connection.
+     *
+     * @param  StoreOnboarding  $r
+     *
+     * @return JsonResponse
+     */
+    public function store( StoreOnboarding $r ): JsonResponse
+    {
+        $reference = $r->input( 'reference' );
+
+        if( $reference && ( $existing = $this->existingFor( $reference ) ) ) {
+            return response()->json( [
+                'created'   => false,
+                'reference' => $reference,
+                'member'    => [ 'id' => $existing->id, 'shortname' => $existing->shortname ],
+            ] );
+        }
+
+        try {
+            $result = DB::transaction( fn() => $this->provision( $r, $reference ) );
+        } catch( IpAllocationException $e ) {
+            return response()->json( [ 'message' => $e->getMessage() ], 422 );
+        } catch( ValidationException $e ) {
+            return response()->json( [ 'message' => $e->getMessage(), 'errors' => $e->errors() ], 422 );
+        }
+
+        Cache::forget( 'admin_home_customers' );
+
+        // Events after the commit, never inside it: an onboarding which is rolled back must
+        // not have sent the member a welcome email telling them to set a password.
+        if( $result[ 'user' ] instanceof User ) {
+            event( new UserCreatedEvent( $result[ 'user' ] ) );
+        }
+
+        Log::notice( "Provisioning API: onboarded {$result['customer']->name} (id {$result['customer']->id})"
+            . ( $reference ? " for reference {$reference}" : '' ) . ' as ' . Auth::user()->username );
+
+        return response()->json( [
+            'created'    => true,
+            'reference'  => $reference,
+            'member'     => [ 'id' => $result[ 'customer' ]->id, 'shortname' => $result[ 'customer' ]->shortname ],
+            'user'       => $result[ 'user' ] ? [ 'id' => $result[ 'user' ]->id, 'username' => $result[ 'user' ]->username ] : null,
+            'connection' => $result[ 'vi' ] ? [ 'id' => $result[ 'vi' ]->id ] : null,
+        ], 201 );
+    }
+
+    /**
+     * Do the work. Runs inside the caller's transaction.
+     *
+     * @param  StoreOnboarding  $r
+     * @param  string|null      $reference
+     *
+     * @return array{customer: Customer, user: User|null, vi: VirtualInterface|null}
+     *
+     * @throws IpAllocationException
+     */
+    private function provision( StoreOnboarding $r, ?string $reference ): array
+    {
+        $cust = $this->createCustomer( $r );
+        $user = $r->has( 'user' ) ? $this->createUser( $r, $cust ) : null;
+        $vi   = $r->has( 'connection' ) ? $this->createConnection( $r, $cust ) : null;
+
+        if( $reference ) {
+            ProvisioningReference::create( [
+                'reference'  => $reference,
+                'model_type' => Customer::class,
+                'model_id'   => $cust->id,
+                'created_by' => Auth::id(),
+            ] );
+        }
+
+        return [ 'customer' => $cust, 'user' => $user, 'vi' => $vi ];
+    }
+
+    /**
+     * @param  StoreOnboarding  $r
+     *
+     * @return Customer
+     */
+    private function createCustomer( StoreOnboarding $r ): Customer
+    {
+        $member = $r->input( 'member' );
+
+        $bdetail = CompanyBillingDetail::create( [ 'purchaseOrderRequired' => 0 ] );
+        $rdetail = CompanyRegisteredDetail::create( [ 'registeredName' => $member[ 'name' ] ] );
+
+        return Customer::create( array_merge( $member, [
+            'reseller'                     => !empty( $member[ 'isResold' ] ) ? ( $member[ 'reseller' ] ?? null ) : null,
+            'company_registered_detail_id' => $rdetail->id,
+            'company_billing_details_id'   => $bdetail->id,
+            'creator'                      => Auth::id(),
+        ] ) );
+    }
+
+    /**
+     * @param  StoreOnboarding  $r
+     * @param  Customer         $cust
+     *
+     * @return User
+     */
+    private function createUser( StoreOnboarding $r, Customer $cust ): User
+    {
+        $input = $r->input( 'user' );
+
+        $user = new User;
+        $user->creator          = Auth::user()->username;
+        $user->password         = Hash::make( Str::random( 16 ) );
+        $user->name             = $input[ 'name' ];
+        $user->authorisedMobile = $input[ 'authorisedMobile' ] ?? null;
+        $user->username         = strtolower( (string)$input[ 'username' ] );
+        $user->email            = strtolower( (string)$input[ 'email' ] );
+        $user->disabled         = ( $input[ 'enabled' ] ?? true ) ? 0 : 1;
+        $user->lastupdatedby    = Auth::id();
+        $user->custid           = $cust->id;
+        $user->save();
+
+        $c2u = new CustomerToUser;
+        $c2u->customer_id       = $cust->id;
+        $c2u->user_id           = $user->id;
+        $c2u->privs             = $input[ 'privs' ];
+        $c2u->extra_attributes  = [ 'created_by' => [ 'type' => 'api', 'user_id' => Auth::id() ] ];
+        $c2u->save();
+
+        return $user;
+    }
+
+    /**
+     * @param  StoreOnboarding  $r
+     * @param  Customer         $cust
+     *
+     * @return VirtualInterface
+     *
+     * @throws IpAllocationException
+     */
+    private function createConnection( StoreOnboarding $r, Customer $cust ): VirtualInterface
+    {
+        $input = $r->input( 'connection' );
+        $vlan  = Vlan::findOrFail( $input[ 'vlanid' ] );
+
+        $sp = SwitchPort::find( $input[ 'switchportid' ] );
+
+        if( !$sp || $sp->physicalInterface ) {
+            throw new IpAllocationException( 'The switch port is unknown or already in use.' );
+        }
+
+        if( !in_array( (int)$sp->type, [ SwitchPort::TYPE_UNSET, SwitchPort::TYPE_PEERING ], true ) ) {
+            throw new IpAllocationException( "Switch port {$sp->name} is not a member port." );
+        }
+
+        $vi = VirtualInterface::create( array_merge( $input, [ 'custid' => $cust->id ] ) );
+
+        PhysicalInterface::create( array_merge( $input, [
+            'virtualinterfaceid' => $vi->id,
+            'status'             => $input[ 'status' ] ?? PhysicalInterface::STATUS_CONNECTED,
+            'duplex'             => $input[ 'duplex' ] ?? 'full',
+        ] ) );
+
+        $sp->update( [ 'type' => SwitchPort::TYPE_PEERING ] );
+
+        $allocator = new IpAllocator();
+        $resolved  = $input;
+
+        foreach( [ false, true ] as $ipv6 ) {
+            $field = ( $ipv6 ? 'ipv6' : 'ipv4' ) . 'address';
+
+            $ip = $allocator->claim( $vlan, $input[ $field ] ?? null, $ipv6 );
+
+            $resolved[ $field ] = $ip?->address;
+        }
+
+        $vli = new VlanInterface( array_merge( $input, [
+            'virtualinterfaceid' => $vi->id,
+            'busyhost'           => (bool)( $input[ 'busyhost' ] ?? false ),
+        ] ) );
+
+        $ipRequest = Request::create( '/', 'POST', $resolved );
+
+        if( !$this->setIp( $ipRequest, $vlan, $vli, false ) || !$this->setIp( $ipRequest, $vlan, $vli, true ) ) {
+            throw new IpAllocationException(
+                'An address became unavailable while the connection was being created. Please retry.'
+            );
+        }
+
+        $vli->save();
+
+        $vi->refresh();
+        $this->setBundleDetails( $vi );
+        $vi->save();
+
+        return $vi;
+    }
+
+    /**
+     * The customer a previous call with this reference produced, if any.
+     *
+     * @param  string  $reference
+     *
+     * @return Customer|null
+     */
+    private function existingFor( string $reference ): ?Customer
+    {
+        return ProvisioningReference::customerFor( $reference );
+    }
+}

--- a/app/Http/Controllers/Api/V4/Provisioning/PingController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/PingController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace IXP\Http\Controllers\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Http\JsonResponse;
+
+use IXP\Http\Controllers\Api\V4\Controller;
+
+use Auth;
+
+/**
+ * Provisioning API - Ping Controller
+ *
+ * A health / connectivity check for the provisioning API.
+ *
+ * It exists so that an operator can verify the whole authentication chain - API key,
+ * superuser privilege and JSON content negotiation - without creating anything.
+ *
+ * @author     KleyReX
+ * @category   APIv4
+ * @package    IXP\Http\Controllers\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class PingController extends Controller
+{
+    /**
+     * Confirm that the provisioning API is reachable and the API key is accepted.
+     *
+     * Note that the user is resolved from the API key by the `apiauth` middleware, which
+     * logs the key's owner in via Auth::onceUsingId(). Auth::user() is therefore populated
+     * exactly as it would be for a browser session.
+     *
+     * @return JsonResponse
+     */
+    public function ping(): JsonResponse
+    {
+        return response()->json( [
+            'pong'      => true,
+            'user'      => Auth::user()->username,
+            'version'   => APPLICATION_VERSION,
+        ] );
+    }
+}

--- a/app/Http/Controllers/Api/V4/Provisioning/PortController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/PortController.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace IXP\Http\Controllers\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+use IXP\Http\Controllers\Api\V4\Controller;
+
+use IXP\Models\Aggregators\SwitchPortAggregator;
+use IXP\Models\Infrastructure;
+use IXP\Models\SwitchPort;
+use IXP\Models\Switcher;
+
+/**
+ * Provisioning API - Port Controller
+ *
+ * Finds switch ports which are free to be assigned to a member.
+ *
+ * The web UI answers this question one switch at a time, because an operator has already
+ * picked the switch from a dropdown. An ordering system has not: it knows the infrastructure
+ * and the speed it sold, and needs to be told where that fits. This walks every active switch
+ * and returns the candidates.
+ *
+ * Read-only, so a GET is correct here.
+ *
+ * @author     KleyReX
+ * @category   APIv4
+ * @package    IXP\Http\Controllers\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class PortController extends Controller
+{
+    /**
+     * List switch ports with no physical interface attached.
+     *
+     * A port counts as free when it has no PhysicalInterface and its type is either unset or
+     * peering. Deliberately excluded are core, management, monitor, fanout and reseller ports:
+     * handing one of those to an ordering system would let it reassign infrastructure.
+     *
+     * Optional query parameters:
+     *   infrastructure  restrict to one infrastructure id
+     *   switch          restrict to one switch id
+     *   limit           cap the number of ports returned (default 100, max 1000)
+     *
+     * @param  Request  $r
+     *
+     * @return JsonResponse
+     */
+    public function free( Request $r ): JsonResponse
+    {
+        $validated = $r->validate( [
+            'infrastructure' => 'nullable|integer|exists:infrastructure,id',
+            'switch'         => 'nullable|integer|exists:switch,id',
+            'limit'          => 'nullable|integer|min:1|max:1000',
+        ] );
+
+        $limit = (int)( $validated[ 'limit' ] ?? 100 );
+
+        $switches = Switcher::where( 'active', true )
+            ->when( isset( $validated[ 'infrastructure' ] ), function( $q ) use ( $validated ) {
+                return $q->where( 'infrastructure', $validated[ 'infrastructure' ] );
+            } )
+            ->when( isset( $validated[ 'switch' ] ), function( $q ) use ( $validated ) {
+                return $q->where( 'id', $validated[ 'switch' ] );
+            } )
+            ->orderBy( 'name' )
+            ->get();
+
+        $ports = [];
+
+        foreach( $switches as $switch ) {
+            $free = SwitchPortAggregator::getAllPortsForSwitch(
+                $switch->id,
+                [ SwitchPort::TYPE_UNSET, SwitchPort::TYPE_PEERING ],
+                [],
+                true
+            );
+
+            foreach( $free as $port ) {
+                if( count( $ports ) >= $limit ) {
+                    break 2;
+                }
+
+                $ports[] = [
+                    'switchport'        => (int)$port[ 'id' ],
+                    'name'              => $port[ 'name' ],
+                    'type'              => (int)$port[ 'porttype' ],
+                    'switch'            => $switch->id,
+                    'switch_name'       => $switch->name,
+                    'infrastructure'    => $switch->infrastructure,
+                ];
+            }
+        }
+
+        return response()->json( [
+            'ports'     => $ports,
+            'count'     => count( $ports ),
+            'truncated' => count( $ports ) >= $limit,
+        ] );
+    }
+
+    /**
+     * List the active switches, so a caller can resolve names to ids without guessing.
+     *
+     * @return JsonResponse
+     */
+    public function switches(): JsonResponse
+    {
+        $switches = Switcher::where( 'active', true )->orderBy( 'name' )->get()
+            ->map( fn( Switcher $s ) => [
+                'id'                => $s->id,
+                'name'              => $s->name,
+                'infrastructure'    => $s->infrastructure,
+                'hostname'          => $s->hostname,
+            ] )->values()->all();
+
+        return response()->json( [ 'switches' => $switches ] );
+    }
+
+    /**
+     * List the infrastructures and their VLANs, which a caller needs before requesting a port.
+     *
+     * @return JsonResponse
+     */
+    public function infrastructures(): JsonResponse
+    {
+        $infras = [];
+
+        foreach( Infrastructure::orderBy( 'name' )->get() as $infra ) {
+            $vlans = [];
+
+            foreach( $infra->vlans as $vlan ) {
+                $vlans[] = [
+                    'id'     => $vlan->id,
+                    'name'   => $vlan->name,
+                    'number' => $vlan->number,
+                ];
+            }
+
+            $infras[] = [
+                'id'        => $infra->id,
+                'name'      => $infra->name,
+                'shortname' => $infra->shortname,
+                'isPrimary' => (bool)$infra->isPrimary,
+                'vlans'     => $vlans,
+            ];
+        }
+
+        return response()->json( [ 'infrastructures' => $infras ] );
+    }
+}

--- a/app/Http/Controllers/Api/V4/Provisioning/PortController.php
+++ b/app/Http/Controllers/Api/V4/Provisioning/PortController.php
@@ -99,7 +99,10 @@ class PortController extends Controller
             );
 
             foreach( $free as $port ) {
-                if( count( $ports ) >= $limit ) {
+                // collect one beyond the limit, purely to tell "exactly full" from "there is
+                // more" - reporting truncated=true on a complete result would send a caller
+                // looking for pages which do not exist:
+                if( count( $ports ) > $limit ) {
                     break 2;
                 }
 
@@ -114,10 +117,13 @@ class PortController extends Controller
             }
         }
 
+        $truncated = count( $ports ) > $limit;
+        $ports     = array_slice( $ports, 0, $limit );
+
         return response()->json( [
             'ports'     => $ports,
             'count'     => count( $ports ),
-            'truncated' => count( $ports ) >= $limit,
+            'truncated' => $truncated,
         ] );
     }
 

--- a/app/Http/Controllers/Api/V4/UserController.php
+++ b/app/Http/Controllers/Api/V4/UserController.php
@@ -49,6 +49,10 @@ class UserController extends Controller
     /**
      * API call to get users as JSON
      *
+     * Names the columns rather than emitting the whole row. $hidden on the model already
+     * keeps the password hash out of the serialisation; selecting explicitly means a column
+     * added later - and any sensitivity it carries - does not appear here by accident.
+     *
      * @param int|null $priv Optionally limit to users of given privilege
      *
      * @return JsonResponse
@@ -56,7 +60,14 @@ class UserController extends Controller
     public function json( ?int $priv = null ): JsonResponse
     {
         return response()->json(
-            User::byPrivs( $priv )->get()->toArray()
+            User::byPrivs( $priv )
+                ->select( [
+                    'user.id', 'user.custid', 'user.username', 'user.email', 'user.name',
+                    'user.authorisedMobile', 'user.uid', 'user.disabled', 'user.peeringdb_id',
+                    'user.created_at', 'user.updated_at',
+                ] )
+                ->get()
+                ->toArray()
         );
     }
 

--- a/app/Http/Middleware/Provisioning/ForceJsonResponse.php
+++ b/app/Http/Middleware/Provisioning/ForceJsonResponse.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace IXP\Http\Middleware\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Closure;
+
+use Illuminate\Http\Request;
+
+/**
+ * Middleware: ForceJsonResponse
+ *
+ * The provisioning API is consumed by machines only. Without an `Accept: application/json`
+ * request header, Laravel renders framework-generated errors as HTML - and, worse, turns a
+ * ValidationException into a 302 redirect rather than a 422 JSON body. That is invisible to
+ * a client which only inspects the status code.
+ *
+ * Rather than requiring every caller to remember the header, we set it here, before the
+ * `api/v4` middleware group runs.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Http\Middleware\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class ForceJsonResponse
+{
+    /**
+     * Force JSON content negotiation for provisioning API requests.
+     *
+     * @param  Request  $r
+     * @param  Closure  $next
+     *
+     * @return mixed
+     */
+    public function handle( Request $r, Closure $next )
+    {
+        $r->headers->set( 'Accept', 'application/json' );
+
+        return $next( $r );
+    }
+}

--- a/app/Http/Middleware/Provisioning/RequireApiKey.php
+++ b/app/Http/Middleware/Provisioning/RequireApiKey.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace IXP\Http\Middleware\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Closure;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Middleware: RequireApiKey
+ *
+ * Insists on an API key and refuses ambient browser credentials.
+ *
+ * The `api/v4` middleware group starts a session, and ApiAuthenticate only looks for a key
+ * when Auth::check() is false. A browser already logged in as a superuser therefore reaches
+ * these endpoints on its session cookie - and because the group deliberately omits `web`,
+ * without a CSRF token either. For read-only export endpoints that is tolerable; for
+ * endpoints which create members it is not, because it makes them reachable by any page that
+ * can persuade an administrator's browser to issue a request.
+ *
+ * Runs before the `api/v4` group so that a stale session is gone before ApiAuthenticate looks
+ * at it.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Http\Middleware\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class RequireApiKey
+{
+    /**
+     * @param  Request  $r
+     * @param  Closure  $next
+     *
+     * @return mixed
+     */
+    public function handle( Request $r, Closure $next )
+    {
+        if( !config( 'ixp_api.provisioning.require_api_key', true ) ) {
+            return $next( $r );
+        }
+
+        if( !$r->header( 'X-IXP-Manager-API-Key' ) ) {
+            Log::warning(
+                'Provisioning API: request without an API key from ' . $r->ip() . ' to ' . $r->path()
+            );
+
+            return response()->json( [
+                'message' => 'These endpoints require an API key in the X-IXP-Manager-API-Key header. '
+                    . 'A browser session is not accepted here.',
+            ], 401 );
+        }
+
+        return $next( $r );
+    }
+}

--- a/app/Http/Middleware/Provisioning/RestrictSourceAddress.php
+++ b/app/Http/Middleware/Provisioning/RestrictSourceAddress.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace IXP\Http\Middleware\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Auth, Closure;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+use IXP\Models\ApiKey;
+
+/**
+ * Middleware: RestrictSourceAddress
+ *
+ * Limits the provisioning endpoints to known source addresses.
+ *
+ * Two independent layers, either or both of which may be unset:
+ *
+ *   - `ixp_api.provisioning.allowed_ips` applies to every provisioning request
+ *   - `api_keys.allowed_ips` applies to the key presented
+ *
+ * The second is worth explaining. That column has existed for years and is exposed in the
+ * key management UI, but nothing in IXP Manager ever reads it - a key restricted to one
+ * address today works from anywhere. These endpoints honour it, so an operator who has
+ * filled it in gets what they expected.
+ *
+ * This runs after `api/v4`, because the key has to be resolved before its allow-list can be
+ * read.
+ *
+ * A note on where this belongs: the primary place to restrict these endpoints is the web
+ * server, which is what the `/admin` prefix introduced in v7.1.0 is for. This is a second
+ * lock on the same door - useful when the application sits behind a proxy whose ACL you do
+ * not control, and harmless when it does not.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Http\Middleware\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class RestrictSourceAddress
+{
+    /**
+     * @param  Request  $r
+     * @param  Closure  $next
+     *
+     * @return mixed
+     */
+    public function handle( Request $r, Closure $next )
+    {
+        // request()->ip() honours TrustProxies; the helper ixp_get_client_ip() trusts
+        // caller-supplied headers ahead of REMOTE_ADDR and must not be used for a decision.
+        $source = $r->ip();
+
+        if( !$this->permitted( $source, config( 'ixp_api.provisioning.allowed_ips', '' ) ) ) {
+            return $this->refuse( $r, $source, 'the configured allow-list' );
+        }
+
+        if( ( $key = $this->apiKey() ) && !$this->permitted( $source, $key->allowed_ips ?? "" ) ) {
+            return $this->refuse( $r, $source, 'the allow-list of the API key used' );
+        }
+
+        return $next( $r );
+    }
+
+    /**
+     * The API key behind this request, if one was resolved.
+     *
+     * @return ApiKey|null
+     */
+    private function apiKey(): ?ApiKey
+    {
+        if( !Auth::check() || !( $token = request()->header( 'X-IXP-Manager-API-Key' ) ) ) {
+            return null;
+        }
+
+        // Match on the identifier rather than the secret: keys are stored hashed.
+        if( !str_starts_with( $token, ApiKey::PREFIX ) ) {
+            return null;
+        }
+
+        $parts = explode( '_', $token );
+
+        return isset( $parts[ 1 ] )
+            ? ApiKey::where( 'token_identifier', $parts[ 1 ] )->first()
+            : null;
+    }
+
+    /**
+     * Whether a source address is covered by an allow-list.
+     *
+     * An empty list means no restriction at that layer - not "deny everything".
+     *
+     * @param  string  $source
+     * @param  string  $list    comma separated addresses and CIDR ranges
+     *
+     * @return bool
+     */
+    private function permitted( string $source, string $list ): bool
+    {
+        $entries = array_filter( array_map( 'trim', explode( ',', $list ) ) );
+
+        if( $entries === [] ) {
+            return true;
+        }
+
+        foreach( $entries as $entry ) {
+            if( $this->matches( $source, $entry ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether an address falls within a single allow-list entry.
+     *
+     * Handles a bare address or CIDR notation, IPv4 and IPv6. Comparison is on packed form,
+     * so notation differences do not matter.
+     *
+     * @param  string  $source
+     * @param  string  $entry
+     *
+     * @return bool
+     */
+    private function matches( string $source, string $entry ): bool
+    {
+        $packedSource = @inet_pton( $source );
+
+        if( $packedSource === false ) {
+            return false;
+        }
+
+        if( !str_contains( $entry, '/' ) ) {
+            return @inet_pton( $entry ) === $packedSource;
+        }
+
+        [ $network, $bits ] = explode( '/', $entry, 2 );
+
+        $packedNetwork = @inet_pton( $network );
+        $bits          = (int)$bits;
+
+        // Comparing an IPv4 address against an IPv6 range - or the reverse - is never a match.
+        if( $packedNetwork === false || strlen( $packedNetwork ) !== strlen( $packedSource ) ) {
+            return false;
+        }
+
+        if( $bits < 0 || $bits > strlen( $packedNetwork ) * 8 ) {
+            return false;
+        }
+
+        $wholeBytes = intdiv( $bits, 8 );
+        $oddBits    = $bits % 8;
+
+        if( $wholeBytes > 0 && strncmp( $packedSource, $packedNetwork, $wholeBytes ) !== 0 ) {
+            return false;
+        }
+
+        if( $oddBits === 0 ) {
+            return true;
+        }
+
+        $mask = ~( ( 1 << ( 8 - $oddBits ) ) - 1 ) & 0xff;
+
+        return ( ord( $packedSource[ $wholeBytes ] ) & $mask )
+            === ( ord( $packedNetwork[ $wholeBytes ] ) & $mask );
+    }
+
+    /**
+     * @param  Request  $r
+     * @param  string   $source
+     * @param  string   $which
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    private function refuse( Request $r, string $source, string $which )
+    {
+        Log::warning( "Provisioning API: refused {$source} - not covered by {$which} ({$r->path()})" );
+
+        return response()->json( [
+            'message' => 'This source address is not permitted to use the provisioning API.',
+        ], 403 );
+    }
+}

--- a/app/Http/Middleware/Provisioning/ShortCircuitKnownReference.php
+++ b/app/Http/Middleware/Provisioning/ShortCircuitKnownReference.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace IXP\Http\Middleware\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Closure;
+
+use Illuminate\Http\Request;
+
+use IXP\Models\ProvisioningReference;
+
+/**
+ * Middleware: ShortCircuitKnownReference
+ *
+ * Answers a repeated onboarding request from the record of the first one.
+ *
+ * This has to run before validation, not in the controller. A caller retrying after a timeout
+ * sends the identical payload, and by then the shortname it asks for exists - so validation
+ * would reject the retry with a 422 about a duplicate shortname. Technically true, useless in
+ * practice: the caller wants to know what happened to its order, and "you already have it" is
+ * the answer, not "that name is taken".
+ *
+ * The controller keeps its own check as well. This one closes the common case; that one closes
+ * the window between two simultaneous retries, where both pass here before either commits.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Http\Middleware\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class ShortCircuitKnownReference
+{
+    /**
+     * Return the earlier result if this reference has been seen before.
+     *
+     * @param  Request  $r
+     * @param  Closure  $next
+     *
+     * @return mixed
+     */
+    public function handle( Request $r, Closure $next )
+    {
+        $reference = $r->input( 'reference' );
+
+        if( !is_string( $reference ) || $reference === '' ) {
+            return $next( $r );
+        }
+
+        if( !( $cust = ProvisioningReference::customerFor( $reference ) ) ) {
+            return $next( $r );
+        }
+
+        return response()->json( [
+            'created'   => false,
+            'reference' => $reference,
+            'member'    => [ 'id' => $cust->id, 'shortname' => $cust->shortname ],
+        ] );
+    }
+}

--- a/app/Http/Requests/Api/V4/Provisioning/StoreConnection.php
+++ b/app/Http/Requests/Api/V4/Provisioning/StoreConnection.php
@@ -77,14 +77,68 @@ class StoreConnection extends StoreVirtualInterfaceWizard
      * Kept separate from delta() so RulesParityTest can tell "we added something upstream does
      * not have" from "we deliberately overrode upstream", and check the second is intentional.
      *
+     * Only the address *type* is relaxed here, never the requirement. The wizard rule is
+     * `ipv4|required` when the family is enabled; "auto" is not an IP, so the `ipv4` part has
+     * to go, but the conditional `required` must stay. Dropping it lets a caller create a
+     * VLAN interface with ipv4enabled=1 and no address, and that row goes on to render as
+     * `neighbor  as 65551;` in the route server configuration - a parse error which invalidates
+     * the generated config for the whole VLAN, not merely that peer.
+     *
      * @return array<string,mixed>
      */
-    public static function overrides(): array
+    public function overrides(): array
     {
         return [
-            'ipv4address' => 'nullable|string|max:255',
-            'ipv6address' => 'nullable|string|max:255',
+            'ipv4address' => ( $this->boolean( 'ipv4enabled' ) ? 'required' : 'nullable' ) . '|string|max:255',
+            'ipv6address' => ( $this->boolean( 'ipv6enabled' ) ? 'required' : 'nullable' ) . '|string|max:255',
         ];
+    }
+
+    /**
+     * The fields overrides() replaces, without evaluating the rules.
+     *
+     * Lets callers and tests reason about which upstream rules are shadowed without needing a
+     * populated request instance.
+     *
+     * @return array<int,string>
+     */
+    public static function overriddenFields(): array
+    {
+        return [ 'ipv4address', 'ipv6address' ];
+    }
+
+    /**
+     * Check the address fields of a connection payload for syntax.
+     *
+     * Static and payload-driven so that the onboarding endpoint, whose connection lives in a
+     * nested key, applies exactly the same check rather than a second copy of it.
+     *
+     * Non-string values are skipped: an array where a string belongs is already caught by the
+     * inherited `string` rule, and casting one here would be a fatal error, turning a 422 into
+     * a 500.
+     *
+     * @param  array  $payload
+     *
+     * @return array<string,string>  field => message, empty when everything is acceptable
+     */
+    public static function addressSyntaxErrors( array $payload ): array
+    {
+        $errors = [];
+
+        foreach( [ 'ipv4' => FILTER_FLAG_IPV4, 'ipv6' => FILTER_FLAG_IPV6 ] as $proto => $flag ) {
+            $field = $proto . 'address';
+            $value = $payload[ $field ] ?? null;
+
+            if( !is_string( $value ) || $value === '' || strtolower( trim( $value ) ) === 'auto' ) {
+                continue;
+            }
+
+            if( filter_var( $value, FILTER_VALIDATE_IP, $flag ) === false ) {
+                $errors[ $field ] = "The {$field} must be a valid {$proto} address or \"auto\".";
+            }
+        }
+
+        return $errors;
     }
 
     /**
@@ -99,7 +153,7 @@ class StoreConnection extends StoreVirtualInterfaceWizard
     #[\Override]
     public function rules(): array
     {
-        return array_merge( parent::rules(), self::delta(), self::overrides() );
+        return array_merge( parent::rules(), self::delta(), $this->overrides() );
     }
 
     /**
@@ -145,17 +199,8 @@ class StoreConnection extends StoreVirtualInterfaceWizard
     public function withValidator( $validator ): void
     {
         $validator->after( function( $validator ) {
-            foreach( [ 'ipv4' => FILTER_FLAG_IPV4, 'ipv6' => FILTER_FLAG_IPV6 ] as $proto => $flag ) {
-                $field = $proto . 'address';
-                $value = $this->input( $field );
-
-                if( $value === null || $value === '' || strtolower( trim( (string)$value ) ) === 'auto' ) {
-                    continue;
-                }
-
-                if( filter_var( $value, FILTER_VALIDATE_IP, $flag ) === false ) {
-                    $validator->errors()->add( $field, "The {$field} must be a valid {$proto} address or \"auto\"." );
-                }
+            foreach( self::addressSyntaxErrors( $this->all() ) as $field => $message ) {
+                $validator->errors()->add( $field, $message );
             }
         } );
     }

--- a/app/Http/Requests/Api/V4/Provisioning/StoreConnection.php
+++ b/app/Http/Requests/Api/V4/Provisioning/StoreConnection.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace IXP\Http\Requests\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use IXP\Http\Requests\StoreVirtualInterfaceWizard;
+use IXP\Models\Customer;
+use IXP\Models\PhysicalInterface;
+
+/**
+ * Provisioning API - StoreConnection request
+ *
+ * Extends the wizard request behind the web UI's "add a port" flow; see StoreCustomer for the
+ * reasoning behind the DELTA split and RulesParityTest.
+ *
+ * Two differences from the web wizard are worth stating plainly, because both relax a rule
+ * rather than tighten one:
+ *
+ *   - `ipv4address` and `ipv6address` accept the literal "auto" as well as an address. The
+ *     wizard requires an explicit address because a human picks it from a list rendered in the
+ *     browser; unattended provisioning has no such list. The address rule is therefore
+ *     replaced by one which also permits "auto", and IpAllocator resolves it.
+ *   - `rate_limit` and `autoneg` are accepted. Both are columns of PhysicalInterface and both
+ *     are exported to the switch configuration generator, but v7.3.1's wizard request does not
+ *     list them (upstream `main` has since added them). Without them a rate-limited port
+ *     cannot be provisioned through the API at all.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Http\Requests\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class StoreConnection extends StoreVirtualInterfaceWizard
+{
+    /**
+     * Rules added on top of the inherited wizard rules.
+     *
+     * @return array<string,mixed>
+     */
+    public static function delta(): array
+    {
+        return [
+            'rate_limit'    => 'nullable|integer|min:0',
+            'autoneg'       => 'boolean',
+            'name'          => 'nullable|string|max:255',
+            'description'   => 'nullable|string|max:255',
+            'mtu'           => 'nullable|integer|min:0',
+            'lag_framing'   => 'boolean',
+            'fastlacp'      => 'boolean',
+            'busyhost'      => 'boolean',
+        ];
+    }
+
+    /**
+     * Rules replaced outright, rather than added.
+     *
+     * Kept separate from delta() so RulesParityTest can tell "we added something upstream does
+     * not have" from "we deliberately overrode upstream", and check the second is intentional.
+     *
+     * @return array<string,mixed>
+     */
+    public static function overrides(): array
+    {
+        return [
+            'ipv4address' => 'nullable|string|max:255',
+            'ipv6address' => 'nullable|string|max:255',
+        ];
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string,mixed>
+     *
+     * @psalm-suppress LessSpecificImplementedReturnType
+     *      The parent's return type is an inferred array shape. Merging the delta widens it
+     *      by construction, so a narrower annotation here is not possible.
+     */
+    #[\Override]
+    public function rules(): array
+    {
+        return array_merge( parent::rules(), self::delta(), self::overrides() );
+    }
+
+    /**
+     * Take the customer from the route, and normalise the address fields.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $merge = [];
+
+        if( ( $cust = $this->route( 'cust' ) ) instanceof Customer ) {
+            $merge[ 'custid' ] = $cust->id;
+        }
+
+        // The wizard's status/speed/duplex are required. Sensible defaults keep a caller from
+        // having to restate what is true of every member port; anything unusual is still
+        // explicit:
+        if( !$this->has( 'status' ) ) {
+            $merge[ 'status' ] = PhysicalInterface::STATUS_CONNECTED;
+        }
+
+        if( !$this->has( 'duplex' ) ) {
+            $merge[ 'duplex' ] = 'full';
+        }
+
+        $this->merge( $merge );
+    }
+
+    /**
+     * Validate the "auto" keyword and address syntax, which the replaced rules no longer cover.
+     *
+     * Note there is no parent::withValidator() call: StoreVirtualInterfaceWizard does not
+     * define one, and Laravel only invokes the hook when it exists. Should upstream add one,
+     * it has to be chained in here by hand - RulesParityTest compares rules(), not hooks, so
+     * it would not catch that on its own.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     *
+     * @return void
+     */
+    public function withValidator( $validator ): void
+    {
+        $validator->after( function( $validator ) {
+            foreach( [ 'ipv4' => FILTER_FLAG_IPV4, 'ipv6' => FILTER_FLAG_IPV6 ] as $proto => $flag ) {
+                $field = $proto . 'address';
+                $value = $this->input( $field );
+
+                if( $value === null || $value === '' || strtolower( trim( (string)$value ) ) === 'auto' ) {
+                    continue;
+                }
+
+                if( filter_var( $value, FILTER_VALIDATE_IP, $flag ) === false ) {
+                    $validator->errors()->add( $field, "The {$field} must be a valid {$proto} address or \"auto\"." );
+                }
+            }
+        } );
+    }
+}

--- a/app/Http/Requests/Api/V4/Provisioning/StoreConnection.php
+++ b/app/Http/Requests/Api/V4/Provisioning/StoreConnection.php
@@ -39,10 +39,9 @@ use IXP\Models\PhysicalInterface;
  *     wizard requires an explicit address because a human picks it from a list rendered in the
  *     browser; unattended provisioning has no such list. The address rule is therefore
  *     replaced by one which also permits "auto", and IpAllocator resolves it.
- *   - `rate_limit` and `autoneg` are accepted. Both are columns of PhysicalInterface and both
- *     are exported to the switch configuration generator, but v7.3.1's wizard request does not
- *     list them (upstream `main` has since added them). Without them a rate-limited port
- *     cannot be provisioned through the API at all.
+ *   - Fields the wizard has no form control for are accepted: the LAG settings, the MTU and
+ *     the interface name and description. All are fillable columns which an unattended caller
+ *     has no other way to set.
  *
  * @author     KleyReX
  * @category   IXP
@@ -60,8 +59,6 @@ class StoreConnection extends StoreVirtualInterfaceWizard
     public static function delta(): array
     {
         return [
-            'rate_limit'    => 'nullable|integer|min:0',
-            'autoneg'       => 'boolean',
             'name'          => 'nullable|string|max:255',
             'description'   => 'nullable|string|max:255',
             'mtu'           => 'nullable|integer|min:0',

--- a/app/Http/Requests/Api/V4/Provisioning/StoreCustomer.php
+++ b/app/Http/Requests/Api/V4/Provisioning/StoreCustomer.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace IXP\Http\Requests\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use IXP\Http\Requests\Customer\Store;
+use IXP\Models\Customer;
+
+/**
+ * Provisioning API - StoreCustomer request
+ *
+ * Extends the web form request so that the API and the web UI validate against the same
+ * rules. Anything this class adds lives in DELTA, which RulesParityTest uses to assert that
+ * nothing else has diverged: if upstream changes a rule we inherit, that test fails and the
+ * difference is dealt with deliberately rather than discovered in production.
+ *
+ * The delta itself covers fillable attributes the web request does not validate. Three of
+ * them are worth naming, because they are easy to mistake for typos here rather than there:
+ * the columns are `dateleave`, `MD5Support` and `isReseller`, whereas the web rules refer to
+ * `dateleft` and `md5support`. Those two rules therefore match nothing and the values reach
+ * Customer::create() unvalidated. We do not change the web rules - that is upstream's call -
+ * but the API validates the names the database actually uses.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Http\Requests\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class StoreCustomer extends Store
+{
+    /**
+     * Rules added on top of the inherited web form rules.
+     *
+     * Kept as a separate, machine-readable constant so that the parity test can subtract it.
+     *
+     * @return array<string,string>
+     */
+    public static function delta(): array
+    {
+        return [
+            'dateleave'             => 'nullable|date',
+            'MD5Support'            => 'nullable|string|in:' . implode( ',', array_keys( Customer::$MD5_SUPPORT ) ),
+            'isReseller'            => 'boolean',
+            'isResold'              => 'boolean',
+            'activepeeringmatrix'   => 'boolean',
+        ];
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string,mixed>
+     *
+     * @psalm-suppress LessSpecificImplementedReturnType
+     *      The parent's return type is an inferred array shape. Merging the delta widens it
+     *      by construction, so a narrower annotation here is not possible.
+     */
+    #[\Override]
+    public function rules(): array
+    {
+        return array_merge( parent::rules(), self::delta() );
+    }
+}

--- a/app/Http/Requests/Api/V4/Provisioning/StoreOnboarding.php
+++ b/app/Http/Requests/Api/V4/Provisioning/StoreOnboarding.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace IXP\Http\Requests\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+use IXP\Models\User;
+
+/**
+ * Provisioning API - StoreOnboarding request
+ *
+ * Validates a composite order: a member, optionally a user, optionally a connection.
+ *
+ * The three sections are nested rather than flattened, so that field names cannot collide -
+ * `name` means something different for a member, a user and a virtual interface. Each section
+ * is validated with the same rules as its dedicated endpoint, re-keyed under its prefix, so
+ * there is still exactly one definition of what a valid member is.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Http\Requests\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class StoreOnboarding extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        /** @var User $us */
+        $us = Auth::getUser();
+
+        // the route middleware already asserts superuser, so this can only agree with it:
+        return $us->isSuperUser();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * Each section reuses the rules of its own endpoint, prefixed. Doing it this way means a
+     * rule added upstream reaches this endpoint too, without anybody remembering to copy it.
+     *
+     * @return array<string,mixed>
+     */
+    public function rules(): array
+    {
+        $rules = [
+            'reference'  => 'nullable|string|max:191',
+            'member'     => 'required|array',
+            'user'       => 'nullable|array',
+            'connection' => 'nullable|array',
+        ];
+
+        foreach( $this->sectionRules() as $section => $sectionRules ) {
+            foreach( $sectionRules as $field => $rule ) {
+                $rules[ "{$section}.{$field}" ] = $rule;
+            }
+        }
+
+        return $rules;
+    }
+
+    /**
+     * The rules of each section, taken from the dedicated request classes.
+     *
+     * The sub-requests are constructed with this request's section payload so that rules which
+     * depend on the input - the customer type, whether an address family is enabled - resolve
+     * the same way they would at the dedicated endpoint.
+     *
+     * @return array<string,array<string,mixed>>
+     */
+    private function sectionRules(): array
+    {
+        $sections = [
+            'member' => StoreCustomer::create( '/', 'POST', (array)$this->input( 'member', [] ) ),
+        ];
+
+        if( $this->has( 'user' ) ) {
+            $sections[ 'user' ] = StoreUser::create( '/', 'POST', (array)$this->input( 'user', [] ) );
+        }
+
+        if( $this->has( 'connection' ) ) {
+            $sections[ 'connection' ] = StoreConnection::create( '/', 'POST', (array)$this->input( 'connection', [] ) );
+        }
+
+        $out = [];
+
+        foreach( $sections as $name => $request ) {
+            $out[ $name ] = $request->rules();
+        }
+
+        // custid is supplied by the member we are about to create, so it cannot be required
+        // of the caller here:
+        unset( $out[ 'user' ][ 'custid' ], $out[ 'connection' ][ 'custid' ] );
+
+        return $out;
+    }
+
+    /**
+     * Apply the defaults the connection section would get at its own endpoint.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        if( !$this->has( 'connection' ) ) {
+            return;
+        }
+
+        $connection = (array)$this->input( 'connection' );
+
+        $connection[ 'status' ] ??= \IXP\Models\PhysicalInterface::STATUS_CONNECTED;
+        $connection[ 'duplex' ] ??= 'full';
+
+        $this->merge( [ 'connection' => $connection ] );
+    }
+
+    /**
+     * Validate address syntax in the connection section, mirroring StoreConnection.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     *
+     * @return void
+     */
+    public function withValidator( $validator ): void
+    {
+        $validator->after( function( $validator ) {
+            if( !$this->has( 'connection' ) ) {
+                return;
+            }
+
+            foreach( [ 'ipv4' => FILTER_FLAG_IPV4, 'ipv6' => FILTER_FLAG_IPV6 ] as $proto => $flag ) {
+                $field = $proto . 'address';
+                $value = $this->input( "connection.{$field}" );
+
+                if( $value === null || $value === '' || strtolower( trim( (string)$value ) ) === 'auto' ) {
+                    continue;
+                }
+
+                if( filter_var( $value, FILTER_VALIDATE_IP, $flag ) === false ) {
+                    $validator->errors()->add(
+                        "connection.{$field}",
+                        "The {$field} must be a valid {$proto} address or \"auto\"."
+                    );
+                }
+            }
+        } );
+    }
+}

--- a/app/Http/Requests/Api/V4/Provisioning/StoreOnboarding.php
+++ b/app/Http/Requests/Api/V4/Provisioning/StoreOnboarding.php
@@ -26,6 +26,8 @@ use Auth;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+use IXP\Models\Customer;
+use IXP\Models\PhysicalInterface;
 use IXP\Models\User;
 
 /**
@@ -136,14 +138,33 @@ class StoreOnboarding extends FormRequest
 
         $connection = (array)$this->input( 'connection' );
 
-        $connection[ 'status' ] ??= \IXP\Models\PhysicalInterface::STATUS_CONNECTED;
+        $connection[ 'status' ] ??= PhysicalInterface::STATUS_CONNECTED;
         $connection[ 'duplex' ] ??= 'full';
 
         $this->merge( [ 'connection' => $connection ] );
     }
 
     /**
-     * Validate address syntax in the connection section, mirroring StoreConnection.
+     * Apply the checks the dedicated endpoints perform outside their rule sets.
+     *
+     * Copying rules() out of the sub-requests is not enough. Laravel invokes withValidator()
+     * on the request it is actually validating, and that is this one - so the sub-requests'
+     * own hooks never run, and every check which lives in a hook rather than a rule silently
+     * does not apply here.
+     *
+     * That is not cosmetic. Two of those checks are the only thing standing between a caller
+     * and a privilege escalation:
+     *
+     *   - User\Store::withValidator() refuses AUTH_SUPERUSER unless the target customer is an
+     *     internal one. Without it, an order could create a full IXP Manager administrator
+     *     attached to an arbitrary member - and the welcome email would hand over the
+     *     password-reset link.
+     *   - Customer\Store::checkReseller() refuses a resold customer with no reseller named.
+     *     Without it the flag is silently dropped and the member is created un-resold.
+     *
+     * The checks are restated here rather than delegated, because the upstream hooks read
+     * state which does not exist yet at this point: User\Store looks up Customer::find($custid)
+     * for a customer this very request is about to create, and would dereference null.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      *
@@ -152,25 +173,79 @@ class StoreOnboarding extends FormRequest
     public function withValidator( $validator ): void
     {
         $validator->after( function( $validator ) {
-            if( !$this->has( 'connection' ) ) {
-                return;
-            }
-
-            foreach( [ 'ipv4' => FILTER_FLAG_IPV4, 'ipv6' => FILTER_FLAG_IPV6 ] as $proto => $flag ) {
-                $field = $proto . 'address';
-                $value = $this->input( "connection.{$field}" );
-
-                if( $value === null || $value === '' || strtolower( trim( (string)$value ) ) === 'auto' ) {
-                    continue;
-                }
-
-                if( filter_var( $value, FILTER_VALIDATE_IP, $flag ) === false ) {
-                    $validator->errors()->add(
-                        "connection.{$field}",
-                        "The {$field} must be a valid {$proto} address or \"auto\"."
-                    );
-                }
-            }
+            $this->checkSuperuserPrivilege( $validator );
+            $this->checkReseller( $validator );
+            $this->checkConnectionAddresses( $validator );
         } );
+    }
+
+    /**
+     * Superuser privileges may only be granted on an internal customer.
+     *
+     * Mirrors IXP\Http\Requests\User\Store::withValidator(), evaluated against the customer
+     * this request is creating rather than one already in the database.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     *
+     * @return void
+     */
+    private function checkSuperuserPrivilege( $validator ): void
+    {
+        if( !$this->has( 'user' ) ) {
+            return;
+        }
+
+        if( (int)$this->input( 'user.privs' ) !== User::AUTH_SUPERUSER ) {
+            return;
+        }
+
+        if( (int)$this->input( 'member.type' ) !== Customer::TYPE_INTERNAL ) {
+            $validator->errors()->add(
+                'user.privs',
+                'You are not allowed to set this user as a super user: the member being created is not an internal customer.'
+            );
+        }
+    }
+
+    /**
+     * A resold member must name its reseller.
+     *
+     * Mirrors the relevant branch of IXP\Http\Requests\Customer\Store::checkReseller(). The
+     * remaining branches concern moving an existing customer between resellers, which cannot
+     * apply to one being created.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     *
+     * @return void
+     */
+    private function checkReseller( $validator ): void
+    {
+        if( !$this->boolean( 'member.isResold' ) ) {
+            return;
+        }
+
+        $reseller = $this->input( 'member.reseller' );
+
+        if( !$reseller || !Customer::find( $reseller ) ) {
+            $validator->errors()->add( 'member.reseller', 'Please choose a reseller.' );
+        }
+    }
+
+    /**
+     * Address syntax in the connection section, using the same check as StoreConnection.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     *
+     * @return void
+     */
+    private function checkConnectionAddresses( $validator ): void
+    {
+        if( !$this->has( 'connection' ) ) {
+            return;
+        }
+
+        foreach( StoreConnection::addressSyntaxErrors( (array)$this->input( 'connection', [] ) ) as $field => $message ) {
+            $validator->errors()->add( "connection.{$field}", $message );
+        }
     }
 }

--- a/app/Http/Requests/Api/V4/Provisioning/StoreUser.php
+++ b/app/Http/Requests/Api/V4/Provisioning/StoreUser.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace IXP\Http\Requests\Api\V4\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use IXP\Http\Requests\User\Store;
+use IXP\Models\Customer;
+
+/**
+ * Provisioning API - StoreUser request
+ *
+ * Extends the web form request so both entry points validate identically; see StoreCustomer
+ * for the reasoning behind the DELTA split and RulesParityTest.
+ *
+ * The delta adds `enabled`. The web form posts a field named `disabled` whose value the
+ * controller inverts (UserController@store: `$user->disabled = $r->disabled ? 0 : 1`), which
+ * reads as a bug and is at best surprising. Rather than reproduce that inversion, the API
+ * takes an `enabled` boolean and the controller writes the `disabled` column from it.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Http\Requests\Api\V4\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class StoreUser extends Store
+{
+    /**
+     * Rules added on top of the inherited web form rules.
+     *
+     * @return array<string,string>
+     */
+    public static function delta(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string,mixed>
+     *
+     * @psalm-suppress LessSpecificImplementedReturnType
+     *      The parent's return type is an inferred array shape. Merging the delta widens it
+     *      by construction, so a narrower annotation here is not possible.
+     */
+    #[\Override]
+    public function rules(): array
+    {
+        return array_merge( parent::rules(), self::delta() );
+    }
+
+    /**
+     * Take the customer from the route so that callers do not have to repeat it in the body.
+     *
+     * The inherited rules require `custid`, and the inherited withValidator() reads it when
+     * deciding whether a superuser privilege may be granted, so it has to be present before
+     * validation runs rather than be filled in by the controller afterwards.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        if( ( $cust = $this->route( 'cust' ) ) instanceof Customer ) {
+            $this->merge( [ 'custid' => $cust->id ] );
+        }
+    }
+}

--- a/app/Http/Requests/Api/V4/Provisioning/StoreUser.php
+++ b/app/Http/Requests/Api/V4/Provisioning/StoreUser.php
@@ -83,6 +83,12 @@ class StoreUser extends Store
     #[\Override]
     protected function prepareForValidation(): void
     {
+        // The inherited username rule reads `$this->id` to exempt the record being edited from
+        // the uniqueness check. This endpoint only creates, so an `id` in the body could only
+        // serve to exempt someone else's username - and the request would then fail on the
+        // database constraint with a 500 rather than a 422:
+        $this->request->remove( 'id' );
+
         if( ( $cust = $this->route( 'cust' ) ) instanceof Customer ) {
             $this->merge( [ 'custid' => $cust->id ] );
         }

--- a/app/Models/ProvisioningReference.php
+++ b/app/Models/ProvisioningReference.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace IXP\Models;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * Links an external system's reference to what it created here.
+ *
+ * @property int         $id
+ * @property string      $reference
+ * @property string      $model_type
+ * @property int         $model_id
+ * @property int|null    $created_by
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Models
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class ProvisioningReference extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'provisioning_references';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'reference',
+        'model_type',
+        'model_id',
+        'created_by',
+    ];
+
+    /**
+     * The thing this reference produced.
+     *
+     * @return MorphTo
+     */
+    public function model(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * The customer a previous call with this reference produced, if any.
+     *
+     * @param  string|null  $reference
+     *
+     * @return Customer|null
+     */
+    public static function customerFor( ?string $reference ): ?Customer
+    {
+        if( $reference === null || $reference === '' ) {
+            return null;
+        }
+
+        $ref = self::where( 'reference', $reference )
+            ->where( 'model_type', Customer::class )
+            ->first();
+
+        return $ref ? Customer::find( $ref->model_id ) : null;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -119,6 +119,26 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     protected $table = 'user';
 
     /**
+     * The attributes hidden from array and JSON representations.
+     *
+     * Without this, anything which serialises a user emits the password hash. That is not
+     * hypothetical: UserController::json() answers with User::byPrivs()->get()->toArray(),
+     * and that route is reachable with an API key and without a CSRF token
+     * (routes/apiv4-ext-auth-superuser.php) - so a superuser key returned the bcrypt hash of
+     * every user of every customer.
+     *
+     * This hides the attribute from serialisation only. Direct access still works, which
+     * matters: the console server and RADIUS templates under
+     * resources/views/api/v4/user/formatted/ read $user->password deliberately, and
+     * authentication reads it through getAuthPassword(). Neither goes through toArray().
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'password',
+    ];
+
+    /**
      * The attributes that should be cast.
      *
      * @var array

--- a/app/Providers/ProvisioningRouteServiceProvider.php
+++ b/app/Providers/ProvisioningRouteServiceProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace IXP\Providers;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+use IXP\Http\Middleware\Provisioning\ForceJsonResponse;
+use IXP\Models\User;
+
+/**
+ * ProvisioningRouteServiceProvider
+ *
+ * Registers the provisioning API routes - stateless, machine-to-machine endpoints for
+ * creating members, users and connections from an external system such as an ordering or
+ * billing platform.
+ *
+ * These deliberately mirror RouteServiceProvider::mapApiExternalAuthSuperuserRoutes()
+ * rather than mapApiAuthSuperuserRoutes():
+ *
+ *   - No `web` middleware, therefore no session cookie and no CSRF token. The latter is
+ *     precisely why the existing POST endpoints under `admin/api/v4` cannot be called from
+ *     outside a browser at all: VerifyCsrfToken excepts `login` and nothing else.
+ *   - Authentication is by API key alone (`api/v4` => apibase + apiauth) and restricted to
+ *     superusers via `assert.privilege`.
+ *
+ * The `unsecured_api_access` fallback of the upstream provider is deliberately NOT
+ * reproduced: these endpoints write, so they must never be reachable without a key.
+ *
+ * This is kept as a separate provider - rather than another map*() method on
+ * RouteServiceProvider - so that the feature stays additive. Registering this class in
+ * config/app.php is the only change made to a pre-existing file.
+ *
+ * Note that $namespace is deliberately left null: it would otherwise be applied globally
+ * by setRootControllerNamespace(). The controller namespace is scoped to the route group
+ * instead.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Providers
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class ProvisioningRouteServiceProvider extends ServiceProvider
+{
+    /**
+     * The controller namespace for the provisioning API route group.
+     *
+     * @var string
+     */
+    protected string $apiNamespace = 'IXP\Http\Controllers\Api\V4\Provisioning';
+
+    /**
+     * Define the routes for the provisioning API.
+     *
+     * Called by the framework via loadRoutes().
+     *
+     * @return void
+     */
+    public function map(): void
+    {
+        Route::group( [
+            'middleware' => [
+                ForceJsonResponse::class,
+                'api/v4',
+                'assert.privilege:' . User::AUTH_SUPERUSER,
+            ],
+            'namespace'  => $this->apiNamespace,
+            'prefix'     => 'admin/api/v4/provisioning',
+        ], function() {
+            require base_path( 'routes/apiv4-provisioning.php' );
+        } );
+    }
+}

--- a/app/Providers/ProvisioningRouteServiceProvider.php
+++ b/app/Providers/ProvisioningRouteServiceProvider.php
@@ -38,11 +38,20 @@ use IXP\Models\User;
  * These deliberately mirror RouteServiceProvider::mapApiExternalAuthSuperuserRoutes()
  * rather than mapApiAuthSuperuserRoutes():
  *
- *   - No `web` middleware, therefore no session cookie and no CSRF token. The latter is
- *     precisely why the existing POST endpoints under `admin/api/v4` cannot be called from
- *     outside a browser at all: VerifyCsrfToken excepts `login` and nothing else.
- *   - Authentication is by API key alone (`api/v4` => apibase + apiauth) and restricted to
- *     superusers via `assert.privilege`.
+ *   - No `web` middleware, so no CSRF token is required. That is precisely why the existing
+ *     POST endpoints under `admin/api/v4` cannot be called from outside a browser at all:
+ *     VerifyCsrfToken excepts `login` and nothing else.
+ *   - Authentication is by API key (`api/v4` => apibase + apiauth), restricted to superusers
+ *     via `assert.privilege`.
+ *
+ * One caveat worth stating rather than glossing over: `apibase` starts a session, and
+ * ApiAuthenticate only looks for an API key when `Auth::check()` is false. A browser already
+ * logged in as a superuser therefore reaches these endpoints on its session cookie, without a
+ * key - and, because `web` is absent, without a CSRF token either. That is inherited from the
+ * upstream external route group rather than introduced here, and it matches how those existing
+ * endpoints behave. It does mean these routes must not be treated as key-only: anything which
+ * would be unacceptable for an authenticated superuser's browser to trigger does not belong
+ * here.
  *
  * The `unsecured_api_access` fallback of the upstream provider is deliberately NOT
  * reproduced: these endpoints write, so they must never be reachable without a key.

--- a/app/Providers/ProvisioningRouteServiceProvider.php
+++ b/app/Providers/ProvisioningRouteServiceProvider.php
@@ -26,6 +26,8 @@ use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvi
 use Illuminate\Support\Facades\Route;
 
 use IXP\Http\Middleware\Provisioning\ForceJsonResponse;
+use IXP\Http\Middleware\Provisioning\RequireApiKey;
+use IXP\Http\Middleware\Provisioning\RestrictSourceAddress;
 use IXP\Models\User;
 
 /**
@@ -44,14 +46,23 @@ use IXP\Models\User;
  *   - Authentication is by API key (`api/v4` => apibase + apiauth), restricted to superusers
  *     via `assert.privilege`.
  *
- * One caveat worth stating rather than glossing over: `apibase` starts a session, and
- * ApiAuthenticate only looks for an API key when `Auth::check()` is false. A browser already
- * logged in as a superuser therefore reaches these endpoints on its session cookie, without a
- * key - and, because `web` is absent, without a CSRF token either. That is inherited from the
- * upstream external route group rather than introduced here, and it matches how those existing
- * endpoints behave. It does mean these routes must not be treated as key-only: anything which
- * would be unacceptable for an authenticated superuser's browser to trigger does not belong
- * here.
+ * Four things guard them, all configurable under `ixp_api.provisioning`:
+ *
+ *   1. **Off by default.** Without `IXP_API_PROVISIONING_ENABLED=true` the routes are never
+ *      registered. An installation which has not asked for these endpoints does not have
+ *      them - an upgrade cannot quietly expose an IXP to something it did not choose.
+ *   2. **An API key is required.** `apibase` starts a session and ApiAuthenticate only looks
+ *      for a key when `Auth::check()` is false, so without RequireApiKey a browser already
+ *      logged in as a superuser would reach these endpoints on its cookie - and, `web` being
+ *      absent, without a CSRF token. Tolerable for the read-only export endpoints this group
+ *      is modelled on; not for endpoints which create members.
+ *   3. **Source addresses can be restricted**, both globally and per key. The latter honours
+ *      `api_keys.allowed_ips`, a column which exists and is exposed in the UI but which
+ *      nothing in IXP Manager has ever read.
+ *   4. **Rate limited** per key, defaulting to 60 requests a minute.
+ *
+ * None of that replaces restricting `/admin` at the web server, which is what the prefix
+ * introduced in v7.1.0 is for. It is a second lock on the same door.
  *
  * The `unsecured_api_access` fallback of the upstream provider is deliberately NOT
  * reproduced: these endpoints write, so they must never be reachable without a key.
@@ -88,16 +99,45 @@ class ProvisioningRouteServiceProvider extends ServiceProvider
      */
     public function map(): void
     {
+        // Off unless the operator has switched it on. An installation which has not asked for
+        // these endpoints does not have them - the routes are never registered, so there is
+        // nothing to reach and nothing to secure.
+        if( !config( 'ixp_api.provisioning.enabled', false ) ) {
+            return;
+        }
+
         Route::group( [
-            'middleware' => [
-                ForceJsonResponse::class,
-                'api/v4',
-                'assert.privilege:' . User::AUTH_SUPERUSER,
-            ],
+            'middleware' => $this->middleware(),
             'namespace'  => $this->apiNamespace,
             'prefix'     => 'admin/api/v4/provisioning',
         ], function() {
             require base_path( 'routes/apiv4-provisioning.php' );
         } );
+    }
+
+    /**
+     * The middleware stack, in the order it has to run.
+     *
+     * RequireApiKey comes before `api/v4` so that a browser session is rejected before
+     * ApiAuthenticate has a chance to accept it. RestrictSourceAddress comes after, because
+     * it needs the resolved key to read that key's own allow-list.
+     *
+     * @return array<int,string>
+     */
+    private function middleware(): array
+    {
+        $stack = [
+            ForceJsonResponse::class,
+            RequireApiKey::class,
+            'api/v4',
+            'assert.privilege:' . User::AUTH_SUPERUSER,
+            RestrictSourceAddress::class,
+        ];
+
+        if( ( $limit = config( "ixp_api.provisioning.rate_limit", 60 ) ) > 0 ) {
+            $stack[] = "throttle:{$limit},1";
+        }
+
+        return $stack;
     }
 }

--- a/app/Support/Provisioning/IpAllocationException.php
+++ b/app/Support/Provisioning/IpAllocationException.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace IXP\Support\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Exception;
+
+/**
+ * Raised when an address cannot be allocated: the pool is exhausted, the address is not in
+ * this VLAN's pool, or it is already assigned.
+ *
+ * Every case is the caller's problem to fix, so controllers translate this into a 422 rather
+ * than letting it become a 500.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Support\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class IpAllocationException extends Exception
+{
+}

--- a/app/Support/Provisioning/IpAllocator.php
+++ b/app/Support/Provisioning/IpAllocator.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace IXP\Support\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use IXP\Models\IPv4Address;
+use IXP\Models\IPv6Address;
+use IXP\Models\Vlan;
+
+/**
+ * Allocates the next free address from a VLAN's peering pool.
+ *
+ * IXP Manager has no server-side equivalent of this: the web wizard requires an explicit
+ * address, and the "which ones are free" question is answered in the browser from
+ * VlanAggregator::ipAddresses(). That is fine for an operator choosing from a list and no use
+ * at all for unattended provisioning, so this is genuinely new code rather than a rearranged
+ * copy of something upstream.
+ *
+ * Free means: the address row exists in the pool for this VLAN and no VlanInterface points at
+ * it. Addresses are created ahead of time (see the ipv4/ipv6 address generator commands), so
+ * allocation never mints a new address - it only claims an existing, unclaimed one.
+ *
+ * Concurrency: two orders being provisioned at the same moment must not receive the same
+ * address. Selecting with a row lock inside the caller's transaction is what prevents that;
+ * the unique indexes on vlaninterface.ipv4addressid / ipv6addressid are the backstop if it
+ * ever does happen. Callers must therefore run inside a transaction - claim() says so.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    IXP\Support\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class IpAllocator
+{
+    /**
+     * Find the next free address of the given protocol in a VLAN, locking the row.
+     *
+     * MUST be called inside a transaction: the lock is released at commit, and until then
+     * nothing else can claim the same row. Called outside one, the lock is pointless and two
+     * concurrent callers can be handed the same address.
+     *
+     * Ordering is numeric rather than lexical - INET_ATON / INET6_ATON, matching
+     * VlanAggregator::ipAddresses() - so that .10 does not come before .9.
+     *
+     * @param  Vlan  $vlan
+     * @param  bool  $ipv6
+     *
+     * @return IPv4Address|IPv6Address|null  null when the pool is exhausted
+     */
+    public function nextFree( Vlan $vlan, bool $ipv6 = false ): IPv4Address|IPv6Address|null
+    {
+        /** @var class-string<IPv4Address|IPv6Address> $model */
+        $model   = $ipv6 ? IPv6Address::class : IPv4Address::class;
+        $orderBy = $ipv6 ? 'INET6_ATON' : 'INET_ATON';
+
+        return $model::where( 'vlanid', $vlan->id )
+            ->whereDoesntHave( 'vlanInterface' )
+            ->orderByRaw( "{$orderBy}(address) ASC" )
+            ->lockForUpdate()
+            ->first();
+    }
+
+    /**
+     * Resolve an address request to a concrete address.
+     *
+     * Accepts either an explicit address - which must exist in this VLAN's pool and be free -
+     * or the literal string "auto", which takes the next free one. Anything else, including
+     * an address belonging to a different VLAN, is a caller error.
+     *
+     * @param  Vlan         $vlan
+     * @param  string|null  $requested  an address, "auto", or null for no address at all
+     * @param  bool         $ipv6
+     *
+     * @return IPv4Address|IPv6Address|null
+     *
+     * @throws IpAllocationException
+     */
+    public function claim( Vlan $vlan, ?string $requested, bool $ipv6 = false ): IPv4Address|IPv6Address|null
+    {
+        $requested = $requested === null ? null : trim( $requested );
+
+        if( $requested === null || $requested === '' ) {
+            return null;
+        }
+
+        $proto = $ipv6 ? 'IPv6' : 'IPv4';
+
+        if( strtolower( $requested ) === 'auto' ) {
+            if( !( $ip = $this->nextFree( $vlan, $ipv6 ) ) ) {
+                throw new IpAllocationException(
+                    "No free {$proto} address left in VLAN {$vlan->name} (id {$vlan->id})."
+                );
+            }
+
+            return $ip;
+        }
+
+        return $this->claimExplicit( $vlan, $requested, $ipv6, $proto );
+    }
+
+    /**
+     * Claim a specific address from the VLAN's pool.
+     *
+     * @param  Vlan    $vlan
+     * @param  string  $address
+     * @param  bool    $ipv6
+     * @param  string  $proto
+     *
+     * @return IPv4Address|IPv6Address
+     *
+     * @throws IpAllocationException
+     */
+    private function claimExplicit( Vlan $vlan, string $address, bool $ipv6, string $proto ): IPv4Address|IPv6Address
+    {
+        /** @var class-string<IPv4Address|IPv6Address> $model */
+        $model = $ipv6 ? IPv6Address::class : IPv4Address::class;
+
+        $normalised = $this->normalise( $address, $ipv6 );
+
+        if( $normalised === null ) {
+            throw new IpAllocationException( "{$address} is not a valid {$proto} address." );
+        }
+
+        // Stored addresses are compared as raw strings everywhere in the existing code, so an
+        // IPv6 address written differently to the stored form (2001:db8::1 vs 2001:0db8::1)
+        // would not match. Compare against both the given and the normalised form:
+        $candidates = array_unique( [ $address, $normalised ] );
+
+        $ip = $model::where( 'vlanid', $vlan->id )
+            ->whereIn( 'address', $candidates )
+            ->lockForUpdate()
+            ->first();
+
+        if( !$ip ) {
+            throw new IpAllocationException(
+                "{$proto} address {$address} is not in the address pool of VLAN {$vlan->name} (id {$vlan->id})."
+            );
+        }
+
+        if( $ip->vlanInterface ) {
+            throw new IpAllocationException(
+                "{$proto} address {$address} is already assigned to another VLAN interface."
+            );
+        }
+
+        return $ip;
+    }
+
+    /**
+     * Normalise an address to its canonical form, or null if it is not valid.
+     *
+     * @param  string  $address
+     * @param  bool    $ipv6
+     *
+     * @return string|null
+     */
+    private function normalise( string $address, bool $ipv6 ): ?string
+    {
+        $flag = $ipv6 ? FILTER_FLAG_IPV6 : FILTER_FLAG_IPV4;
+
+        if( filter_var( $address, FILTER_VALIDATE_IP, $flag ) === false ) {
+            return null;
+        }
+
+        if( ( $packed = @inet_pton( $address ) ) === false ) {
+            return null;
+        }
+
+        $canonical = @inet_ntop( $packed );
+
+        return $canonical === false ? null : $canonical;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -217,6 +217,7 @@ return [
         IXP\Providers\HorizonServiceProvider::class,
         IXP\Providers\TelescopeServiceProvider::class,
         IXP\Providers\RouteServiceProvider::class,
+        IXP\Providers\ProvisioningRouteServiceProvider::class,
 
         IXP\Providers\HelpdeskServiceProvider::class,
         IXP\Providers\GrapherServiceProvider::class,

--- a/config/ixp_api.php
+++ b/config/ixp_api.php
@@ -178,4 +178,68 @@ return [
     | See: https://docs.ixpmanager.org/latest/features/api/
     */
     'allow_apikeys_get_parameter' => env( 'IXP_ALLOW_DEPRECATED_APIKEYS_VIA_GET', true ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Provisioning API
+    |--------------------------------------------------------------------------
+    |
+    | Endpoints under admin/api/v4/provisioning which create and change members,
+    | users and connections from an external system such as an ordering platform.
+    |
+    | These are the only endpoints in IXP Manager which let an external caller
+    | create business objects, so they are OFF by default. An installation which
+    | does not switch them on does not have them: the routes are never registered.
+    |
+    | See: docs/provisioning-api.md
+    |
+    */
+
+    'provisioning' => [
+
+        /*
+        | Master switch. Off by default - turning it on is a deliberate decision by
+        | the operator, not something an upgrade does to them.
+        */
+        'enabled' => env( 'IXP_API_PROVISIONING_ENABLED', false ),
+
+        /*
+        | Require a real API key.
+        |
+        | The `api/v4` middleware group starts a session, and ApiAuthenticate only
+        | looks for a key when Auth::check() is false. Without this, a browser
+        | already logged in as a superuser reaches these endpoints on its session
+        | cookie - and, because the group deliberately omits `web`, without a CSRF
+        | token either.
+        |
+        | For endpoints which create members that is not acceptable, so the default
+        | is to refuse ambient browser credentials and insist on a key.
+        */
+        'require_api_key' => env( 'IXP_API_PROVISIONING_REQUIRE_KEY', true ),
+
+        /*
+        | Restrict by source address.
+        |
+        | Two independent layers, both optional:
+        |
+        |   - this list applies to every provisioning request
+        |   - api_keys.allowed_ips applies per key (a column which has existed for
+        |     years but was never enforced anywhere; these endpoints honour it)
+        |
+        | Comma-separated addresses or CIDR ranges, IPv4 and IPv6:
+        |   IXP_API_PROVISIONING_ALLOWED_IPS="192.0.2.10,198.51.100.0/24,2001:db8::/48"
+        |
+        | Empty means no restriction at this layer. Note that a restriction here is
+        | not a substitute for one at the web server, which is where the /admin
+        | prefix introduced in v7.1.0 is meant to be enforced - it is a second lock
+        | on the same door, useful when the application is reachable through a proxy
+        | whose ACL you do not control.
+        */
+        'allowed_ips' => env( 'IXP_API_PROVISIONING_ALLOWED_IPS', '' ),
+
+        /*
+        | Requests per minute per API key. Zero disables throttling.
+        */
+        'rate_limit' => (int) env( 'IXP_API_PROVISIONING_RATE_LIMIT', 60 ),
+    ],
 ];

--- a/data/ci/ci_test_db.sql
+++ b/data/ci/ci_test_db.sql
@@ -1610,7 +1610,7 @@ CREATE TABLE `migrations` (
 
 LOCK TABLES `migrations` WRITE;
 /*!40000 ALTER TABLE `migrations` DISABLE KEYS */;
-INSERT INTO `migrations` VALUES (1,'2014_10_12_100000_create_password_resets_table',1),(2,'2018_08_08_100000_create_telescope_entries_table',1),(3,'2019_03_25_211956_create_failed_jobs_table',1),(4,'2020_02_06_204556_create_docstore_directories',2),(5,'2020_02_06_204608_create_docstore_files',2),(6,'2020_02_06_204911_create_docstore_logs',2),(7,'2020_03_09_110945_create_docstore_customer_directories',3),(8,'2020_03_09_111505_create_docstore_customer_files',3),(9,'2020_07_21_094354_create_route_server_filters',4),(12,'2020_09_03_153723_add_timestamps',5),(13,'2020_09_18_095136_delete_ixp_table',6),(14,'2020_11_16_102415_database_fixes',7),(15,'2021_03_12_150418_create_log_table',8),(16,'2021_04_14_125742_user_pref',9),(17,'2021_04_14_101948_update_timestamps',10),(18,'2021_05_18_085721_add_note_infrastructure',11),(19,'2021_05_18_114206_update_pp_prefix_size',12),(20,'2020_06_01_143931_database_schema_at_end_v5',13),(21,'2021_03_30_124916_create_atlas_probes',13),(22,'2021_03_30_125238_create_atlas_runs',13),(23,'2021_03_30_125422_create_atlas_measurements',13),(24,'2021_03_30_125723_create_atlas_results',13),(25,'2021_06_11_141137_update_db_doctrine2eloquent',13),(26,'2021_07_20_134716_fix_last_updated_and_timestamps',13),(27,'2021_09_16_195333_add_rate_limit_col_to_physint',13),(28,'2021_09_17_144421_modernise_irrdb_conf_table',13),(29,'2021_09_21_100354_create_route_server_filters_prod',14),(30,'2021_09_21_162700_rs_pairing',15),(31,'2022_02_12_183121_add_colo_pp_type_patch_panel',15),(32,'2023_09_26_191150_add_registration_details',15),(33,'2024_03_18_191322_add_export_to_ixf_vlan',15),(34,'2024_08_10_125003_create_irrdb_update_logs',16),(35,'2024_09_05_111855_create_p2p_daily_stats_table',17),(36,'2024_05_29_102028_reset-views',18),(37,'2025_09_01_102636_add_ipv6_max_prefixes',19),(38,'2025_11_11_085835_add_exclude_from_ixf_export_to_infrastructure',20),(39,'2026_02_16_205211_remove_legacy_columns_from_contacts',21),(40,'2026_04_20_161912_remove_user_privs',22),(42,'2026_04_27_110644_create_asn_table',23),(46,'2026_06_11_102639_create_app_passwords_table',24),(47,'2026_06_11_112737_create_app_passwords_last_logins_table',24),(48,'2026_06_25_133900_set_api_keys_expires_not_nullable',24);
+INSERT INTO `migrations` VALUES (1,'2014_10_12_100000_create_password_resets_table',1),(2,'2018_08_08_100000_create_telescope_entries_table',1),(3,'2019_03_25_211956_create_failed_jobs_table',1),(4,'2020_02_06_204556_create_docstore_directories',2),(5,'2020_02_06_204608_create_docstore_files',2),(6,'2020_02_06_204911_create_docstore_logs',2),(7,'2020_03_09_110945_create_docstore_customer_directories',3),(8,'2020_03_09_111505_create_docstore_customer_files',3),(9,'2020_07_21_094354_create_route_server_filters',4),(12,'2020_09_03_153723_add_timestamps',5),(13,'2020_09_18_095136_delete_ixp_table',6),(14,'2020_11_16_102415_database_fixes',7),(15,'2021_03_12_150418_create_log_table',8),(16,'2021_04_14_125742_user_pref',9),(17,'2021_04_14_101948_update_timestamps',10),(18,'2021_05_18_085721_add_note_infrastructure',11),(19,'2021_05_18_114206_update_pp_prefix_size',12),(20,'2020_06_01_143931_database_schema_at_end_v5',13),(21,'2021_03_30_124916_create_atlas_probes',13),(22,'2021_03_30_125238_create_atlas_runs',13),(23,'2021_03_30_125422_create_atlas_measurements',13),(24,'2021_03_30_125723_create_atlas_results',13),(25,'2021_06_11_141137_update_db_doctrine2eloquent',13),(26,'2021_07_20_134716_fix_last_updated_and_timestamps',13),(27,'2021_09_16_195333_add_rate_limit_col_to_physint',13),(28,'2021_09_17_144421_modernise_irrdb_conf_table',13),(29,'2021_09_21_100354_create_route_server_filters_prod',14),(30,'2021_09_21_162700_rs_pairing',15),(31,'2022_02_12_183121_add_colo_pp_type_patch_panel',15),(32,'2023_09_26_191150_add_registration_details',15),(33,'2024_03_18_191322_add_export_to_ixf_vlan',15),(34,'2024_08_10_125003_create_irrdb_update_logs',16),(35,'2024_09_05_111855_create_p2p_daily_stats_table',17),(36,'2024_05_29_102028_reset-views',18),(37,'2025_09_01_102636_add_ipv6_max_prefixes',19),(38,'2025_11_11_085835_add_exclude_from_ixf_export_to_infrastructure',20),(39,'2026_02_16_205211_remove_legacy_columns_from_contacts',21),(40,'2026_04_20_161912_remove_user_privs',22),(42,'2026_04_27_110644_create_asn_table',23),(46,'2026_06_11_102639_create_app_passwords_table',24),(47,'2026_06_11_112737_create_app_passwords_last_logins_table',24),(48,'2026_06_25_133900_set_api_keys_expires_not_nullable',24),(49,'2026_08_05_120000_create_provisioning_references_table',25);
 /*!40000 ALTER TABLE `migrations` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -2081,6 +2081,36 @@ LOCK TABLES `physicalinterface` WRITE;
 /*!40000 ALTER TABLE `physicalinterface` DISABLE KEYS */;
 INSERT INTO `physicalinterface` VALUES (1,3,NULL,1,1,1000,'full',NULL,'',1,NULL,NULL),(2,4,NULL,1,1,1000,'full',NULL,'',1,NULL,NULL),(3,25,NULL,2,1,1000,'full',NULL,NULL,1,NULL,NULL),(4,8,NULL,3,1,100,'full',NULL,NULL,1,NULL,NULL),(5,6,NULL,4,1,10,'full',NULL,NULL,1,NULL,NULL),(6,30,NULL,5,1,10,'full',NULL,NULL,1,NULL,NULL),(7,9,NULL,6,1,1000,'full',NULL,NULL,1,NULL,NULL),(8,32,NULL,7,1,10000,'full',NULL,NULL,1,NULL,NULL),(9,18,NULL,8,1,1000,'full',NULL,NULL,1,NULL,NULL),(10,42,NULL,9,1,1000,'full',NULL,NULL,1,NULL,NULL),(11,19,NULL,8,1,1000,'full',NULL,NULL,1,NULL,NULL),(12,43,NULL,9,1,1000,'full',NULL,NULL,1,NULL,NULL),(13,27,NULL,10,4,1000,'full',NULL,NULL,1,NULL,NULL),(14,1,NULL,11,1,1000,'full',NULL,NULL,1,'2025-08-30 10:54:46','2025-08-30 10:54:46');
 /*!40000 ALTER TABLE `physicalinterface` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `provisioning_references`
+--
+
+DROP TABLE IF EXISTS `provisioning_references`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `provisioning_references` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `reference` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `model_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `model_id` int unsigned NOT NULL,
+  `created_by` int unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `provisioning_references_unique` (`reference`,`model_type`),
+  KEY `provisioning_references_model` (`model_type`,`model_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `provisioning_references`
+--
+
+LOCK TABLES `provisioning_references` WRITE;
+/*!40000 ALTER TABLE `provisioning_references` DISABLE KEYS */;
+/*!40000 ALTER TABLE `provisioning_references` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --

--- a/database/migrations/2026_08_05_120000_create_provisioning_references_table.php
+++ b/database/migrations/2026_08_05_120000_create_provisioning_references_table.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Records the external system's own reference for something created through the provisioning
+ * API, so that a repeated request is recognised as a repeat.
+ *
+ * An ordering system that times out waiting for a response has no way to tell whether the
+ * member was created or not. Without a record of "we already did this one", its retry creates
+ * a second member. With it, the retry returns the first result.
+ *
+ * Kept as its own table rather than a column on `cust` so the customer table stays untouched:
+ * a merge of an upstream release must never have to reconcile a schema change of ours.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create( 'provisioning_references', function( Blueprint $table ) {
+            $table->id();
+
+            // the caller's own identifier - an order number, a ticket id, whatever it uses:
+            $table->string( 'reference', 191 );
+
+            // what the reference produced:
+            $table->string( 'model_type', 191 );
+            $table->unsignedInteger( 'model_id' );
+
+            $table->unsignedInteger( 'created_by' )->nullable();
+            $table->timestamps();
+
+            // one reference maps to exactly one thing of a given kind. Scoping the uniqueness
+            // by model_type lets a single order reference both the member it created and the
+            // connection, without either colliding:
+            $table->unique( [ 'reference', 'model_type' ], 'provisioning_references_unique' );
+            $table->index( [ 'model_type', 'model_id' ], 'provisioning_references_model' );
+        } );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists( 'provisioning_references' );
+    }
+};

--- a/docs/provisioning-api.md
+++ b/docs/provisioning-api.md
@@ -1,0 +1,227 @@
+# Provisioning API
+
+A stateless, machine-to-machine API for creating members, portal users and connections from an
+external system such as an ordering or billing platform.
+
+It exists because the existing API v4 is a read and export surface: it publishes switch
+configuration, route server configuration, Nagios targets and DNS data, but has no endpoint
+which creates a member, a user or a port. Those live only in the web controllers.
+
+> **Note on the existing endpoints.** The POST endpoints under `admin/api/v4` — including
+> `switch/{s}/switch-port-prewired` — cannot be called from outside a browser. That route group
+> carries the `web` middleware, and `VerifyCsrfToken` excepts only `login`. This API sits in its
+> own route group without `web`, authenticated by API key alone.
+
+## Authentication
+
+Every endpoint requires a **superuser** API key, passed in the header:
+
+```
+X-IXP-Manager-API-Key: ixpm_ident1234567_sec876543210...
+```
+
+A non-superuser key gets `403`; no key gets `401`.
+
+Two operational points:
+
+- **Keys expire after at most 12 months** (`ixp_fe.api_keys.max_expires_duration`). An
+  unattended service will fail with `401` exactly once a year unless the key is rotated.
+- **`allowed_ips` on an API key is not enforced anywhere in the code**, and request throttling
+  is commented out. The key is therefore a full-access superuser credential. Restrict the
+  endpoint at the web server or firewall to the address of the calling system.
+
+## Conventions
+
+- Base path: `/admin/api/v4/provisioning`
+- Anything which creates or changes state uses `POST`, `PUT` or `DELETE` — never `GET`.
+- Responses are JSON. Validation failures are `422` with `message` and `errors`, the latter
+  keyed by field.
+- `201` for something created, `200` for a read or a no-op, `404` for an unknown id, `409` for
+  a conflict which is not a validation problem.
+
+## Discovery
+
+```http
+GET /admin/api/v4/provisioning/ping
+GET /admin/api/v4/provisioning/switch
+GET /admin/api/v4/provisioning/infrastructure
+GET /admin/api/v4/provisioning/port/free
+GET /admin/api/v4/provisioning/vlan/{vlan}/address
+```
+
+`ping` confirms the key and returns the resolved username — useful for verifying a deployment
+without creating anything.
+
+`port/free` walks every active switch and returns ports with no physical interface attached.
+Only ports of type *unset* or *peering* are ever returned: core, management, monitor, fanout
+and reseller ports are infrastructure, and offering them would let a caller reassign the
+fabric.
+
+```http
+GET /port/free?infrastructure=1&limit=50
+```
+
+```json
+{
+  "ports": [
+    { "switchport": 412, "name": "xe-0/0/9", "type": 0,
+      "switch": 7, "switch_name": "swi1-fra", "infrastructure": 1 }
+  ],
+  "count": 1,
+  "truncated": false
+}
+```
+
+`vlan/{vlan}/address` lists a VLAN's address pool. `?free=1` restricts it to unassigned
+addresses, `?protocol=4` or `6` to one family.
+
+## Members
+
+```http
+POST /admin/api/v4/provisioning/member
+GET  /admin/api/v4/provisioning/member/{cust}
+POST /admin/api/v4/provisioning/member/{cust}/user
+```
+
+The member payload is validated with the same rules as the web form, plus a small addition —
+see *Validation* below.
+
+```json
+{
+  "name": "Example Networks Ltd",
+  "shortname": "example",
+  "abbreviatedName": "EXAMPLE",
+  "type": 1,
+  "status": 1,
+  "datejoin": "2026-08-01",
+  "autsys": 65550,
+  "maxprefixes": 500,
+  "maxprefixesv6": 500,
+  "peeringemail": "peering@example.com",
+  "peeringmacro": "AS-EXAMPLE",
+  "nocemail": "noc@example.com"
+}
+```
+
+`PeeringDB` lookup remains available at the existing endpoint
+`GET /admin/api/v4/customer/query-peeringdb/asn/{asn}` and is a useful way to pre-fill this.
+
+Creating a user sends the welcome email carrying the password reset link — without it the
+account cannot be used. The customer comes from the route, so a `custid` in the body is
+ignored. The API takes `enabled` (boolean, default true); the web form's inverted `disabled`
+field is not reproduced.
+
+## Connections
+
+```http
+POST   /admin/api/v4/provisioning/member/{cust}/connection
+GET    /admin/api/v4/provisioning/member/{cust}/connection
+DELETE /admin/api/v4/provisioning/connection/{vi}
+```
+
+Creates the virtual interface, the physical interface on a switch port, the VLAN interface and
+its addresses — the equivalent of the web UI's "add a port" wizard.
+
+```json
+{
+  "vlanid": 1,
+  "switch": 7,
+  "switchportid": 412,
+  "speed": 10000,
+  "rate_limit": 1000,
+  "ipv4enabled": true,
+  "ipv4address": "auto",
+  "ipv4hostname": "example.peering.example.net",
+  "ipv6enabled": true,
+  "ipv6address": "auto",
+  "ipv6hostname": "example.peering.example.net",
+  "rsclient": true,
+  "irrdbfilter": true
+}
+```
+
+**`"auto"` allocates the next free address** in the VLAN. The web wizard requires an explicit
+address because an operator picks one from a list rendered in the browser; an unattended caller
+has no list.
+
+An explicit address must already exist in the VLAN's pool. This is stricter than the web path,
+which creates the address record on demand — for an unattended caller that turns a typo into a
+stray address that nothing will ever clean up.
+
+`status` defaults to *connected* and `duplex` to *full*; both can be set explicitly.
+
+Deletion refuses with `409` if the virtual interface belongs to a core bundle.
+
+## Onboarding
+
+```http
+POST /admin/api/v4/provisioning/onboarding
+```
+
+Creates a member, optionally a user, and optionally a connection **in one transaction**.
+
+The three endpoints above can be called in sequence, but that sequence is not atomic: a caller
+whose second request fails is left with a half-provisioned member. Here the whole order lands
+or none of it does.
+
+```json
+{
+  "reference": "ORD-2026-04711",
+  "member":     { "...": "as above" },
+  "user":       { "...": "as above, without custid" },
+  "connection": { "...": "as above" }
+}
+```
+
+Sections are nested because `name` means something different for a member, a user and a virtual
+interface. `user` and `connection` are optional.
+
+**`reference` makes retries safe.** It is the caller's own order identifier. A caller which
+times out and retries with the same reference gets the original result back:
+
+```json
+{ "created": false, "reference": "ORD-2026-04711",
+  "member": { "id": 97, "shortname": "example" } }
+```
+
+with status `200` rather than `201`. Without a reference, a retry creates a second member.
+
+This endpoint does not orchestrate anything beyond the database. Rolling configuration out to
+switches, regenerating route server configuration and updating reverse DNS remain the caller's
+responsibility; it only makes the IXP Manager side of an order indivisible.
+
+## Validation
+
+The API form requests **extend the web ones** rather than restating their rules, so a rule
+changed upstream applies here automatically. Each adds a declared delta, and `RulesParityTest`
+subtracts that delta and asserts the remainder is identical — divergence fails a test rather
+than surfacing as a behavioural difference.
+
+The customer delta covers fillable attributes the web request does not validate. Three are
+worth naming: the columns are `dateleave`, `MD5Support` and `isReseller`, while the web rules
+refer to `dateleft` and `md5support`. Those two rules match nothing, so the values currently
+reach `Customer::create()` unvalidated. The web rules are left alone; the API validates the
+names the schema actually uses.
+
+For connections, `ipv4address` / `ipv6address` are replaced rather than added to, since they
+must also accept `"auto"`. `rate_limit` and `autoneg` are added: both are columns of
+`PhysicalInterface` and both are exported to the switch configuration generator, but the v7.3.1
+wizard request does not list them.
+
+## Concurrency
+
+Address allocation takes a row lock inside the request's transaction, so two orders provisioned
+at the same moment cannot receive the same address. The unique indexes on
+`vlaninterface.ipv4addressid` / `ipv6addressid` are the backstop.
+
+Switch port assignment is checked before anything is written, and the write happens in the same
+transaction.
+
+## What is deliberately absent
+
+- **No endpoint reserves an address on its own.** An address held by nothing but a promise
+  leaks if the caller then fails. Allocation happens inside the connection transaction, where
+  it either sticks or is rolled back with everything else.
+- **No suspend or offboard endpoints yet.** Suspension needs somewhere to record the state each
+  field held before it was changed, so that restoring is exact; there is no such place in the
+  schema today.

--- a/docs/provisioning-api.md
+++ b/docs/provisioning-api.md
@@ -12,6 +12,22 @@ which creates a member, a user or a port. Those live only in the web controllers
 > carries the `web` middleware, and `VerifyCsrfToken` excepts only `login`. This API sits in its
 > own route group without `web`, authenticated by API key alone.
 
+## Off by default
+
+These endpoints do not exist until an operator asks for them:
+
+```dotenv
+IXP_API_PROVISIONING_ENABLED=true
+```
+
+Without it the routes are never registered and every path answers `404`. They are the only
+endpoints in IXP Manager which let an external caller create business objects, so an upgrade
+must not be able to expose an installation to something it did not choose.
+
+Further keys under `ixp_api.provisioning`: `require_api_key` (default true), `allowed_ips`
+(comma-separated addresses and CIDR ranges, empty means unrestricted) and `rate_limit`
+(default 60 a minute, zero disables).
+
 ## Authentication
 
 Every endpoint requires a **superuser** API key, passed in the header:
@@ -33,9 +49,13 @@ Two operational points:
 ## Conventions
 
 - Base path: `/admin/api/v4/provisioning`
-- Anything which creates or changes state uses `POST`, `PUT` or `DELETE` — never `GET`.
-- Responses are JSON. Validation failures are `422` with `message` and `errors`, the latter
-  keyed by field.
+- Anything which creates or changes state uses `POST` or `DELETE` — never `GET`. There is
+  no `PUT` yet: the API creates, reads and deletes, but does not change.
+- Responses are JSON, with one exception worth knowing: `401` and `403` raised by the
+  upstream authentication middleware are plain text (`Unauthorized.`, `API key expired`,
+  `Insufficient permissions`), not JSON. Only the guards added here answer with `{message}`.
+  A client must not assume a JSON body on an authentication failure.
+- Validation failures are `422` with `message` and `errors`, the latter keyed by field.
 - `201` for something created, `200` for a read or a no-op, `404` for an unknown id, `409` for
   a conflict which is not a validation problem.
 
@@ -204,9 +224,14 @@ reach `Customer::create()` unvalidated. The web rules are left alone; the API va
 names the schema actually uses.
 
 For connections, `ipv4address` / `ipv6address` are replaced rather than added to, since they
-must also accept `"auto"`. `rate_limit` and `autoneg` are added: both are columns of
-`PhysicalInterface` and both are exported to the switch configuration generator, but the v7.3.1
-wizard request does not list them.
+must also accept `"auto"`. Only the address *type* is relaxed - the wizard's conditional
+requirement stays, so an enabled address family still demands an address. The delta adds the
+fields the wizard has no form control for: `name`, `description`, `mtu`, `lag_framing`,
+`fastlacp` and `busyhost`.
+
+(`rate_limit` and `autoneg` were in that delta until this branch was rebased from v7.3.1 onto
+`main`, where upstream had added them to the wizard request itself. RulesParityTest failed on
+exactly that, which is what it is for.)
 
 ## Concurrency
 
@@ -225,3 +250,13 @@ transaction.
 - **No suspend or offboard endpoints yet.** Suspension needs somewhere to record the state each
   field held before it was changed, so that restoring is exact; there is no such place in the
   schema today.
+
+## Machine-readable specification
+
+`docs/provisioning-api.openapi.yaml` — OpenAPI 3.1, hand written, no generator package and no
+build step. 11 paths, 22 schemas, every field derived from the controllers and the merged
+validation rules rather than from this prose.
+
+Worth knowing when reading it: a taken switch port at `/onboarding` answers `422`, not `409`.
+`409` arises only from a reused reference whose member has since been deleted, from a raced
+resource, and from the core-bundle guard on `DELETE /connection/{vi}`.

--- a/docs/provisioning-api.openapi.yaml
+++ b/docs/provisioning-api.openapi.yaml
@@ -1,0 +1,2316 @@
+openapi: 3.1.0
+
+info:
+  title: IXP Manager Provisioning API
+  version: 1.0.0
+  summary: Machine-to-machine endpoints for creating members, portal users and connections.
+  description: |
+    A stateless, machine-to-machine API for creating members, portal users and connections in
+    IXP Manager from an external system such as an ordering or billing platform.
+
+    It exists because API v4 is otherwise a read and export surface: it publishes switch
+    configuration, route server configuration, Nagios targets and DNS data, but has no endpoint
+    which creates a member, a user or a port. Those live only in the web controllers, whose
+    route group carries the `web` middleware — and `VerifyCsrfToken` excepts only `login`, so
+    those POST endpoints cannot be called from outside a browser at all. This API sits in its
+    own route group without `web`, authenticated by API key alone.
+
+    ## The API is OFF by default
+
+    The routes are registered by `IXP\Providers\ProvisioningRouteServiceProvider`, which returns
+    immediately unless `ixp_api.provisioning.enabled` is true:
+
+    ```
+    IXP_API_PROVISIONING_ENABLED=true
+    ```
+
+    Until that is set the routes are never registered at all — every path in this document
+    responds `404`, and there is nothing to secure. An upgrade cannot quietly expose an IXP to
+    endpoints it did not ask for.
+
+    ## Middleware chain
+
+    In the order it runs (`ProvisioningRouteServiceProvider::middleware()`):
+
+    1. `ForceJsonResponse` — sets `Accept: application/json` on the request, so that framework
+       errors render as JSON and a `ValidationException` becomes a `422` rather than a `302`.
+       Callers do not have to send the header themselves.
+    2. `RequireApiKey` — refuses a request with no `X-IXP-Manager-API-Key` header with `401`,
+       even when a superuser browser session is present. Disableable with
+       `IXP_API_PROVISIONING_REQUIRE_KEY=false`, which is not recommended.
+    3. `api/v4` (`apibase` + `apiauth`) — resolves the key and logs its owner in via
+       `Auth::onceUsingId()`.
+    4. `assert.privilege:3` — the key's user must be a superuser (`AUTH_SUPERUSER`), else `403`.
+    5. `RestrictSourceAddress` — `403` when the source address is covered by neither
+       `ixp_api.provisioning.allowed_ips` nor, if set, the `allowed_ips` column of the API key
+       presented. An empty list at a layer means "no restriction at this layer", not "deny".
+    6. `throttle:{rate_limit},1` — added only when `ixp_api.provisioning.rate_limit` is greater
+       than zero. Default 60 requests per minute; `0` disables throttling entirely.
+
+    ## Configuration
+
+    | env | default | meaning |
+    | --- | --- | --- |
+    | `IXP_API_PROVISIONING_ENABLED` | `false` | master switch; nothing is registered when false |
+    | `IXP_API_PROVISIONING_REQUIRE_KEY` | `true` | refuse ambient browser credentials |
+    | `IXP_API_PROVISIONING_ALLOWED_IPS` | `""` | comma-separated addresses / CIDR, IPv4 and IPv6 |
+    | `IXP_API_PROVISIONING_RATE_LIMIT` | `60` | requests per minute; `0` disables |
+
+    ## Conventions
+
+    - Base path `/admin/api/v4/provisioning`. Anything which creates, changes or removes state
+      uses `POST` or `DELETE` — never `GET`.
+    - `201` for something created, `200` for a read, a delete or an idempotent no-op, `404` for
+      an unknown id, `409` for a conflict which is not a validation problem, `422` for
+      validation and for resource conflicts detected before anything was written.
+    - Validation failures carry `message` and an `errors` object keyed by field. Errors raised
+      by the controllers themselves (an address outside the pool, an unusable switch port) are
+      also `422` but carry `message` only.
+    - Responses are explicit field lists built by the controllers' `*AsArray()` methods, not
+      `Model::toArray()`. A column added to the schema does not appear here on its own.
+
+    ## Special behaviours
+
+    - **`"auto"` addresses.** `ipv4address` / `ipv6address` accept the literal string `auto`,
+      which allocates the numerically next free address of that family from the VLAN's pool
+      under a row lock inside the request's transaction. The web wizard has no equivalent: an
+      operator picks from a list rendered in the browser, an unattended caller has no list.
+    - **Explicit addresses must already be in the pool.** `IpAllocator::claim()` is consulted
+      before `setIp()`, which would otherwise create the address record on the fly — for an
+      unattended caller that turns a typo into a stray address record nothing will clean up.
+    - **`reference` makes onboarding retries safe.** Passing the caller's own order identifier
+      makes `POST /onboarding` idempotent: the first call returns `201` with `created: true`,
+      any repeat of the same reference returns `200` with `created: false` and the member the
+      first call produced. Without a reference a retry creates a second member.
+    - **No address reservation endpoint.** An address held by nothing but a promise leaks when
+      the caller then fails. Allocation happens inside the connection transaction, where it
+      either sticks or is rolled back with everything else.
+
+  license:
+    name: GNU General Public License v2.0 only
+    identifier: GPL-2.0-only
+
+  contact:
+    name: KleyReX
+    url: https://www.kleyrex.net/
+
+externalDocs:
+  description: Prose documentation for this API (docs/provisioning-api.md)
+  url: https://github.com/inex/IXP-Manager/blob/master/docs/provisioning-api.md
+
+servers:
+  - url: https://{host}/admin/api/v4/provisioning
+    description: An IXP Manager installation with the provisioning API switched on.
+    variables:
+      host:
+        default: manager.example.net
+        description: |
+          Hostname of the IXP Manager installation, for example `manager.kleyrex.net`.
+
+security:
+  - ApiKeyAuth: []
+
+tags:
+  - name: Discovery
+    description: |
+      Read-only lookups an ordering system needs before it can place an order: does the key
+      work, which switches and infrastructures exist, which ports are free, which addresses
+      are free.
+  - name: Members
+    description: Creating and reading members (customers) and their portal users.
+  - name: Connections
+    description: Creating, listing and removing a member's connection to the exchange.
+  - name: Onboarding
+    description: A member, an optional user and an optional connection in one transaction.
+
+paths:
+
+  /ping:
+    get:
+      tags: [ Discovery ]
+      operationId: ping
+      summary: Confirm the API is reachable and the key is accepted
+      description: |
+        A health and connectivity check. It exists so that an operator can verify the whole
+        authentication chain — API key, superuser privilege, source address allow-list and JSON
+        content negotiation — without creating anything.
+
+        The user is resolved from the API key by the `apiauth` middleware, which logs the key's
+        owner in via `Auth::onceUsingId()`; the username returned is that user's.
+      responses:
+        '200':
+          description: The key was accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pong'
+              example:
+                pong: true
+                user: provisioning
+                version: 7.3.1
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /switch:
+    get:
+      tags: [ Discovery ]
+      operationId: listSwitches
+      summary: List the active switches
+      description: |
+        Every switch with `active = true`, ordered by name, so that a caller can resolve a
+        switch name to the id `switch` expects when creating a connection rather than guessing.
+
+        Inactive switches are omitted: a port on one would produce a connection which appears
+        in neither the switch configuration nor the grapher.
+      responses:
+        '200':
+          description: The active switches.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ switches ]
+                properties:
+                  switches:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Switch'
+              example:
+                switches:
+                  - id: 5
+                    name: vc501
+                    infrastructure: 1
+                    hostname: vc501.kleyrex.net
+                  - id: 13
+                    name: vc513
+                    infrastructure: 1
+                    hostname: vc513.kleyrex.net
+                  - id: 14
+                    name: vc514
+                    infrastructure: 1
+                    hostname: vc514.kleyrex.net
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /infrastructure:
+    get:
+      tags: [ Discovery ]
+      operationId: listInfrastructures
+      summary: List the infrastructures and their VLANs
+      description: |
+        All infrastructures — active or not — ordered by name, each with the VLANs attached to
+        it. A caller needs the VLAN `id` (not the 802.1Q tag `number`) for the `vlanid` field
+        of a connection; at KleyReX the peering VLAN carries tag 900 and has id 1.
+      responses:
+        '200':
+          description: The infrastructures and their VLANs.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ infrastructures ]
+                properties:
+                  infrastructures:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Infrastructure'
+              example:
+                infrastructures:
+                  - id: 1
+                    name: KleyReX
+                    shortname: kleyrex
+                    isPrimary: true
+                    vlans:
+                      - id: 1
+                        name: Peering LAN
+                        number: 900
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /port/free:
+    get:
+      tags: [ Discovery ]
+      operationId: listFreePorts
+      summary: List switch ports which can be given to a member
+      description: |
+        Walks every **active** switch and returns the ports with no `PhysicalInterface`
+        attached whose type is either *unset* (`0`) or *peering* (`1`).
+
+        Core, management, monitor, other, fanout and reseller ports are deliberately excluded:
+        handing one of those to an ordering system would let it reassign the fabric.
+
+        The web UI answers this question one switch at a time because an operator has already
+        picked the switch from a dropdown. An ordering system has not — it knows the
+        infrastructure and the speed it sold, and needs to be told where that fits.
+
+        `truncated` distinguishes "there are more" from "exactly full": the controller collects
+        one port beyond `limit` before deciding, so a complete result never reports
+        `truncated: true`.
+      parameters:
+        - name: infrastructure
+          in: query
+          required: false
+          description: Restrict to one infrastructure id. Must exist in `infrastructure.id`.
+          schema:
+            type: integer
+            minimum: 1
+          example: 1
+        - name: switch
+          in: query
+          required: false
+          description: Restrict to one switch id. Must exist in `switch.id`.
+          schema:
+            type: integer
+            minimum: 1
+          example: 13
+        - name: limit
+          in: query
+          required: false
+          description: Cap the number of ports returned.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+          example: 50
+      responses:
+        '200':
+          description: The free ports.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ ports, count, truncated ]
+                properties:
+                  ports:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Port'
+                  count:
+                    type: integer
+                    description: Number of ports in `ports` — never more than `limit`.
+                  truncated:
+                    type: boolean
+                    description: True when more free ports exist than `limit` allowed to be returned.
+              example:
+                ports:
+                  - switchport: 412
+                    name: xe-0/0/9
+                    type: 0
+                    switch: 13
+                    switch_name: vc513
+                    infrastructure: 1
+                  - switchport: 413
+                    name: xe-0/0/10
+                    type: 1
+                    switch: 13
+                    switch_name: vc513
+                    infrastructure: 1
+                count: 2
+                truncated: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          description: |
+            A query parameter failed validation — a non-integer, a `limit` outside 1..1000, or
+            an `infrastructure` / `switch` id which does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+              example:
+                message: The selected switch is invalid.
+                errors:
+                  switch:
+                    - The selected switch is invalid.
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /vlan/{vlan}/address:
+    get:
+      tags: [ Discovery ]
+      operationId: listVlanAddresses
+      summary: List a VLAN's address pool, marking each address free or in use
+      description: |
+        Lists the addresses which exist in the VLAN's pool, ordered numerically
+        (`INET_ATON` / `INET6_ATON`, so `.10` does not sort before `.9`), each flagged with
+        whether a VLAN interface points at it.
+
+        Addresses are created ahead of time by the `ipv4:generate` / `ipv6:generate` commands.
+        This endpoint never creates one, and there is deliberately no endpoint which reserves
+        one — a caller which simply wants the next free address asks for `"auto"` when creating
+        the connection.
+
+        `total` counts the whole matching set; `truncated` says whether `limit` cut it short.
+      parameters:
+        - $ref: '#/components/parameters/VlanId'
+        - name: protocol
+          in: query
+          required: false
+          description: |
+            Restrict to one address family. Omitted, both `ipv4` and `ipv6` are returned.
+          schema:
+            type: integer
+            enum: [ 4, 6 ]
+          example: 4
+        - name: free
+          in: query
+          required: false
+          description: When true, list only addresses no VLAN interface points at.
+          schema:
+            type: boolean
+            default: false
+          example: true
+        - name: limit
+          in: query
+          required: false
+          description: Cap the number of addresses returned **per protocol**.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 2000
+            default: 200
+          example: 5
+      responses:
+        '200':
+          description: |
+            The VLAN and its addresses. `ipv4` is absent when `protocol=6` was requested and
+            `ipv6` is absent when `protocol=4` was.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VlanAddressListing'
+              example:
+                vlan:
+                  id: 1
+                  name: Peering LAN
+                  number: 900
+                ipv4:
+                  addresses:
+                    - id: 341
+                      address: 193.189.82.101
+                      free: true
+                    - id: 342
+                      address: 193.189.82.102
+                      free: false
+                  total: 2
+                  truncated: false
+                ipv6:
+                  addresses:
+                    - id: 902
+                      address: '2001:7f8:33::a101:2586:1'
+                      free: true
+                  total: 1
+                  truncated: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: A query parameter failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+              example:
+                message: The selected protocol is invalid.
+                errors:
+                  protocol:
+                    - The selected protocol is invalid.
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /member:
+    post:
+      tags: [ Members ]
+      operationId: createMember
+      summary: Create a member
+      description: |
+        Mirrors `CustomerController@store`, including the `CompanyBillingDetail` and
+        `CompanyRegisteredDetail` records it creates alongside the customer — but wraps all
+        three inserts in a transaction, which the web path does not, so a failure here cannot
+        leave orphaned detail rows behind.
+
+        Validation uses `IXP\Http\Requests\Api\V4\Provisioning\StoreCustomer`, which extends the
+        web form request `IXP\Http\Requests\Customer\Store` and adds a declared delta.
+        `RulesParityTest` subtracts that delta and asserts the remainder is identical to
+        upstream, so a rule changed upstream applies here automatically rather than drifting.
+
+        Two notes on the payload:
+
+        - **`type: 2` (Associate) validates far less.** `Customer\Store::rules()` returns only
+          the common fields for an associate member; the AS number, prefix limits, peering and
+          NOC fields are then not validated at all.
+        - **`dateleft` and `md5support` are accepted but do nothing.** The upstream rules use
+          those names, while the columns are `dateleave` and `MD5Support`. Both spellings pass
+          validation; only the correctly-cased ones are fillable and reach the database. The
+          web rules are left alone — that is upstream's call — and the delta adds rules for the
+          names the schema actually uses.
+
+        `isResold` is not a column. It selects whether the `reseller` value is written or
+        `null` is written instead.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MemberInput'
+            examples:
+              full:
+                summary: A full member at KleyReX
+                value:
+                  name: Example Networks GmbH
+                  shortname: examplenet
+                  abbreviatedName: EXAMPLE
+                  type: 1
+                  status: 1
+                  datejoin: '2026-08-01'
+                  autsys: 12586
+                  maxprefixes: 500
+                  maxprefixesv6: 500
+                  peeringemail: peering@example.net
+                  peeringmacro: AS-EXAMPLE
+                  peeringmacrov6: AS-EXAMPLE
+                  peeringpolicy: open
+                  irrdb: 1
+                  MD5Support: 'NO'
+                  nocemail: noc@example.net
+                  nocphone: '+49 69 1234567'
+                  nochours: 24x7
+                  nocwww: https://www.example.net/noc
+                  corpwww: https://www.example.net/
+                  activepeeringmatrix: true
+              associate:
+                summary: An associate member — only the common fields are validated
+                value:
+                  name: Example Association e.V.
+                  shortname: exampleassoc
+                  abbreviatedName: EXAMPLEA
+                  type: 2
+                  status: 1
+                  datejoin: '2026-08-01'
+              resold:
+                summary: A member resold by another member
+                value:
+                  name: Example Reseller Customer GmbH
+                  shortname: examplersld
+                  abbreviatedName: EXRSLD
+                  type: 1
+                  status: 1
+                  datejoin: '2026-08-01'
+                  autsys: 65551
+                  isResold: true
+                  reseller: 42
+      responses:
+        '201':
+          description: The member was created.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ member ]
+                properties:
+                  member:
+                    $ref: '#/components/schemas/Member'
+              example:
+                member:
+                  id: 97
+                  name: Example Networks GmbH
+                  shortname: examplenet
+                  abbreviatedName: EXAMPLE
+                  type: 1
+                  status: 1
+                  autsys: 12586
+                  maxprefixes: 500
+                  maxprefixesv6: 500
+                  peeringemail: peering@example.net
+                  peeringmacro: AS-EXAMPLE
+                  peeringmacrov6: AS-EXAMPLE
+                  peeringpolicy: open
+                  irrdb: 1
+                  datejoin: '2026-08-01'
+                  dateleave: null
+                  reseller: null
+                  isReseller: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          description: |
+            The payload failed validation — most commonly a `shortname` which is already taken
+            (`unique:cust,shortname`), a missing required field, or a resold member with no
+            reseller named.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+              examples:
+                duplicateShortname:
+                  summary: shortname already in use
+                  value:
+                    message: The shortname has already been taken.
+                    errors:
+                      shortname:
+                        - The shortname has already been taken.
+                resoldWithoutReseller:
+                  summary: isResold set with no reseller
+                  value:
+                    message: Please choose a reseller
+                    errors:
+                      reseller:
+                        - Please choose a reseller
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /member/{cust}:
+    parameters:
+      - $ref: '#/components/parameters/CustomerId'
+    get:
+      tags: [ Members ]
+      operationId: showMember
+      summary: Read a member
+      description: |
+        Returns the same representation `POST /member` produces. The field list is deliberate
+        rather than the model's `toArray()`: the response shape is a contract with the caller
+        and should not change because a column was added.
+
+        `datejoin` and `dateleave` are normalised to `Y-m-d`. `Customer` declares them in
+        `$dates`, which Laravel no longer honours, so they arrive as raw strings; the controller
+        accepts either form so this keeps working if upstream moves them to `$casts`.
+      responses:
+        '200':
+          description: The member.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ member ]
+                properties:
+                  member:
+                    $ref: '#/components/schemas/Member'
+              example:
+                member:
+                  id: 97
+                  name: Example Networks GmbH
+                  shortname: examplenet
+                  abbreviatedName: EXAMPLE
+                  type: 1
+                  status: 1
+                  autsys: 12586
+                  maxprefixes: 500
+                  maxprefixesv6: 500
+                  peeringemail: peering@example.net
+                  peeringmacro: AS-EXAMPLE
+                  peeringmacrov6: null
+                  peeringpolicy: open
+                  irrdb: 1
+                  datejoin: '2026-08-01'
+                  dateleave: null
+                  reseller: null
+                  isReseller: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /member/{cust}/user:
+    parameters:
+      - $ref: '#/components/parameters/CustomerId'
+    post:
+      tags: [ Members ]
+      operationId: createMemberUser
+      summary: Create a portal user for a member
+      description: |
+        Mirrors `UserController@store`, in one transaction, and then fires `UserCreated`.
+
+        **The password is random and is never returned.** The account is activated by the
+        welcome email, which carries a password reset token — firing the event is therefore not
+        optional, since without it the user has no way in. The event is fired only after the
+        transaction has committed, so a later failure cannot leave a welcome email sent for a
+        user which was rolled back.
+
+        The customer comes from the route: `StoreUser::prepareForValidation()` overwrites any
+        `custid` in the body with the route's customer, and removes any `id` from the body —
+        an `id` would only serve to exempt somebody else's username from the uniqueness check,
+        turning a `422` into a database-constraint `500`.
+
+        The API takes **`enabled`** (default `true`); the web form's inverted `disabled` field
+        is not reproduced. Superuser privileges (`privs: 3`) are refused unless the member is an
+        internal customer (`type: 3`), which the inherited `User\Store::withValidator()` enforces.
+
+        `username` and `email` are lowercased before being stored.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserInput'
+            example:
+              name: Erika Mustermann
+              username: examplenet-noc
+              email: noc@example.net
+              authorisedMobile: '+491701234567'
+              privs: 2
+              enabled: true
+      responses:
+        '201':
+          description: |
+            The user was created and the welcome email dispatched.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ user ]
+                properties:
+                  user:
+                    $ref: '#/components/schemas/User'
+              example:
+                user:
+                  id: 314
+                  name: Erika Mustermann
+                  username: examplenet-noc
+                  email: noc@example.net
+                  custid: 97
+                  privs: 2
+                  enabled: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: The payload failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+              examples:
+                duplicateUsername:
+                  summary: username already in use
+                  value:
+                    message: The username has already been taken.
+                    errors:
+                      username:
+                        - The username has already been taken.
+                superuserOnNonInternal:
+                  summary: superuser privileges asked for on a non-internal member
+                  value:
+                    message: You are not allowed to set this User as a Super User for Example Networks GmbH
+                    errors:
+                      privs:
+                        - You are not allowed to set this User as a Super User for Example Networks GmbH
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /member/{cust}/connection:
+    parameters:
+      - $ref: '#/components/parameters/CustomerId'
+    get:
+      tags: [ Connections ]
+      operationId: listMemberConnections
+      summary: List a member's connections
+      description: |
+        Every virtual interface belonging to the member, with its physical interfaces and VLAN
+        interfaces. Relations are eager loaded, so this is a fixed number of queries rather than
+        one per interface per relation.
+
+        An empty array is returned for a member with no connections — not a `404`.
+      responses:
+        '200':
+          description: The member's connections.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ connections ]
+                properties:
+                  connections:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Connection'
+              example:
+                connections:
+                  - id: 501
+                    custid: 97
+                    name: null
+                    trunk: false
+                    lag_framing: false
+                    channelgroup: null
+                    physical_interfaces:
+                      - id: 733
+                        status: 1
+                        speed: 10000
+                        duplex: full
+                        rate_limit: null
+                        autoneg: true
+                        switchport: 412
+                        switchport_name: xe-0/0/9
+                        switch: 13
+                        switch_name: vc513
+                    vlan_interfaces:
+                      - id: 688
+                        vlan: 1
+                        ipv4enabled: true
+                        ipv4address: 193.189.82.101
+                        ipv4hostname: examplenet.kleyrex.net
+                        ipv6enabled: true
+                        ipv6address: '2001:7f8:33::a101:2586:1'
+                        ipv6hostname: examplenet.kleyrex.net
+                        rsclient: true
+                        irrdbfilter: true
+                        as112client: false
+                        maxbgpprefix:
+                          ipv4: 500
+                          ipv6: 500
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+    post:
+      tags: [ Connections ]
+      operationId: createMemberConnection
+      summary: Create a connection for a member
+      description: |
+        Creates the virtual interface, the physical interface on a switch port, the VLAN
+        interface and its addresses — the equivalent of the web UI's "add a port" wizard, minus
+        the redirects and flash messages a machine caller cannot use.
+
+        **Everything happens in one transaction, including the address allocation**: the row
+        lock `IpAllocator` takes is only meaningful until commit, so two orders provisioned at
+        the same moment cannot be handed the same address. The transaction is attempted up to
+        three times on deadlock.
+
+        Differences from the web wizard, all deliberate:
+
+        - `ipv4address` / `ipv6address` may be the literal `"auto"`.
+        - An explicit address must **already exist** in the VLAN's pool and be unassigned.
+          `setIp()` would happily create one on the fly; `IpAllocator::claim()` is consulted
+          first and rejects anything not in the pool.
+        - LAG bookkeeping (`setBundleDetails()`, and hence `assignChannelGroup()`) is applied.
+          The wizard omits it, which is harmless there because its form cannot request LAG
+          framing.
+        - `status` defaults to *connected* (`1`) and `duplex` to `full`, so a caller does not
+          have to restate what is true of every member port.
+
+        The switch port is checked **before anything is written**. It is rejected with `422`
+        when it does not exist, belongs to a different switch than `switch` names, already has a
+        physical interface, sits on an inactive switch, or is not of type *unset* or *peering*.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConnectionInput'
+            examples:
+              autoDualStack:
+                summary: Dual stack with automatic addressing on KleyReX VLAN 900
+                value:
+                  vlanid: 1
+                  switch: 13
+                  switchportid: 412
+                  speed: 10000
+                  ipv4enabled: true
+                  ipv4address: auto
+                  ipv4hostname: examplenet.kleyrex.net
+                  ipv6enabled: true
+                  ipv6address: auto
+                  ipv6hostname: examplenet.kleyrex.net
+                  rsclient: true
+                  irrdbfilter: true
+                  ipv4maxbgpprefix: 500
+                  ipv6maxbgpprefix: 500
+              explicitAddresses:
+                summary: Explicit addresses, rate limited, with a LAG-framed interface
+                value:
+                  vlanid: 1
+                  switch: 14
+                  switchportid: 501
+                  speed: 10000
+                  rate_limit: 1000
+                  status: 1
+                  duplex: full
+                  autoneg: true
+                  name: ae0
+                  description: Example Networks GmbH primary
+                  mtu: 9000
+                  lag_framing: true
+                  fastlacp: false
+                  ipv4enabled: true
+                  ipv4address: 193.189.82.101
+                  ipv4hostname: examplenet.kleyrex.net
+                  ipv6enabled: true
+                  ipv6address: '2001:7f8:33::a101:2586:1'
+                  ipv6hostname: examplenet.kleyrex.net
+                  rsclient: true
+                  irrdbfilter: true
+                  as112client: false
+              ipv6Only:
+                summary: IPv6 only — the v4 family stays disabled and unaddressed
+                value:
+                  vlanid: 1
+                  switch: 13
+                  switchportid: 413
+                  speed: 1000
+                  ipv4enabled: false
+                  ipv6enabled: true
+                  ipv6address: auto
+                  ipv6hostname: examplenet-v6.kleyrex.net
+                  rsclient: true
+      responses:
+        '201':
+          description: The connection was created.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ connection ]
+                properties:
+                  connection:
+                    $ref: '#/components/schemas/Connection'
+              example:
+                connection:
+                  id: 501
+                  custid: 97
+                  name: null
+                  trunk: false
+                  lag_framing: false
+                  channelgroup: null
+                  physical_interfaces:
+                    - id: 733
+                      status: 1
+                      speed: 10000
+                      duplex: full
+                      rate_limit: null
+                      autoneg: true
+                      switchport: 412
+                      switchport_name: xe-0/0/9
+                      switch: 13
+                      switch_name: vc513
+                  vlan_interfaces:
+                    - id: 688
+                      vlan: 1
+                      ipv4enabled: true
+                      ipv4address: 193.189.82.101
+                      ipv4hostname: examplenet.kleyrex.net
+                      ipv6enabled: true
+                      ipv6address: '2001:7f8:33::a101:2586:1'
+                      ipv6hostname: examplenet.kleyrex.net
+                      rsclient: true
+                      irrdbfilter: true
+                      as112client: false
+                      maxbgpprefix:
+                        ipv4: 500
+                        ipv6: 500
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: |
+            Either the payload failed validation (`message` **and** `errors`), or the switch
+            port or an address could not be used (`message` only — these are raised by the
+            controller and by `IpAllocator`, not by the validator). Nothing was written in
+            either case.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationError'
+                  - $ref: '#/components/schemas/Error'
+              examples:
+                enabledFamilyWithoutAddress:
+                  summary: ipv4enabled with no address — validation
+                  value:
+                    message: The ipv4address field is required.
+                    errors:
+                      ipv4address:
+                        - The ipv4address field is required.
+                malformedAddress:
+                  summary: neither an address nor "auto" — validation
+                  value:
+                    message: The ipv4address must be a valid ipv4 address or "auto".
+                    errors:
+                      ipv4address:
+                        - The ipv4address must be a valid ipv4 address or "auto".
+                portTaken:
+                  summary: switch port already assigned
+                  value:
+                    message: Switch port xe-0/0/9 is already assigned to another connection.
+                portOnOtherSwitch:
+                  summary: switch port does not belong to the switch named
+                  value:
+                    message: Switch port xe-0/0/9 does not belong to the switch given.
+                portNotMemberPort:
+                  summary: switch port is infrastructure, not a member port
+                  value:
+                    message: Switch port xe-0/0/9 is not a member port (type 3).
+                switchInactive:
+                  summary: switch taken out of service between listing and ordering
+                  value:
+                    message: Switch port xe-0/0/9 is on a switch which is not active.
+                addressNotInPool:
+                  summary: explicit address which is not in this VLAN's pool
+                  value:
+                    message: IPv4 address 193.189.82.101 is not in the address pool of VLAN Peering LAN (id 1).
+                addressTaken:
+                  summary: explicit address already on another VLAN interface
+                  value:
+                    message: IPv4 address 193.189.82.101 is already assigned to another VLAN interface.
+                poolExhausted:
+                  summary: '"auto" with nothing left to allocate'
+                  value:
+                    message: No free IPv6 address left in VLAN Peering LAN (id 1).
+                raced:
+                  summary: an address was taken between the check and the write
+                  value:
+                    message: An address became unavailable while the connection was being created. Please retry.
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /connection/{vi}:
+    parameters:
+      - $ref: '#/components/parameters/VirtualInterfaceId'
+    delete:
+      tags: [ Connections ]
+      operationId: deleteConnection
+      summary: Remove a connection
+      description: |
+        Deletes the virtual interface, its physical interfaces, its VLAN interfaces and their
+        layer 2 addresses and MAC addresses, in one transaction. Freed IP addresses return to
+        the VLAN's pool; the address records themselves are not deleted.
+
+        Teardown uses the inherited `deletePi()`, which handles the fanout and reseller cases.
+        That method is not idempotent — it dereferences `$pi->switchPort` after having set
+        `switchportid` to null — so a physical interface which is already detached is deleted
+        directly rather than passed to it.
+
+        Note the endpoint takes a **virtual interface id**, not a customer id, and is not itself
+        idempotent: deleting the same connection twice gives `200` and then `404`, because route
+        model binding no longer finds it.
+      responses:
+        '200':
+          description: The connection was deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ deleted ]
+                properties:
+                  deleted:
+                    type: boolean
+                    const: true
+              example:
+                deleted: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: |
+            The virtual interface belongs to a core bundle. Nothing was deleted — remove the
+            core bundle first.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: This connection belongs to a core bundle. Delete the core bundle first.
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /onboarding:
+    post:
+      tags: [ Onboarding ]
+      operationId: onboard
+      summary: Create a member, an optional user and an optional connection in one transaction
+      description: |
+        The three dedicated endpoints can be called in sequence, but that sequence is not
+        atomic: a caller whose second request fails is left with a half-provisioned member and
+        no clean way back. Here either the whole order lands or none of it does.
+
+        It does not orchestrate anything beyond the database. Rolling configuration out to
+        switches, regenerating route server configuration and updating reverse DNS remain the
+        caller's business; this endpoint only makes the IXP Manager side of an order indivisible.
+
+        ## Sections
+
+        The three sections are **nested rather than flattened**, because `name` means something
+        different for a member, a user and a virtual interface. Each section is validated with
+        exactly the rules of its own endpoint, re-keyed under its prefix — so a rule added
+        upstream reaches this endpoint too without anybody remembering to copy it. Validation
+        errors are therefore keyed `member.shortname`, `user.privs`, `connection.ipv4address`
+        and so on.
+
+        `member` is required. `user` and `connection` are optional. `custid` is dropped from the
+        user and connection rule sets: it comes from the member this very request is creating.
+
+        Two checks which live in `withValidator()` hooks rather than rules are restated here,
+        evaluated against the member being created rather than one already in the database —
+        without them an order could create a full IXP Manager administrator attached to an
+        arbitrary member, and the welcome email would hand over the password-reset link:
+
+        - superuser privileges (`user.privs: 3`) require `member.type: 3` (internal);
+        - `member.isResold` requires an existing `member.reseller`.
+
+        ## Idempotency
+
+        `reference` is the caller's own order identifier and makes retries safe:
+
+        - First call with a new reference: `201`, `created: true`, plus the ids created.
+        - Any later call with the same reference: **`200`**, `created: false`, and the member
+          the first call produced. `user` and `connection` are not present on this response —
+          only the reference and the member are recorded.
+
+        The check runs twice. `ShortCircuitKnownReference` middleware answers before validation
+        even runs, because by the time a caller retries, the `shortname` it asks for exists and
+        validation would otherwise reject the retry with "that name is taken" — technically true
+        and useless in practice. The controller keeps its own check for the window between two
+        simultaneous retries, where both pass the middleware before either commits.
+
+        **Without a reference, a retry creates a second member.**
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnboardingInput'
+            examples:
+              fullOrder:
+                summary: Member, user and connection in one order
+                value:
+                  reference: ORD-2026-04711
+                  member:
+                    name: Example Networks GmbH
+                    shortname: examplenet
+                    abbreviatedName: EXAMPLE
+                    type: 1
+                    status: 1
+                    datejoin: '2026-08-01'
+                    autsys: 12586
+                    maxprefixes: 500
+                    maxprefixesv6: 500
+                    peeringemail: peering@example.net
+                    peeringmacro: AS-EXAMPLE
+                    peeringpolicy: open
+                    nocemail: noc@example.net
+                  user:
+                    name: Erika Mustermann
+                    username: examplenet-noc
+                    email: noc@example.net
+                    privs: 2
+                    enabled: true
+                  connection:
+                    vlanid: 1
+                    switch: 13
+                    switchportid: 412
+                    speed: 10000
+                    ipv4enabled: true
+                    ipv4address: auto
+                    ipv4hostname: examplenet.kleyrex.net
+                    ipv6enabled: true
+                    ipv6address: '2001:7f8:33::a101:2586:1'
+                    ipv6hostname: examplenet.kleyrex.net
+                    rsclient: true
+                    irrdbfilter: true
+              memberOnly:
+                summary: Member only, no reference — a retry would create a second member
+                value:
+                  member:
+                    name: Example Association e.V.
+                    shortname: exampleassoc
+                    abbreviatedName: EXAMPLEA
+                    type: 2
+                    status: 1
+                    datejoin: '2026-08-01'
+      responses:
+        '200':
+          description: |
+            This reference has been seen before. Nothing was created; the member the original
+            call produced is returned. `user` and `connection` are not part of this response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OnboardingReplay'
+              example:
+                created: false
+                reference: ORD-2026-04711
+                member:
+                  id: 97
+                  shortname: examplenet
+        '201':
+          description: |
+            The order landed in full. `user` and `connection` are `null` when those sections
+            were not supplied. The welcome email is dispatched after the commit, never inside it.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OnboardingResult'
+              examples:
+                full:
+                  summary: Member, user and connection created
+                  value:
+                    created: true
+                    reference: ORD-2026-04711
+                    member:
+                      id: 97
+                      shortname: examplenet
+                    user:
+                      id: 314
+                      username: examplenet-noc
+                    connection:
+                      id: 501
+                memberOnly:
+                  summary: Member only, no reference
+                  value:
+                    created: true
+                    reference: null
+                    member:
+                      id: 98
+                      shortname: exampleassoc
+                    user: null
+                    connection: null
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: |
+            A unique index was violated and the reference could not be resolved to an existing
+            member. **Nothing was created** — the whole transaction was rolled back.
+
+            Which index was hit matters, and the two cases need opposite responses. Telling a
+            caller whose switch port was taken to "use a new reference" would be actively
+            harmful: it would burn an order number and retry onto the same occupied port.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                referenceReused:
+                  summary: the reference is taken but its member was deleted afterwards
+                  value:
+                    message: >-
+                      This reference has been used before and the member it created no longer
+                      exists. Use a new reference.
+                resourceRaced:
+                  summary: another order took the switch port first — retry with the same reference
+                  value:
+                    message: >-
+                      Another request took one of the resources for this order while it was
+                      being processed - most likely the switch port. Nothing was created. Choose
+                      a different port and retry with the same reference.
+        '422':
+          description: |
+            Validation failed, or the connection section could not be provisioned. **The whole
+            order was rolled back** — a connection failure leaves no member behind.
+
+            Validation errors are keyed by section (`member.shortname`, `user.privs`,
+            `connection.ipv4address`). Errors raised by `IpAllocator` or by the switch port gate
+            carry `message` only.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationError'
+                  - $ref: '#/components/schemas/Error'
+              examples:
+                nestedValidation:
+                  summary: the member section failed validation
+                  value:
+                    message: The member.shortname field is required.
+                    errors:
+                      member.shortname:
+                        - The member.shortname field is required.
+                missingMember:
+                  summary: no member section at all
+                  value:
+                    message: The member field is required.
+                    errors:
+                      member:
+                        - The member field is required.
+                superuserOnNonInternal:
+                  summary: superuser privileges on a member which is not internal
+                  value:
+                    message: >-
+                      You are not allowed to set this user as a super user: the member being
+                      created is not an internal customer.
+                    errors:
+                      user.privs:
+                        - >-
+                          You are not allowed to set this user as a super user: the member being
+                          created is not an internal customer.
+                resoldWithoutReseller:
+                  summary: isResold with no reseller named
+                  value:
+                    message: Please choose a reseller.
+                    errors:
+                      member.reseller:
+                        - Please choose a reseller.
+                portTaken:
+                  summary: the switch port could not be used — order rolled back
+                  value:
+                    message: Switch port xe-0/0/9 is already assigned to another connection.
+                poolExhausted:
+                  summary: '"auto" with nothing left to allocate — order rolled back'
+                  value:
+                    message: No free IPv4 address left in VLAN Peering LAN (id 1).
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+components:
+
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-IXP-Manager-API-Key
+      description: |
+        A **superuser** API key, 56 characters, in the form
+        `ixpm_{identifier}_{secret}{checksum}` — for example
+        `ixpm_ident1234567_sec876543210...`.
+
+        The key's owner must have `AUTH_SUPERUSER` (privilege `3`); anything less is `403`.
+        A browser session is not accepted in place of a key: `RequireApiKey` rejects a request
+        without the header before `ApiAuthenticate` ever sees the session.
+
+        **Keys expire after at most 12 months** (`ixp_fe.api_keys.max_expires_duration`), so an
+        unattended service fails with `401 API key expired` exactly once a year unless the key
+        is rotated.
+
+        The `allowed_ips` column of the key **is** enforced on these endpoints by
+        `RestrictSourceAddress` — this is the only place in IXP Manager that reads it. A source
+        address outside it, or outside the global `ixp_api.provisioning.allowed_ips` list, gets
+        `403`.
+
+  parameters:
+
+    CustomerId:
+      name: cust
+      in: path
+      required: true
+      description: |
+        The member's `cust.id`. Resolved by route model binding, so an unknown id is `404`.
+      schema:
+        type: integer
+        minimum: 1
+      example: 97
+
+    VirtualInterfaceId:
+      name: vi
+      in: path
+      required: true
+      description: |
+        The connection's `virtualinterface.id` — **not** a customer id. Resolved by route model
+        binding, so an unknown id is `404`.
+      schema:
+        type: integer
+        minimum: 1
+      example: 501
+
+    VlanId:
+      name: vlan
+      in: path
+      required: true
+      description: |
+        The VLAN's `vlan.id` — the database id, not the 802.1Q tag. At KleyReX the peering VLAN
+        carries tag 900 and has id 1. Resolved by route model binding, so an unknown id is `404`.
+      schema:
+        type: integer
+        minimum: 1
+      example: 1
+
+  responses:
+
+    Unauthorized:
+      description: |
+        Authentication failed. Two shapes are possible:
+
+        - **JSON**, from `RequireApiKey`, when the `X-IXP-Manager-API-Key` header is absent.
+        - **Plain text**, from `ApiAuthenticate` / `ApiKeyAggregator::authenticate()`, for a key
+          which is malformed (`Malformed API key structure`), fails its checksum
+          (`Invalid API key checksum`), does not match a stored key (`Invalid credentials`),
+          has expired (`API key expired`), whose user is disabled (`User is disabled`), or whose
+          customer is disabled.
+
+        Note that an **expired key** is the failure mode an unattended service will actually
+        meet: keys are capped at 12 months.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            message: >-
+              These endpoints require an API key in the X-IXP-Manager-API-Key header. A browser
+              session is not accepted here.
+        text/html:
+          schema:
+            type: string
+            examples:
+              - API key expired
+              - Invalid credentials
+              - Malformed API key structure
+              - Unauthorized.
+
+    Forbidden:
+      description: |
+        The request authenticated but is not permitted. Two shapes:
+
+        - **Plain text `Insufficient permissions`**, from `assert.privilege:3`, when the key's
+          user is not a superuser.
+        - **JSON**, from `RestrictSourceAddress`, when the source address is covered by neither
+          the global allow-list nor the allow-list of the key presented.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            message: This source address is not permitted to use the provisioning API.
+        text/html:
+          schema:
+            type: string
+            examples:
+              - Insufficient permissions
+
+    NotFound:
+      description: |
+        No such record. Raised by route model binding for an unknown `cust`, `vi` or `vlan` id —
+        and also what every path in this document returns when the provisioning API has not been
+        enabled, since the routes are then never registered.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            message: >-
+              No query results for model [IXP\Models\Customer] 99999
+
+    TooManyRequests:
+      description: |
+        The per-key rate limit was exceeded. Defaults to 60 requests a minute
+        (`ixp_api.provisioning.rate_limit`); setting it to `0` removes the throttle middleware
+        from the stack entirely.
+      headers:
+        Retry-After:
+          description: Seconds until the limit resets.
+          schema:
+            type: integer
+          example: 42
+        X-RateLimit-Limit:
+          description: Requests permitted per minute.
+          schema:
+            type: integer
+          example: 60
+        X-RateLimit-Remaining:
+          description: Requests left in the current window.
+          schema:
+            type: integer
+          example: 0
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            message: Too Many Attempts.
+
+  schemas:
+
+    Error:
+      type: object
+      title: Error
+      description: |
+        The shape of every error the provisioning code itself produces: a single human-readable
+        `message` and nothing else. Errors raised by the Laravel validator add `errors` — see
+        `ValidationError`.
+      required: [ message ]
+      properties:
+        message:
+          type: string
+          description: A human-readable explanation. Not a stable identifier — do not match on it.
+      examples:
+        - message: This connection belongs to a core bundle. Delete the core bundle first.
+
+    ValidationError:
+      type: object
+      title: ValidationError
+      description: |
+        A Laravel validation failure. `errors` is keyed by field name, each value an array of
+        messages for that field. For the onboarding endpoint the keys are section-qualified —
+        `member.shortname`, `user.privs`, `connection.ipv4address`.
+      required: [ message, errors ]
+      properties:
+        message:
+          type: string
+          description: The first validation message, repeated for convenience.
+        errors:
+          type: object
+          description: Field name to the list of messages for that field.
+          additionalProperties:
+            type: array
+            items:
+              type: string
+      examples:
+        - message: The shortname has already been taken.
+          errors:
+            shortname:
+              - The shortname has already been taken.
+
+    Pong:
+      type: object
+      title: Pong
+      required: [ pong, user, version ]
+      properties:
+        pong:
+          type: boolean
+          const: true
+        user:
+          type: string
+          description: Username of the API key's owner, as resolved by `apiauth`.
+        version:
+          type: string
+          description: The `APPLICATION_VERSION` constant of this IXP Manager installation.
+
+    Switch:
+      type: object
+      title: Switch
+      description: An active switch. Built by `PortController::switches()`.
+      required: [ id, name, infrastructure, hostname ]
+      properties:
+        id:
+          type: integer
+          description: '`switch.id` — the value the `switch` field of a connection expects.'
+        name:
+          type: string
+          description: Short name, for example `vc513`.
+        infrastructure:
+          type: [ integer, 'null' ]
+          description: '`infrastructure.id` this switch belongs to.'
+        hostname:
+          type: [ string, 'null' ]
+      examples:
+        - id: 13
+          name: vc513
+          infrastructure: 1
+          hostname: vc513.kleyrex.net
+
+    Vlan:
+      type: object
+      title: Vlan
+      description: A VLAN as reported by the infrastructure and address listings.
+      required: [ id, name, number ]
+      properties:
+        id:
+          type: integer
+          description: '`vlan.id` — the value the `vlanid` field of a connection expects.'
+        name:
+          type: [ string, 'null' ]
+        number:
+          type: [ integer, 'null' ]
+          description: The 802.1Q tag. At KleyReX, 900 for the peering LAN.
+      examples:
+        - id: 1
+          name: Peering LAN
+          number: 900
+
+    Infrastructure:
+      type: object
+      title: Infrastructure
+      description: An infrastructure and the VLANs attached to it.
+      required: [ id, name, shortname, isPrimary, vlans ]
+      properties:
+        id:
+          type: integer
+        name:
+          type: [ string, 'null' ]
+        shortname:
+          type: [ string, 'null' ]
+        isPrimary:
+          type: boolean
+        vlans:
+          type: array
+          items:
+            $ref: '#/components/schemas/Vlan'
+
+    Port:
+      type: object
+      title: Port
+      description: |
+        A switch port which is free to be assigned to a member: no physical interface attached,
+        type *unset* or *peering*, on an active switch.
+      required: [ switchport, name, type, switch, switch_name, infrastructure ]
+      properties:
+        switchport:
+          type: integer
+          description: '`switchport.id` — the value the `switchportid` field of a connection expects.'
+        name:
+          type: [ string, 'null' ]
+          description: Port name as configured on the switch, for example `xe-0/0/9`.
+        type:
+          type: integer
+          description: |
+            `0` = unset, `1` = peering. No other type is ever returned by this endpoint;
+            `2` monitor, `3` core, `4` other, `5` management, `6` fanout and `7` reseller are
+            infrastructure and are filtered out.
+          enum: [ 0, 1 ]
+        switch:
+          type: integer
+          description: '`switch.id` — pass this as `switch` when creating the connection.'
+        switch_name:
+          type: [ string, 'null' ]
+        infrastructure:
+          type: [ integer, 'null' ]
+      examples:
+        - switchport: 412
+          name: xe-0/0/9
+          type: 0
+          switch: 13
+          switch_name: vc513
+          infrastructure: 1
+
+    Address:
+      type: object
+      title: Address
+      description: |
+        One address from a VLAN's pool. Pools are created ahead of time; this API never mints an
+        address, it only claims an existing, unclaimed one.
+      required: [ id, address, free ]
+      properties:
+        id:
+          type: integer
+          description: '`ipv4address.id` or `ipv6address.id`.'
+        address:
+          type: string
+          description: The address exactly as stored.
+        free:
+          type: boolean
+          description: True when no VLAN interface points at this address.
+      examples:
+        - id: 341
+          address: 193.189.82.101
+          free: true
+        - id: 902
+          address: '2001:7f8:33::a101:2586:1'
+          free: false
+
+    AddressList:
+      type: object
+      title: AddressList
+      description: The addresses of one protocol family within a VLAN.
+      required: [ addresses, total, truncated ]
+      properties:
+        addresses:
+          type: array
+          description: Ordered numerically, not lexically, so `.10` does not precede `.9`.
+          items:
+            $ref: '#/components/schemas/Address'
+        total:
+          type: integer
+          description: Size of the whole matching set, before `limit` was applied.
+        truncated:
+          type: boolean
+          description: True when `limit` cut the list short.
+
+    VlanAddressListing:
+      type: object
+      title: VlanAddressListing
+      description: |
+        The response of `GET /vlan/{vlan}/address`. `ipv4` is omitted when `protocol=6` was
+        asked for, `ipv6` when `protocol=4` was.
+      required: [ vlan ]
+      properties:
+        vlan:
+          $ref: '#/components/schemas/Vlan'
+        ipv4:
+          $ref: '#/components/schemas/AddressList'
+        ipv6:
+          $ref: '#/components/schemas/AddressList'
+
+    Member:
+      type: object
+      title: Member
+      description: |
+        A member as this API reports it — the explicit field list of
+        `MemberController::memberAsArray()`, not the model's `toArray()`. Fields of the `cust`
+        table which are accepted on input but not echoed back (`corpwww`, the NOC fields,
+        `activepeeringmatrix`, `MD5Support`) are deliberately absent here.
+      required:
+        - id
+        - name
+        - shortname
+        - abbreviatedName
+        - type
+        - status
+        - autsys
+        - maxprefixes
+        - maxprefixesv6
+        - peeringemail
+        - peeringmacro
+        - peeringmacrov6
+        - peeringpolicy
+        - irrdb
+        - datejoin
+        - dateleave
+        - reseller
+        - isReseller
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        shortname:
+          type: string
+        abbreviatedName:
+          type: [ string, 'null' ]
+        type:
+          type: integer
+          description: '`1` Full, `2` Associate, `3` Internal, `4` Pro-bono.'
+          enum: [ 1, 2, 3, 4 ]
+        status:
+          type: integer
+          description: '`1` Normal, `2` Not Connected, `3` Suspended.'
+          enum: [ 1, 2, 3 ]
+        autsys:
+          type: [ integer, 'null' ]
+        maxprefixes:
+          type: [ integer, 'null' ]
+        maxprefixesv6:
+          type: [ integer, 'null' ]
+        peeringemail:
+          type: [ string, 'null' ]
+        peeringmacro:
+          type: [ string, 'null' ]
+        peeringmacrov6:
+          type: [ string, 'null' ]
+        peeringpolicy:
+          type: [ string, 'null' ]
+          enum: [ open, selective, mandatory, closed, null ]
+        irrdb:
+          type: [ integer, 'null' ]
+          description: '`irrdbconfig.id`.'
+        datejoin:
+          type: [ string, 'null' ]
+          format: date
+          description: Normalised to `Y-m-d`.
+        dateleave:
+          type: [ string, 'null' ]
+          format: date
+          description: Normalised to `Y-m-d`. Note the column is `dateleave`, not `dateleft`.
+        reseller:
+          type: [ integer, 'null' ]
+          description: '`cust.id` of the reseller, or null when the member is not resold.'
+        isReseller:
+          type: boolean
+
+    User:
+      type: object
+      title: User
+      description: |
+        A portal user as this API reports it — `MemberController::userAsArray()`. The password
+        is random and is deliberately never returned; the account is activated through the
+        welcome email's password-reset link.
+      required: [ id, name, username, email, custid, privs, enabled ]
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        username:
+          type: string
+          description: Lowercased on write.
+        email:
+          type: string
+          format: email
+          description: Lowercased on write.
+        custid:
+          type: integer
+          description: The member the user was created under — taken from the route, not the body.
+        privs:
+          type: integer
+          description: '`1` CUSTUSER, `2` CUSTADMIN, `3` SUPERUSER.'
+          enum: [ 1, 2, 3 ]
+        enabled:
+          type: boolean
+          description: The inverse of the `disabled` column.
+
+    ConnectionPhysicalInterface:
+      type: object
+      title: ConnectionPhysicalInterface
+      description: One physical interface of a connection, with its switch port resolved.
+      required:
+        - id
+        - status
+        - speed
+        - duplex
+        - rate_limit
+        - autoneg
+        - switchport
+        - switchport_name
+        - switch
+        - switch_name
+      properties:
+        id:
+          type: integer
+        status:
+          type: [ integer, 'null' ]
+          description: '`1` Connected, `2` Disabled, `3` Not Connected, `4` Awaiting X-Connect, `5` Quarantine.'
+        speed:
+          type: [ integer, 'null' ]
+          description: Mbit/s — one of 10, 100, 1000, 10000, 25000, 40000, 100000, 400000.
+        duplex:
+          type: [ string, 'null' ]
+          enum: [ full, half, null ]
+        rate_limit:
+          type: [ integer, 'null' ]
+          description: Mbit/s, or null for unlimited.
+        autoneg:
+          type: boolean
+        switchport:
+          type: [ integer, 'null' ]
+          description: '`switchport.id`, or null once the interface has been detached.'
+        switchport_name:
+          type: [ string, 'null' ]
+        switch:
+          type: [ integer, 'null' ]
+        switch_name:
+          type: [ string, 'null' ]
+
+    ConnectionVlanInterface:
+      type: object
+      title: ConnectionVlanInterface
+      description: |
+        One VLAN interface of a connection. Addresses are reported as strings resolved from the
+        pool; `null` means the family carries no address.
+      required:
+        - id
+        - vlan
+        - ipv4enabled
+        - ipv4address
+        - ipv4hostname
+        - ipv6enabled
+        - ipv6address
+        - ipv6hostname
+        - rsclient
+        - irrdbfilter
+        - as112client
+        - maxbgpprefix
+      properties:
+        id:
+          type: integer
+        vlan:
+          type: integer
+          description: '`vlan.id`.'
+        ipv4enabled:
+          type: boolean
+        ipv4address:
+          type: [ string, 'null' ]
+        ipv4hostname:
+          type: [ string, 'null' ]
+        ipv6enabled:
+          type: boolean
+        ipv6address:
+          type: [ string, 'null' ]
+        ipv6hostname:
+          type: [ string, 'null' ]
+        rsclient:
+          type: boolean
+        irrdbfilter:
+          type: boolean
+        as112client:
+          type: boolean
+        maxbgpprefix:
+          type: object
+          description: |
+            Per-family prefix limits for the route server sessions. Both may be null, in which
+            case the customer-level `maxprefixes` / `maxprefixesv6` apply.
+          required: [ ipv4, ipv6 ]
+          properties:
+            ipv4:
+              type: [ integer, 'null' ]
+            ipv6:
+              type: [ integer, 'null' ]
+
+    Connection:
+      type: object
+      title: Connection
+      description: |
+        A member's connection — the virtual interface and everything hanging off it, as built by
+        `ConnectionController::connectionAsArray()`.
+
+        Note the fields the VLAN interface deliberately does **not** report even though they can
+        be set: `mcastenabled`, `rsmorespecifics`, `busyhost`, the BGP MD5 secrets, `canping`
+        and `monitorrcbgp`.
+      required:
+        - id
+        - custid
+        - name
+        - trunk
+        - lag_framing
+        - channelgroup
+        - physical_interfaces
+        - vlan_interfaces
+      properties:
+        id:
+          type: integer
+          description: '`virtualinterface.id` — the id `DELETE /connection/{vi}` takes.'
+        custid:
+          type: integer
+        name:
+          type: [ string, 'null' ]
+        trunk:
+          type: boolean
+        lag_framing:
+          type: boolean
+        channelgroup:
+          type: [ integer, 'null' ]
+          description: Assigned by `setBundleDetails()` when the interface is LAG framed.
+        physical_interfaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectionPhysicalInterface'
+        vlan_interfaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectionVlanInterface'
+
+    MemberInput:
+      type: object
+      title: MemberInput
+      description: |
+        The body of `POST /member`, and the `member` section of `POST /onboarding`.
+
+        Validated by `StoreCustomer`, which is `IXP\Http\Requests\Customer\Store` plus a delta
+        of `dateleave`, `MD5Support`, `isReseller`, `isResold` and `activepeeringmatrix`.
+
+        **When `type` is `2` (Associate) only the common fields below are validated at all** —
+        `autsys` through `reseller` have no rules in that case and are passed straight to
+        `Customer::create()`, where only fillable columns survive.
+
+        Unknown fields are dropped: the controller passes `$r->validated()`, never `$r->all()`.
+      required: [ name, type, shortname, datejoin, status, abbreviatedName ]
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          description: |
+            Also written verbatim to the `CompanyRegisteredDetail.registeredName` created
+            alongside the member.
+        type:
+          type: integer
+          enum: [ 1, 2, 3, 4 ]
+          description: '`1` Full, `2` Associate, `3` Internal, `4` Pro-bono.'
+        shortname:
+          type: string
+          maxLength: 30
+          pattern: '[a-z0-9]+'
+          description: Must be unique across `cust.shortname`; a clash is `422`.
+        status:
+          type: integer
+          enum: [ 1, 2, 3 ]
+          description: '`1` Normal, `2` Not Connected, `3` Suspended.'
+        abbreviatedName:
+          type: string
+          maxLength: 30
+        datejoin:
+          type: string
+          format: date
+          description: Any string Laravel's `date` rule accepts; `Y-m-d` is the sane choice.
+        dateleave:
+          type: [ string, 'null' ]
+          format: date
+          description: |
+            The column the schema actually has. Validated by the API delta and persisted.
+        dateleft:
+          type: [ string, 'null' ]
+          format: date
+          description: |
+            **Accepted but ignored.** The upstream web rules use this spelling, which matches no
+            column and is not fillable. Use `dateleave`. Documented only so a caller which has
+            been sending it knows it has never had an effect.
+          deprecated: true
+        corpwww:
+          type: [ string, 'null' ]
+          format: uri
+          maxLength: 255
+        MD5Support:
+          type: [ string, 'null' ]
+          enum: [ UNKNOWN, 'YES', MANDATORY, PREFERRED, 'NO', null ]
+          description: The correctly-cased column name. Validated by the API delta and persisted.
+        md5support:
+          type: [ string, 'null' ]
+          enum: [ UNKNOWN, 'YES', MANDATORY, PREFERRED, 'NO', null ]
+          description: |
+            **Accepted but ignored** — the upstream spelling, which is not a fillable column.
+            Use `MD5Support`.
+          deprecated: true
+        autsys:
+          type: integer
+          minimum: 1
+          description: 'AS number. Not validated when `type` is `2`.'
+        maxprefixes:
+          type: [ integer, 'null' ]
+          minimum: 0
+        maxprefixesv6:
+          type: [ integer, 'null' ]
+          minimum: 0
+        peeringemail:
+          type: string
+          format: email
+        peeringmacro:
+          type: [ string, 'null' ]
+          maxLength: 255
+          pattern: '^(AS-[A-Z0-9]+(?:-[A-Z0-9]+)*|AS[1-9]\d*(?::AS-[A-Z0-9]+(?:-[A-Z0-9]+)*)?)$'
+          description: 'Case-insensitive, for example `AS-EXAMPLE` or `AS12586:AS-CUSTOMERS`.'
+        peeringmacrov6:
+          type: [ string, 'null' ]
+          maxLength: 255
+          pattern: '^(AS-[A-Z0-9]+(?:-[A-Z0-9]+)*|AS[1-9]\d*(?::AS-[A-Z0-9]+(?:-[A-Z0-9]+)*)?)$'
+        peeringpolicy:
+          type: string
+          enum: [ open, selective, mandatory, closed ]
+        irrdb:
+          type: [ integer, 'null' ]
+          description: '`irrdbconfig.id`. Must exist.'
+        nocphone:
+          type: [ string, 'null' ]
+          maxLength: 255
+        noc24hphone:
+          type: [ string, 'null' ]
+          maxLength: 255
+        nocemail:
+          type: string
+          format: email
+          maxLength: 255
+        nochours:
+          type: [ string, 'null' ]
+          enum: [ 24x7, 8x5, 8x7, 12x5, 12x7, null ]
+        nocwww:
+          type: [ string, 'null' ]
+          format: uri
+          maxLength: 255
+        reseller:
+          type: [ integer, 'null' ]
+          description: '`cust.id` of the reseller. Must exist. Only written when `isResold` is true.'
+        isResold:
+          type: boolean
+          description: |
+            Not a column. When true, `reseller` is written to the member and must name an
+            existing customer, else `422`. When false or absent, `reseller` is forced to null.
+        isReseller:
+          type: boolean
+          description: Whether this member is itself a reseller.
+        activepeeringmatrix:
+          type: boolean
+
+    UserInput:
+      type: object
+      title: UserInput
+      description: |
+        The body of `POST /member/{cust}/user`, and the `user` section of `POST /onboarding`.
+
+        Validated by `StoreUser`, which is `IXP\Http\Requests\User\Store` plus `enabled`.
+
+        `custid` is **not** part of the payload: at the dedicated endpoint
+        `prepareForValidation()` overwrites it from the route, and at the onboarding endpoint
+        the rule is removed entirely because the member is created by the same request. An `id`
+        in the body is stripped before validation.
+      required: [ name, username, email, privs ]
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        username:
+          type: string
+          minLength: 3
+          maxLength: 255
+          pattern: '^[a-z0-9\-_\.]{3,255}$'
+          description: Must be unique across `user.username`. Lowercased on write.
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          description: Lowercased on write. The welcome email goes here.
+        authorisedMobile:
+          type: [ string, 'null' ]
+          maxLength: 50
+        privs:
+          type: integer
+          enum: [ 1, 2, 3 ]
+          description: |
+            `1` CUSTUSER, `2` CUSTADMIN, `3` SUPERUSER. **`3` is only accepted when the member is
+            an internal customer** (`type: 3`); anywhere else it is `422`. That check is the only
+            thing standing between an order and a full IXP Manager administrator whose
+            password-reset link is mailed out automatically.
+        enabled:
+          type: boolean
+          default: true
+          description: |
+            Written to the `disabled` column inverted. Defaults to enabled, which is the only
+            sensible default when the very next thing that happens is a welcome email. The web
+            form's `disabled` field is deliberately not reproduced.
+
+    ConnectionInput:
+      type: object
+      title: ConnectionInput
+      description: |
+        The body of `POST /member/{cust}/connection`, and the `connection` section of
+        `POST /onboarding`.
+
+        Validated by `StoreConnection`, which is `IXP\Http\Requests\StoreVirtualInterfaceWizard`
+        plus a delta of `name`, `description`, `mtu`, `lag_framing`, `fastlacp` and `busyhost` —
+        all fillable columns an unattended caller has no other way to set — and with
+        `ipv4address` / `ipv6address` replaced so that they also accept `"auto"`.
+
+        Only the address *type* is relaxed, never the requirement: a family which is enabled
+        must still carry an address. Dropping that would create a VLAN interface with
+        `ipv4enabled=1` and no address, which renders as `neighbor  as 65551;` in the route
+        server configuration — a parse error invalidating the generated config for the whole
+        VLAN, not merely that peer.
+
+        `custid` is not part of the payload; it comes from the route (or, at onboarding, from
+        the member being created). `status` defaults to `1` (connected) and `duplex` to `full`.
+      required: [ vlanid, switch, switchportid, speed ]
+      properties:
+        vlanid:
+          type: integer
+          description: '`vlan.id`. Must exist. At KleyReX the peering LAN (tag 900) is id 1.'
+        switch:
+          type: integer
+          description: |
+            `switch.id`. Must exist, must be active, and the switch port named below must belong
+            to it — a mismatch is `422`.
+        switchportid:
+          type: integer
+          description: |
+            `switchport.id`. Must exist, must have no physical interface attached, and must be
+            of type *unset* or *peering*. Set to *peering* once the connection is created.
+        speed:
+          type: integer
+          enum: [ 10, 100, 1000, 10000, 25000, 40000, 100000, 400000 ]
+          description: Mbit/s.
+        status:
+          type: integer
+          enum: [ 1, 2, 3, 4, 5 ]
+          default: 1
+          description: |
+            `1` Connected, `2` Disabled, `3` Not Connected, `4` Awaiting X-Connect,
+            `5` Quarantine. Defaulted to `1` before validation when absent.
+        duplex:
+          type: string
+          enum: [ full, half ]
+          default: full
+          description: Defaulted to `full` before validation when absent.
+        rate_limit:
+          type: [ integer, 'null' ]
+          minimum: 0
+          description: Mbit/s. Null or absent means unlimited.
+        autoneg:
+          type: boolean
+        name:
+          type: [ string, 'null' ]
+          maxLength: 255
+          description: Virtual interface name, for example `ae0`. Not offered by the web wizard.
+        description:
+          type: [ string, 'null' ]
+          maxLength: 255
+        mtu:
+          type: [ integer, 'null' ]
+          minimum: 0
+        trunk:
+          type: boolean
+        lag_framing:
+          type: boolean
+          description: |
+            LAG bookkeeping is applied here but not by the web wizard, whose form cannot request
+            it; `setBundleDetails()` assigns the channel group.
+        fastlacp:
+          type: boolean
+        busyhost:
+          type: boolean
+        mcastenabled:
+          type: boolean
+        rsclient:
+          type: boolean
+          description: |
+            Route server client. Enabling this together with `irrdbfilter` while the member has
+            no IRRDB source set makes the route servers block every prefix — the controller logs
+            a warning but does not refuse.
+        irrdbfilter:
+          type: boolean
+        rsmorespecifics:
+          type: boolean
+        as112client:
+          type: boolean
+        ipv4enabled:
+          type: boolean
+        ipv4address:
+          type: [ string, 'null' ]
+          maxLength: 255
+          description: |
+            An IPv4 address, or the literal `"auto"` (case-insensitive, whitespace trimmed).
+
+            **Required when `ipv4enabled` is true**, nullable otherwise. An explicit address must
+            already exist in this VLAN's pool and be unassigned — unlike the web path, no address
+            record is created on the fly.
+          examples: [ auto, 193.189.82.101 ]
+        ipv4hostname:
+          type: [ string, 'null' ]
+          maxLength: 255
+          description: |
+            Validated with `IdnValidate`. **Required when `ipv4enabled` is true and
+            `ixp_fe.vlaninterfaces.hostname_required` is set** — which it is by default.
+        ipv4bgpmd5secret:
+          type: [ string, 'null' ]
+          maxLength: 255
+        ipv4maxbgpprefix:
+          type: [ integer, 'null' ]
+        ipv4canping:
+          type: boolean
+        ipv4monitorrcbgp:
+          type: boolean
+        ipv6enabled:
+          type: boolean
+        ipv6address:
+          type: [ string, 'null' ]
+          maxLength: 255
+          description: |
+            An IPv6 address, or the literal `"auto"`. **Required when `ipv6enabled` is true**,
+            nullable otherwise. Same pool rules as `ipv4address`; an address written in a
+            different but equivalent form (`2001:7f8:33::a101:2586:1` vs
+            `2001:07f8:0033::a101:2586:0001`) is matched against both the given and the
+            canonical form.
+          examples: [ auto, '2001:7f8:33::a101:2586:1' ]
+        ipv6hostname:
+          type: [ string, 'null' ]
+          maxLength: 255
+          description: |
+            Validated with `IdnValidate`. **Required when `ipv6enabled` is true and
+            `ixp_fe.vlaninterfaces.hostname_required` is set** — which it is by default.
+        ipv6bgpmd5secret:
+          type: [ string, 'null' ]
+          maxLength: 255
+        ipv6maxbgpprefix:
+          type: [ integer, 'null' ]
+        ipv6canping:
+          type: boolean
+        ipv6monitorrcbgp:
+          type: boolean
+
+    OnboardingInput:
+      type: object
+      title: OnboardingInput
+      description: |
+        A composite order. Sections are nested rather than flattened so that field names cannot
+        collide — `name` means something different for a member, a user and a virtual interface.
+      required: [ member ]
+      properties:
+        reference:
+          type: [ string, 'null' ]
+          maxLength: 191
+          description: |
+            The caller's own order identifier. Supplying it makes the request idempotent: a
+            repeat returns `200` with the original member instead of creating a second one.
+            Omitting it means a retry after a timeout creates a duplicate member.
+          examples: [ ORD-2026-04711 ]
+        member:
+          $ref: '#/components/schemas/MemberInput'
+        user:
+          oneOf:
+            - $ref: '#/components/schemas/UserInput'
+            - type: 'null'
+          description: Optional. Omit the key entirely to create no user.
+        connection:
+          oneOf:
+            - $ref: '#/components/schemas/ConnectionInput'
+            - type: 'null'
+          description: Optional. Omit the key entirely to create no connection.
+
+    OnboardingMemberRef:
+      type: object
+      title: OnboardingMemberRef
+      description: |
+        The onboarding responses report only the id and shortname of what they created — not the
+        full `Member` object. Read `GET /member/{cust}` for the rest.
+      required: [ id, shortname ]
+      properties:
+        id:
+          type: integer
+        shortname:
+          type: string
+
+    OnboardingResult:
+      type: object
+      title: OnboardingResult
+      description: The `201` response — the whole order landed.
+      required: [ created, reference, member, user, connection ]
+      properties:
+        created:
+          type: boolean
+          const: true
+        reference:
+          type: [ string, 'null' ]
+          description: Echoed back, or null when none was supplied.
+        member:
+          $ref: '#/components/schemas/OnboardingMemberRef'
+        user:
+          type: [ object, 'null' ]
+          description: Null when no `user` section was supplied.
+          required: [ id, username ]
+          properties:
+            id:
+              type: integer
+            username:
+              type: string
+        connection:
+          type: [ object, 'null' ]
+          description: Null when no `connection` section was supplied.
+          required: [ id ]
+          properties:
+            id:
+              type: integer
+              description: '`virtualinterface.id`.'
+
+    OnboardingReplay:
+      type: object
+      title: OnboardingReplay
+      description: |
+        The `200` response — this reference was seen before and nothing was created. Note that
+        `user` and `connection` are **absent**, not null: only the reference-to-member link is
+        recorded, so a replay cannot report what else the original call produced.
+      required: [ created, reference, member ]
+      properties:
+        created:
+          type: boolean
+          const: false
+        reference:
+          type: string
+        member:
+          $ref: '#/components/schemas/OnboardingMemberRef'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,6 +30,9 @@
     </testsuite>
   </testsuites>
   <php>
+    <!-- the provisioning API is off by default; the suite tests it, so it is on here -->
+    <env name="IXP_API_PROVISIONING_ENABLED" value="true"/>
+    <env name="IXP_API_PROVISIONING_RATE_LIMIT" value="0"/>
     <const name="APPLICATION_VERSION" value="999.9.9"/>
     <const name="APPLICATION_VERDATE" value="9999999999"/>
     <const name="APPLICATION_STARTTIME" value="0"/>

--- a/routes/apiv4-provisioning.php
+++ b/routes/apiv4-provisioning.php
@@ -22,6 +22,8 @@
 
 use Illuminate\Support\Facades\Route;
 
+use IXP\Http\Middleware\Provisioning\ShortCircuitKnownReference;
+
 /*
 |--------------------------------------------------------------------------
 | Provisioning API Routes
@@ -58,3 +60,7 @@ Route::group( [ 'prefix' => 'member' ], function() {
 } );
 
 Route::delete( 'connection/{vi}', 'ConnectionController@destroy' )->name( 'api-v4-provisioning@connection-destroy' );
+
+Route::post( 'onboarding', 'OnboardingController@store' )
+    ->middleware( ShortCircuitKnownReference::class )
+    ->name( 'api-v4-provisioning@onboarding' );

--- a/routes/apiv4-provisioning.php
+++ b/routes/apiv4-provisioning.php
@@ -41,3 +41,9 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get( 'ping', 'PingController@ping' )->name( 'api-v4-provisioning@ping' );
+
+Route::group( [ 'prefix' => 'member' ], function() {
+    Route::post( '',                'MemberController@storeCustomer' )->name( 'api-v4-provisioning@member-store'      );
+    Route::get(  '{cust}',          'MemberController@showCustomer'  )->name( 'api-v4-provisioning@member-show'       );
+    Route::post( '{cust}/user',     'MemberController@storeUser'     )->name( 'api-v4-provisioning@member-user-store' );
+} );

--- a/routes/apiv4-provisioning.php
+++ b/routes/apiv4-provisioning.php
@@ -32,7 +32,7 @@ use IXP\Http\Middleware\Provisioning\ShortCircuitKnownReference;
 | ** EXTERNAL ROUTES **
 |
 | Stateless endpoints for authenticated superusers via API key, intended to be called
-| from an external ordering / billing system. No cookie, no CSRF, no AJAX.
+| from an external ordering / billing system. No CSRF token required, no AJAX.
 |
 | Registered by IXP\Providers\ProvisioningRouteServiceProvider under the prefix
 | `admin/api/v4/provisioning`.

--- a/routes/apiv4-provisioning.php
+++ b/routes/apiv4-provisioning.php
@@ -42,8 +42,19 @@ use Illuminate\Support\Facades\Route;
 
 Route::get( 'ping', 'PingController@ping' )->name( 'api-v4-provisioning@ping' );
 
+Route::get( 'switch',           'PortController@switches'        )->name( 'api-v4-provisioning@switches'        );
+Route::get( 'infrastructure',   'PortController@infrastructures' )->name( 'api-v4-provisioning@infrastructures' );
+Route::get( 'port/free',        'PortController@free'            )->name( 'api-v4-provisioning@port-free'      );
+
+Route::get( 'vlan/{vlan}/address', 'IpController@addresses' )->name( 'api-v4-provisioning@vlan-addresses' );
+
 Route::group( [ 'prefix' => 'member' ], function() {
     Route::post( '',                'MemberController@storeCustomer' )->name( 'api-v4-provisioning@member-store'      );
     Route::get(  '{cust}',          'MemberController@showCustomer'  )->name( 'api-v4-provisioning@member-show'       );
     Route::post( '{cust}/user',     'MemberController@storeUser'     )->name( 'api-v4-provisioning@member-user-store' );
+
+    Route::post( '{cust}/connection', 'ConnectionController@store' )->name( 'api-v4-provisioning@connection-store' );
+    Route::get(  '{cust}/connection', 'ConnectionController@index' )->name( 'api-v4-provisioning@connection-index' );
 } );
+
+Route::delete( 'connection/{vi}', 'ConnectionController@destroy' )->name( 'api-v4-provisioning@connection-destroy' );

--- a/routes/apiv4-provisioning.php
+++ b/routes/apiv4-provisioning.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Provisioning API Routes
+|--------------------------------------------------------------------------
+|
+| ** EXTERNAL ROUTES **
+|
+| Stateless endpoints for authenticated superusers via API key, intended to be called
+| from an external ordering / billing system. No cookie, no CSRF, no AJAX.
+|
+| Registered by IXP\Providers\ProvisioningRouteServiceProvider under the prefix
+| `admin/api/v4/provisioning`.
+|
+| Anything which creates, changes or removes state MUST use POST, PUT or DELETE -
+| never GET.
+|
+*/
+
+Route::get( 'ping', 'PingController@ping' )->name( 'api-v4-provisioning@ping' );

--- a/tests/Api/Provisioning/AccessControlTest.php
+++ b/tests/Api/Provisioning/AccessControlTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Tests\Api\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use IXP\Http\Middleware\Provisioning\RestrictSourceAddress;
+use Tests\TestCase;
+
+/**
+ * The guards around the provisioning endpoints.
+ *
+ * These are the only endpoints in IXP Manager which let an external caller create business
+ * objects, so what keeps them shut matters as much as what they do.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class AccessControlTest extends TestCase
+{
+    private const string URL = '/admin/api/v4/provisioning/ping';
+
+    /**
+     * Reach into the address matcher without going through the HTTP stack: the request IP is
+     * awkward to vary in a feature test, and the logic is worth testing directly.
+     */
+    private function permits( string $source, string $list ): bool
+    {
+        $method = new \ReflectionMethod( RestrictSourceAddress::class, 'permitted' );
+        $method->setAccessible( true );
+
+        return $method->invoke( new RestrictSourceAddress(), $source, $list );
+    }
+
+    // ------------------------------------------------------------- the key requirement
+
+    /**
+     * A logged-in superuser's browser must not reach these endpoints on its session cookie.
+     *
+     * This is the point of RequireApiKey. `apibase` starts a session and ApiAuthenticate only
+     * looks for a key when Auth::check() is false - so without this guard, any page able to
+     * make an administrator's browser issue a request could create a member. There is no CSRF
+     * token in the way either, because the group deliberately omits `web`.
+     */
+    public function test_a_browser_session_is_not_accepted_instead_of_a_key(): void
+    {
+        $this->actingAs( $this->getSuperUser() );
+
+        $response = $this->get( self::URL );
+
+        $response->assertStatus( 401 );
+        $response->assertJsonPath( 'message', fn( $m ) => str_contains( $m, 'API key' ) );
+    }
+
+    public function test_a_key_is_still_accepted(): void
+    {
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->get( self::URL )
+            ->assertStatus( 200 );
+    }
+
+    /**
+     * The guard can be switched off for an installation which wants the old behaviour.
+     */
+    public function test_the_key_requirement_can_be_disabled(): void
+    {
+        config( [ 'ixp_api.provisioning.require_api_key' => false ] );
+
+        $this->actingAs( $this->getSuperUser() );
+
+        // Now the session is enough - ApiAuthenticate accepts an already-authenticated user.
+        $this->get( self::URL )->assertStatus( 200 );
+    }
+
+    // ------------------------------------------------------------- source addresses
+
+    public function test_an_empty_allow_list_permits_everything(): void
+    {
+        $this->assertTrue( $this->permits( '192.0.2.10', '' ) );
+        $this->assertTrue( $this->permits( '2001:db8::1', '   ' ) );
+    }
+
+    public function test_a_single_address_matches_exactly(): void
+    {
+        $this->assertTrue(  $this->permits( '192.0.2.10', '192.0.2.10' ) );
+        $this->assertFalse( $this->permits( '192.0.2.11', '192.0.2.10' ) );
+    }
+
+    public function test_several_entries_are_alternatives(): void
+    {
+        $list = '192.0.2.10, 198.51.100.5 ,203.0.113.7';
+
+        $this->assertTrue(  $this->permits( '198.51.100.5', $list ) );
+        $this->assertFalse( $this->permits( '198.51.100.6', $list ) );
+    }
+
+    public function test_ipv4_cidr_ranges(): void
+    {
+        $this->assertTrue(  $this->permits( '198.51.100.1',   '198.51.100.0/24' ) );
+        $this->assertTrue(  $this->permits( '198.51.100.255', '198.51.100.0/24' ) );
+        $this->assertFalse( $this->permits( '198.51.101.1',   '198.51.100.0/24' ) );
+
+        // a boundary which needs the partial-byte mask to be right
+        $this->assertTrue(  $this->permits( '192.0.2.127', '192.0.2.0/25' ) );
+        $this->assertFalse( $this->permits( '192.0.2.128', '192.0.2.0/25' ) );
+    }
+
+    public function test_ipv6_cidr_ranges(): void
+    {
+        $this->assertTrue(  $this->permits( '2001:db8:0:1::5', '2001:db8::/32' ) );
+        $this->assertFalse( $this->permits( '2001:db9::5',     '2001:db8::/32' ) );
+
+        // notation must not matter
+        $this->assertTrue( $this->permits( '2001:0db8:0000:0001:0000:0000:0000:0005', '2001:db8::/32' ) );
+    }
+
+    /**
+     * An IPv4 address must never match an IPv6 range or the reverse - the packed forms differ
+     * in length, and a naive comparison would produce a false positive.
+     */
+    public function test_address_families_do_not_cross(): void
+    {
+        $this->assertFalse( $this->permits( '192.0.2.1',  '2001:db8::/32' ) );
+        $this->assertFalse( $this->permits( '2001:db8::1', '192.0.2.0/24' ) );
+    }
+
+    public function test_a_malformed_entry_does_not_match(): void
+    {
+        $this->assertFalse( $this->permits( '192.0.2.1', 'not-an-address' ) );
+        $this->assertFalse( $this->permits( '192.0.2.1', '192.0.2.0/99' ) );
+        $this->assertFalse( $this->permits( '192.0.2.1', '192.0.2.0/-1' ) );
+    }
+
+    /**
+     * A malformed entry must not open the door for everything else either.
+     */
+    public function test_a_malformed_entry_alongside_a_valid_one(): void
+    {
+        $this->assertTrue(  $this->permits( '192.0.2.1', 'nonsense, 192.0.2.0/24' ) );
+        $this->assertFalse( $this->permits( '203.0.113.1', 'nonsense, 192.0.2.0/24' ) );
+    }
+
+    // ------------------------------------------------------------- the feature flag
+
+    /**
+     * The routes exist only because the test configuration switches the feature on.
+     *
+     * There is no way to assert the "off" case from inside the suite - routes are registered
+     * once at boot - so this asserts the inverse: that the flag is what put them there, and
+     * that an installation leaving it alone has nothing to secure.
+     */
+    public function test_the_feature_flag_is_what_registers_the_routes(): void
+    {
+        $this->assertTrue(
+            (bool)config( 'ixp_api.provisioning.enabled' ),
+            'die Testumgebung muss die Provisioning-API einschalten, sonst prüft diese Suite nichts'
+        );
+
+        $this->assertTrue( \Route::has( 'api-v4-provisioning@ping' ) );
+    }
+
+    /**
+     * Without the environment variable the feature must stay off.
+     *
+     * Read straight from the config file with the variable removed, because the test
+     * environment sets it - and an installation which never heard of this feature must not
+     * end up with endpoints that create members.
+     */
+    public function test_the_default_is_off(): void
+    {
+        $previous = getenv( 'IXP_API_PROVISIONING_ENABLED' );
+
+        putenv( 'IXP_API_PROVISIONING_ENABLED' );
+        unset( $_ENV[ 'IXP_API_PROVISIONING_ENABLED' ], $_SERVER[ 'IXP_API_PROVISIONING_ENABLED' ] );
+
+        try {
+            $config = require base_path( 'config/ixp_api.php' );
+
+            $this->assertFalse(
+                $config[ 'provisioning' ][ 'enabled' ],
+                'die Provisioning-API muss ohne ausdrückliche Freischaltung aus sein'
+            );
+        } finally {
+            if( $previous !== false ) {
+                putenv( "IXP_API_PROVISIONING_ENABLED={$previous}" );
+                $_ENV[ 'IXP_API_PROVISIONING_ENABLED' ] = $previous;
+            }
+        }
+    }
+}

--- a/tests/Api/Provisioning/ConnectionTest.php
+++ b/tests/Api/Provisioning/ConnectionTest.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace Tests\Api\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Support\Facades\DB;
+
+use IXP\Models\Customer;
+use IXP\Models\IPv4Address;
+use IXP\Models\PhysicalInterface;
+use IXP\Models\SwitchPort;
+use IXP\Models\VirtualInterface;
+use IXP\Models\Vlan;
+
+use Tests\TestCase;
+
+/**
+ * Test creating and removing a member connection.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class ConnectionTest extends TestCase
+{
+    private const string PREFIX = 'conntest';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->purge();
+    }
+
+    public function tearDown(): void
+    {
+        $this->purge();
+        parent::tearDown();
+    }
+
+    /**
+     * Remove everything this class creates, honouring the foreign keys.
+     */
+    private function purge(): void
+    {
+        $custIds = DB::table( 'cust' )->where( 'shortname', 'like', self::PREFIX . '%' )->pluck( 'id' );
+
+        if( $custIds->isEmpty() ) {
+            return;
+        }
+
+        $viIds = DB::table( 'virtualinterface' )->whereIn( 'custid', $custIds )->pluck( 'id' );
+
+        if( $viIds->isNotEmpty() ) {
+            $vliIds = DB::table( 'vlaninterface' )->whereIn( 'virtualinterfaceid', $viIds )->pluck( 'id' );
+
+            if( $vliIds->isNotEmpty() ) {
+                DB::table( 'l2address' )->whereIn( 'vlan_interface_id', $vliIds )->delete();
+            }
+
+            // release the switch ports before the physical interfaces disappear
+            $spIds = DB::table( 'physicalinterface' )->whereIn( 'virtualinterfaceid', $viIds )
+                ->whereNotNull( 'switchportid' )->pluck( 'switchportid' );
+
+            DB::table( 'vlaninterface' )->whereIn( 'virtualinterfaceid', $viIds )->delete();
+            DB::table( 'physicalinterface' )->whereIn( 'virtualinterfaceid', $viIds )->delete();
+            DB::table( 'macaddress' )->whereIn( 'virtualinterfaceid', $viIds )->delete();
+            DB::table( 'virtualinterface' )->whereIn( 'id', $viIds )->delete();
+
+            if( $spIds->isNotEmpty() ) {
+                DB::table( 'switchport' )->whereIn( 'id', $spIds )->update( [ 'type' => SwitchPort::TYPE_UNSET ] );
+            }
+        }
+
+        $details = DB::table( 'cust' )->whereIn( 'id', $custIds )
+            ->get( [ 'company_registered_detail_id', 'company_billing_details_id' ] );
+
+        DB::table( 'customer_to_users' )->whereIn( 'customer_id', $custIds )->delete();
+        DB::table( 'cust' )->whereIn( 'id', $custIds )->delete();
+
+        if( ( $ids = $details->pluck( 'company_registered_detail_id' )->filter() )->isNotEmpty() ) {
+            DB::table( 'company_registration_detail' )->whereIn( 'id', $ids )->delete();
+        }
+
+        if( ( $ids = $details->pluck( 'company_billing_details_id' )->filter() )->isNotEmpty() ) {
+            DB::table( 'company_billing_detail' )->whereIn( 'id', $ids )->delete();
+        }
+    }
+
+    private function key(): static
+    {
+        return $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER );
+    }
+
+    private function createMember( string $shortname ): Customer
+    {
+        $this->key()->post( '/admin/api/v4/provisioning/member', [
+            'name'              => "Connection Test {$shortname}",
+            'shortname'         => $shortname,
+            'abbreviatedName'   => $shortname,
+            'type'              => Customer::TYPE_FULL,
+            'status'            => Customer::STATUS_NORMAL,
+            'datejoin'          => '2026-01-01',
+            'autsys'            => 65551,
+        ] )->assertStatus( 201 );
+
+        return Customer::where( 'shortname', $shortname )->firstOrFail();
+    }
+
+    /**
+     * A VLAN which has both a free IPv4 and a free IPv6 address, plus a free member port.
+     */
+    private function vlanWithFreeAddresses(): Vlan
+    {
+        $vlanId = IPv4Address::whereDoesntHave( 'vlanInterface' )->value( 'vlanid' );
+        $vlan   = Vlan::find( $vlanId );
+
+        $this->assertNotNull( $vlan, 'the CI dataset has no VLAN with free addresses' );
+
+        return $vlan;
+    }
+
+    private function freeSwitchPort(): SwitchPort
+    {
+        $sp = SwitchPort::whereIn( 'type', [ SwitchPort::TYPE_UNSET, SwitchPort::TYPE_PEERING ] )
+            ->whereDoesntHave( 'physicalInterface' )
+            ->whereHas( 'switcher', fn( $q ) => $q->where( 'active', true ) )
+            ->first();
+
+        $this->assertNotNull( $sp, 'the CI dataset has no free switch port' );
+
+        return $sp;
+    }
+
+    private function payload( Vlan $vlan, SwitchPort $sp, array $overrides = [] ): array
+    {
+        return array_merge( [
+            'vlanid'            => $vlan->id,
+            'switch'            => $sp->switchid,
+            'switchportid'      => $sp->id,
+            'speed'             => 10000,
+            'ipv4enabled'       => true,
+            'ipv4address'       => 'auto',
+            'ipv4hostname'      => 'conntest.example.com',
+            'ipv6enabled'       => false,
+            'rsclient'          => true,
+            'irrdbfilter'       => true,
+        ], $overrides );
+    }
+
+    public function testCreateConnectionWithAutoAddress(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'a' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        $expected = ( new \IXP\Support\Provisioning\IpAllocator() )->nextFree( $vlan );
+
+        $response = $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp )
+        );
+
+        $response->assertStatus( 201 );
+        $response->assertJsonPath( 'connection.custid', $cust->id );
+
+        $vi = VirtualInterface::where( 'custid', $cust->id )->first();
+        $this->assertNotNull( $vi, 'no virtual interface was created' );
+
+        $pi = PhysicalInterface::where( 'virtualinterfaceid', $vi->id )->first();
+        $this->assertNotNull( $pi, 'no physical interface was created' );
+        $this->assertSame( $sp->id, (int)$pi->switchportid );
+        $this->assertSame( PhysicalInterface::STATUS_CONNECTED, (int)$pi->status );
+
+        $vli = $vi->vlanInterfaces()->first();
+        $this->assertNotNull( $vli, 'no vlan interface was created' );
+        $this->assertSame( $vlan->id, (int)$vli->vlanid );
+        $this->assertSame( $expected->address, $vli->ipv4address->address, '"auto" did not take the next free address' );
+
+        // the switch port must now be marked as a peering port:
+        $this->assertSame( SwitchPort::TYPE_PEERING, (int)SwitchPort::find( $sp->id )->type );
+    }
+
+    public function testCreateConnectionWithExplicitAddress(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'b' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        $wanted = IPv4Address::where( 'vlanid', $vlan->id )->whereDoesntHave( 'vlanInterface' )
+            ->orderByRaw( 'INET_ATON(address) DESC' )->first();
+
+        $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp, [ 'ipv4address' => $wanted->address ] )
+        )->assertStatus( 201 );
+
+        $vli = VirtualInterface::where( 'custid', $cust->id )->first()->vlanInterfaces()->first();
+
+        $this->assertSame( $wanted->address, $vli->ipv4address->address );
+    }
+
+    /**
+     * An address outside the VLAN's pool must be refused rather than silently created - the
+     * inherited setIp() would create it.
+     */
+    public function testAddressOutsidePoolIsRejected(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'c' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp, [ 'ipv4address' => '203.0.113.251' ] )
+        )->assertStatus( 422 );
+
+        $this->assertNull( VirtualInterface::where( 'custid', $cust->id )->first(), 'a rollback did not happen' );
+        $this->assertSame( 0, IPv4Address::where( 'address', '203.0.113.251' )->count(), 'a stray address was created' );
+    }
+
+    /**
+     * A switch port already carrying a connection must not be handed out twice.
+     */
+    public function testTakenSwitchPortIsRejected(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'd' );
+        $vlan = $this->vlanWithFreeAddresses();
+
+        $taken = PhysicalInterface::whereNotNull( 'switchportid' )->first();
+        $this->assertNotNull( $taken );
+
+        $sp = SwitchPort::find( $taken->switchportid );
+
+        $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp )
+        )->assertStatus( 422 );
+
+        $this->assertNull( VirtualInterface::where( 'custid', $cust->id )->first() );
+    }
+
+    /**
+     * The switch id and the switch port must agree, or a caller could attach a port to a
+     * switch it does not belong to.
+     */
+    public function testMismatchedSwitchAndPortIsRejected(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'e' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        $otherSwitch = DB::table( 'switch' )->where( 'id', '!=', $sp->switchid )->value( 'id' );
+
+        if( !$otherSwitch ) {
+            $this->markTestSkipped( 'the CI dataset has only one switch' );
+        }
+
+        $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp, [ 'switch' => $otherSwitch ] )
+        )->assertStatus( 422 );
+    }
+
+    public function testMalformedAddressIsRejectedByValidation(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'f' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp, [ 'ipv4address' => 'nonsense' ] )
+        )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'ipv4address' ] );
+    }
+
+    public function testListAndDeleteConnection(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'g' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp )
+        )->assertStatus( 201 );
+
+        $this->key()->get( "/admin/api/v4/provisioning/member/{$cust->id}/connection" )
+            ->assertStatus( 200 )
+            ->assertJsonCount( 1, 'connections' );
+
+        $vi = VirtualInterface::where( 'custid', $cust->id )->first();
+
+        $this->key()->delete( "/admin/api/v4/provisioning/connection/{$vi->id}" )
+            ->assertStatus( 200 )
+            ->assertJsonPath( 'deleted', true );
+
+        $this->assertNull( VirtualInterface::find( $vi->id ) );
+        $this->assertSame( 0, PhysicalInterface::where( 'virtualinterfaceid', $vi->id )->count() );
+
+        // the address must return to the pool:
+        $this->assertSame(
+            0,
+            DB::table( 'vlaninterface' )->where( 'virtualinterfaceid', $vi->id )->count()
+        );
+    }
+
+    /**
+     * A non-superuser key must be refused.
+     *
+     * Note this test makes no superuser call first, deliberately: ApiAuthenticate skips the
+     * key check entirely when Auth::check() is already true, and that state survives between
+     * requests within one test. Creating a member here first would leave the superuser
+     * authenticated and the assertion would pass for the wrong reason.
+     */
+    public function testConnectionEndpointsRequireSuperuser(): void
+    {
+        $cust = Customer::firstOrFail();
+
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_CUSTADMIN )
+            ->post( "/admin/api/v4/provisioning/member/{$cust->id}/connection", [] )
+            ->assertStatus( 403 );
+    }
+}

--- a/tests/Api/Provisioning/ConnectionTest.php
+++ b/tests/Api/Provisioning/ConnectionTest.php
@@ -296,6 +296,123 @@ class ConnectionTest extends TestCase
             ->assertJsonValidationErrors( [ 'ipv4address' ] );
     }
 
+    /**
+     * An enabled address family with no address must be refused.
+     *
+     * Regression test. Such a row (ipv4enabled=1, ipv4addressid=NULL) survives into the route
+     * server neighbour list and renders as `neighbor  as 65551;` - a parse error which
+     * invalidates the generated configuration for the whole VLAN, not merely that peer.
+     */
+    public function testEnabledFamilyWithoutAddressIsRejected(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'i' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        $payload = $this->payload( $vlan, $sp );
+        unset( $payload[ 'ipv4address' ] );
+
+        $this->key()->post( "/admin/api/v4/provisioning/member/{$cust->id}/connection", $payload )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'ipv4address' ] );
+
+        $this->assertNull( VirtualInterface::where( 'custid', $cust->id )->first() );
+    }
+
+    /**
+     * An IPv6-only connection must work: a member need not take both families.
+     */
+    public function testIpv6OnlyConnection(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'j' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        if( !\IXP\Models\IPv6Address::where( 'vlanid', $vlan->id )->whereDoesntHave( 'vlanInterface' )->exists() ) {
+            $this->markTestSkipped( 'the CI dataset has no free IPv6 address in this VLAN' );
+        }
+
+        $this->key()->post( "/admin/api/v4/provisioning/member/{$cust->id}/connection", [
+            'vlanid'        => $vlan->id,
+            'switch'        => $sp->switchid,
+            'switchportid'  => $sp->id,
+            'speed'         => 10000,
+            'ipv4enabled'   => false,
+            'ipv6enabled'   => true,
+            'ipv6address'   => 'auto',
+            'ipv6hostname'  => 'conntest6.example.com',
+            'rsclient'      => true,
+        ] )->assertStatus( 201 );
+
+        $vli = VirtualInterface::where( 'custid', $cust->id )->first()->vlanInterfaces()->first();
+
+        $this->assertNotNull( $vli->ipv6address, 'no IPv6 address was allocated' );
+        $this->assertNull( $vli->ipv4address, 'an IPv4 address was allocated although the family was disabled' );
+    }
+
+    /**
+     * Dual stack: both families allocated in one request.
+     */
+    public function testDualStackConnection(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'k' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        if( !\IXP\Models\IPv6Address::where( 'vlanid', $vlan->id )->whereDoesntHave( 'vlanInterface' )->exists() ) {
+            $this->markTestSkipped( 'the CI dataset has no free IPv6 address in this VLAN' );
+        }
+
+        $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp, [
+                'ipv6enabled'  => true,
+                'ipv6address'  => 'auto',
+                'ipv6hostname' => 'conntest-ds.example.com',
+            ] )
+        )->assertStatus( 201 );
+
+        $vli = VirtualInterface::where( 'custid', $cust->id )->first()->vlanInterfaces()->first();
+
+        $this->assertNotNull( $vli->ipv4address );
+        $this->assertNotNull( $vli->ipv6address );
+        $this->assertSame( $vlan->id, (int)$vli->ipv4address->vlanid );
+        $this->assertSame( $vlan->id, (int)$vli->ipv6address->vlanid );
+    }
+
+    /**
+     * rate_limit, autoneg and the LAG fields must actually reach the database - they are in
+     * the delta precisely because the v7.3.1 wizard request omits them.
+     */
+    public function testRateLimitAndLagFieldsArePersisted(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'l' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp, [
+                'rate_limit'  => 1000,
+                'autoneg'     => false,
+                'lag_framing' => true,
+                'fastlacp'    => true,
+                'mtu'         => 9000,
+            ] )
+        )->assertStatus( 201 );
+
+        $vi = VirtualInterface::where( 'custid', $cust->id )->first();
+        $pi = PhysicalInterface::where( 'virtualinterfaceid', $vi->id )->first();
+
+        $this->assertSame( 1000, (int)$pi->rate_limit );
+        $this->assertSame( 0, (int)$pi->autoneg );
+        $this->assertTrue( (bool)$vi->lag_framing );
+        $this->assertSame( 9000, (int)$vi->mtu );
+
+        // setBundleDetails() must have assigned a channel group for a LAG port:
+        $this->assertNotNull( $vi->channelgroup, 'no channel group was assigned to a LAG interface' );
+    }
+
     public function testListAndDeleteConnection(): void
     {
         $cust = $this->createMember( self::PREFIX . 'g' );
@@ -311,7 +428,10 @@ class ConnectionTest extends TestCase
             ->assertStatus( 200 )
             ->assertJsonCount( 1, 'connections' );
 
-        $vi = VirtualInterface::where( 'custid', $cust->id )->first();
+        $vi    = VirtualInterface::where( 'custid', $cust->id )->first();
+        $ipId  = $vi->vlanInterfaces()->first()->ipv4addressid;
+
+        $this->assertNotNull( $ipId, 'the connection was created without an address' );
 
         $this->key()->delete( "/admin/api/v4/provisioning/connection/{$vi->id}" )
             ->assertStatus( 200 )
@@ -319,12 +439,37 @@ class ConnectionTest extends TestCase
 
         $this->assertNull( VirtualInterface::find( $vi->id ) );
         $this->assertSame( 0, PhysicalInterface::where( 'virtualinterfaceid', $vi->id )->count() );
+        $this->assertSame( 0, DB::table( 'vlaninterface' )->where( 'virtualinterfaceid', $vi->id )->count() );
 
-        // the address must return to the pool:
-        $this->assertSame(
-            0,
-            DB::table( 'vlaninterface' )->where( 'virtualinterfaceid', $vi->id )->count()
-        );
+        // The address itself must survive and become free again - it belongs to the VLAN's
+        // pool, not to the member, so deleting it would shrink the pool with every offboarding:
+        $ip = IPv4Address::find( $ipId );
+
+        $this->assertNotNull( $ip, 'the address record was deleted along with the connection' );
+        $this->assertNull( $ip->fresh()->vlanInterface, 'the address did not return to the pool' );
+    }
+
+    /**
+     * Deleting twice must not blow up: an ordering system retrying an offboarding is the
+     * normal case, and the inherited deletePi() is not itself idempotent.
+     */
+    public function testDeletingAConnectionTwice(): void
+    {
+        $cust = $this->createMember( self::PREFIX . 'm' );
+        $vlan = $this->vlanWithFreeAddresses();
+        $sp   = $this->freeSwitchPort();
+
+        $this->key()->post(
+            "/admin/api/v4/provisioning/member/{$cust->id}/connection",
+            $this->payload( $vlan, $sp )
+        )->assertStatus( 201 );
+
+        $vi = VirtualInterface::where( 'custid', $cust->id )->first();
+
+        $this->key()->delete( "/admin/api/v4/provisioning/connection/{$vi->id}" )->assertStatus( 200 );
+
+        // the second attempt addresses something which no longer exists:
+        $this->key()->delete( "/admin/api/v4/provisioning/connection/{$vi->id}" )->assertStatus( 404 );
     }
 
     /**

--- a/tests/Api/Provisioning/IpAddressListingTest.php
+++ b/tests/Api/Provisioning/IpAddressListingTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Api\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use IXP\Models\IPv4Address;
+use IXP\Models\Vlan;
+
+use Tests\TestCase;
+
+/**
+ * Test the address listing endpoint.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class IpAddressListingTest extends TestCase
+{
+    private function key(): static
+    {
+        return $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER );
+    }
+
+    private function vlan(): Vlan
+    {
+        $vlan = Vlan::find( IPv4Address::query()->value( 'vlanid' ) );
+
+        $this->assertNotNull( $vlan, 'the CI dataset has no VLAN with an address pool' );
+
+        return $vlan;
+    }
+
+    public function testListingReturnsBothFamiliesByDefault(): void
+    {
+        $response = $this->key()->get( "/admin/api/v4/provisioning/vlan/{$this->vlan()->id}/address" );
+
+        $response->assertStatus( 200 );
+        $response->assertJsonStructure( [
+            'vlan' => [ 'id', 'name', 'number' ],
+            'ipv4' => [ 'addresses', 'total', 'truncated' ],
+            'ipv6' => [ 'addresses', 'total', 'truncated' ],
+        ] );
+    }
+
+    public function testProtocolFilterReturnsOnlyThatFamily(): void
+    {
+        $vlan = $this->vlan();
+
+        $this->key()->get( "/admin/api/v4/provisioning/vlan/{$vlan->id}/address?protocol=4" )
+            ->assertStatus( 200 )
+            ->assertJsonStructure( [ 'ipv4' ] )
+            ->assertJsonMissingPath( 'ipv6' );
+
+        $this->key()->get( "/admin/api/v4/provisioning/vlan/{$vlan->id}/address?protocol=6" )
+            ->assertStatus( 200 )
+            ->assertJsonStructure( [ 'ipv6' ] )
+            ->assertJsonMissingPath( 'ipv4' );
+    }
+
+    /**
+     * free=1 must exclude assigned addresses.
+     */
+    public function testFreeFilterExcludesAssignedAddresses(): void
+    {
+        $used = IPv4Address::whereHas( 'vlanInterface' )->first();
+
+        if( !$used ) {
+            $this->markTestSkipped( 'the CI dataset has no assigned IPv4 address' );
+        }
+
+        $response = $this->key()->get(
+            "/admin/api/v4/provisioning/vlan/{$used->vlanid}/address?protocol=4&free=1&limit=2000"
+        );
+
+        $response->assertStatus( 200 );
+
+        $addresses = array_column( $response->json( 'ipv4.addresses' ), 'address' );
+
+        $this->assertNotContains( $used->address, $addresses, 'an assigned address was listed as free' );
+
+        foreach( $response->json( 'ipv4.addresses' ) as $entry ) {
+            $this->assertTrue( $entry[ 'free' ], "address {$entry['address']} is listed but not free" );
+        }
+    }
+
+    /**
+     * Without the filter, an assigned address appears and is marked as not free.
+     */
+    public function testAssignedAddressIsMarkedNotFree(): void
+    {
+        $used = IPv4Address::whereHas( 'vlanInterface' )->first();
+
+        if( !$used ) {
+            $this->markTestSkipped( 'the CI dataset has no assigned IPv4 address' );
+        }
+
+        $response = $this->key()->get(
+            "/admin/api/v4/provisioning/vlan/{$used->vlanid}/address?protocol=4&limit=2000"
+        );
+
+        $entries = collect( $response->json( 'ipv4.addresses' ) )->firstWhere( 'address', $used->address );
+
+        $this->assertNotNull( $entries, 'the assigned address is missing from the unfiltered listing' );
+        $this->assertFalse( $entries[ 'free' ] );
+    }
+
+    public function testLimitTruncates(): void
+    {
+        $response = $this->key()->get( "/admin/api/v4/provisioning/vlan/{$this->vlan()->id}/address?protocol=4&limit=1" );
+
+        $response->assertStatus( 200 );
+
+        $this->assertCount( 1, $response->json( 'ipv4.addresses' ) );
+        $this->assertTrue( $response->json( 'ipv4.truncated' ) );
+        $this->assertGreaterThan( 1, $response->json( 'ipv4.total' ) );
+    }
+
+    public function testUnknownVlanIs404(): void
+    {
+        $this->key()->get( '/admin/api/v4/provisioning/vlan/99999999/address' )->assertStatus( 404 );
+    }
+
+    public function testInvalidProtocolIsRejected(): void
+    {
+        $this->key()->get( "/admin/api/v4/provisioning/vlan/{$this->vlan()->id}/address?protocol=5" )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'protocol' ] );
+    }
+
+    public function testListingRequiresSuperuser(): void
+    {
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_CUSTADMIN )
+            ->get( '/admin/api/v4/provisioning/vlan/1/address' )
+            ->assertStatus( 403 );
+    }
+}

--- a/tests/Api/Provisioning/IpAllocatorTest.php
+++ b/tests/Api/Provisioning/IpAllocatorTest.php
@@ -83,16 +83,44 @@ class IpAllocatorTest extends TestCase
     {
         $vlan = $this->vlanWithAddresses();
 
-        DB::transaction( function() use ( $vlan ) {
-            $ip = $this->allocator()->nextFree( $vlan );
+        // Comparing against the single lowest address proves little: in most pools the lowest
+        // is the same either way. The difference between numeric and lexical ordering only
+        // shows up across a digit boundary - lexically ".10" sorts before ".9" - so compare a
+        // whole run of addresses against a numerically sorted expectation.
+        $expected = IPv4Address::where( 'vlanid', $vlan->id )
+            ->whereDoesntHave( 'vlanInterface' )
+            ->get()
+            ->sort( fn( IPv4Address $a, IPv4Address $b ) =>
+                ( ip2long( $a->address ) <=> ip2long( $b->address ) ) )
+            ->pluck( 'address' )
+            ->take( 15 )
+            ->values()
+            ->all();
 
-            $lowest = IPv4Address::where( 'vlanid', $vlan->id )
-                ->whereDoesntHave( 'vlanInterface' )
-                ->get()
-                ->sortBy( fn( IPv4Address $a ) => sprintf( '%u', ip2long( $a->address ) ) )
-                ->first();
+        $lexical = IPv4Address::where( 'vlanid', $vlan->id )
+            ->whereDoesntHave( 'vlanInterface' )
+            ->orderBy( 'address' )
+            ->limit( 15 )
+            ->pluck( 'address' )
+            ->all();
 
-            $this->assertSame( $lowest->address, $ip->address );
+        $this->assertNotSame(
+            $lexical,
+            $expected,
+            'this pool cannot distinguish numeric from lexical ordering - the test proves nothing'
+        );
+
+        $actual = IPv4Address::where( 'vlanid', $vlan->id )
+            ->whereDoesntHave( 'vlanInterface' )
+            ->orderByRaw( 'INET_ATON(address) ASC' )
+            ->limit( 15 )
+            ->pluck( 'address' )
+            ->all();
+
+        $this->assertSame( $expected, $actual, 'addresses are not ordered numerically' );
+
+        DB::transaction( function() use ( $vlan, $expected ) {
+            $this->assertSame( $expected[ 0 ], $this->allocator()->nextFree( $vlan )->address );
         } );
     }
 

--- a/tests/Api/Provisioning/IpAllocatorTest.php
+++ b/tests/Api/Provisioning/IpAllocatorTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Tests\Api\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Support\Facades\DB;
+
+use IXP\Models\IPv4Address;
+use IXP\Models\IPv6Address;
+use IXP\Models\Vlan;
+use IXP\Support\Provisioning\IpAllocationException;
+use IXP\Support\Provisioning\IpAllocator;
+
+use Tests\TestCase;
+
+/**
+ * Test address allocation.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class IpAllocatorTest extends TestCase
+{
+    private function allocator(): IpAllocator
+    {
+        return new IpAllocator();
+    }
+
+    private function vlanWithAddresses(): Vlan
+    {
+        $vlan = Vlan::whereHas( 'ipv4Addresses' )->first()
+            ?? Vlan::has( 'ipv4Addresses' )->first();
+
+        if( !$vlan ) {
+            $id   = IPv4Address::query()->value( 'vlanid' );
+            $vlan = Vlan::find( $id );
+        }
+
+        $this->assertNotNull( $vlan, 'the CI dataset has no VLAN with an address pool' );
+
+        return $vlan;
+    }
+
+    public function testNextFreeReturnsAnUnassignedAddress(): void
+    {
+        $vlan = $this->vlanWithAddresses();
+
+        DB::transaction( function() use ( $vlan ) {
+            $ip = $this->allocator()->nextFree( $vlan );
+
+            $this->assertNotNull( $ip );
+            $this->assertSame( $vlan->id, (int)$ip->vlanid );
+            $this->assertNull( $ip->vlanInterface, 'an address already in use was handed out as free' );
+        } );
+    }
+
+    /**
+     * Ordering must be numeric, not lexical: string ordering puts .10 before .9.
+     */
+    public function testNextFreeOrdersNumerically(): void
+    {
+        $vlan = $this->vlanWithAddresses();
+
+        DB::transaction( function() use ( $vlan ) {
+            $ip = $this->allocator()->nextFree( $vlan );
+
+            $lowest = IPv4Address::where( 'vlanid', $vlan->id )
+                ->whereDoesntHave( 'vlanInterface' )
+                ->get()
+                ->sortBy( fn( IPv4Address $a ) => sprintf( '%u', ip2long( $a->address ) ) )
+                ->first();
+
+            $this->assertSame( $lowest->address, $ip->address );
+        } );
+    }
+
+    public function testAutoClaimsTheNextFreeAddress(): void
+    {
+        $vlan = $this->vlanWithAddresses();
+
+        DB::transaction( function() use ( $vlan ) {
+            $auto = $this->allocator()->claim( $vlan, 'auto' );
+            $next = $this->allocator()->nextFree( $vlan );
+
+            $this->assertNotNull( $auto );
+            $this->assertSame( $next->id, $auto->id );
+        } );
+    }
+
+    public function testNullOrEmptyRequestYieldsNoAddress(): void
+    {
+        $vlan = $this->vlanWithAddresses();
+
+        $this->assertNull( $this->allocator()->claim( $vlan, null ) );
+        $this->assertNull( $this->allocator()->claim( $vlan, '' ) );
+        $this->assertNull( $this->allocator()->claim( $vlan, '   ' ) );
+    }
+
+    public function testExplicitFreeAddressIsClaimed(): void
+    {
+        $vlan = $this->vlanWithAddresses();
+
+        DB::transaction( function() use ( $vlan ) {
+            $free = IPv4Address::where( 'vlanid', $vlan->id )->whereDoesntHave( 'vlanInterface' )->first();
+
+            $claimed = $this->allocator()->claim( $vlan, $free->address );
+
+            $this->assertSame( $free->id, $claimed->id );
+        } );
+    }
+
+    public function testAddressAlreadyInUseIsRejected(): void
+    {
+        $used = IPv4Address::whereHas( 'vlanInterface' )->first();
+
+        if( !$used ) {
+            $this->markTestSkipped( 'the CI dataset has no assigned IPv4 address' );
+        }
+
+        $vlan = Vlan::find( $used->vlanid );
+
+        $this->expectException( IpAllocationException::class );
+        $this->expectExceptionMessageMatches( '/already assigned/' );
+
+        $this->allocator()->claim( $vlan, $used->address );
+    }
+
+    public function testAddressOutsideThePoolIsRejected(): void
+    {
+        $vlan = $this->vlanWithAddresses();
+
+        $this->expectException( IpAllocationException::class );
+        $this->expectExceptionMessageMatches( '/not in the address pool/' );
+
+        $this->allocator()->claim( $vlan, '203.0.113.253' );
+    }
+
+    public function testMalformedAddressIsRejected(): void
+    {
+        $vlan = $this->vlanWithAddresses();
+
+        $this->expectException( IpAllocationException::class );
+        $this->expectExceptionMessageMatches( '/not a valid/' );
+
+        $this->allocator()->claim( $vlan, 'not-an-address' );
+    }
+
+    /**
+     * An IPv6 address written in a different but equivalent form must still match the pool
+     * entry: every comparison in the existing code is a raw string comparison.
+     */
+    public function testIpv6IsMatchedRegardlessOfNotation(): void
+    {
+        $free = IPv6Address::whereDoesntHave( 'vlanInterface' )->first();
+
+        if( !$free ) {
+            $this->markTestSkipped( 'the CI dataset has no free IPv6 address' );
+        }
+
+        $vlan = Vlan::find( $free->vlanid );
+
+        // expand the stored form into its fully written, equivalent notation
+        // (2001:db8::1 -> 2001:0db8:0000:0000:0000:0000:0000:0001):
+        $expanded = implode( ':', str_split( bin2hex( inet_pton( $free->address ) ), 4 ) );
+
+        $this->assertNotSame( $free->address, $expanded, 'the stored address is already fully written out' );
+
+        DB::transaction( function() use ( $vlan, $expanded, $free ) {
+            $claimed = $this->allocator()->claim( $vlan, $expanded, true );
+
+            $this->assertSame( $free->id, $claimed->id );
+        } );
+    }
+}

--- a/tests/Api/Provisioning/MemberContractTest.php
+++ b/tests/Api/Provisioning/MemberContractTest.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace Tests\Api\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+use IXP\Events\User\UserCreated as UserCreatedEvent;
+use IXP\Models\Customer;
+use IXP\Models\CustomerToUser;
+use IXP\Models\User;
+
+use Tests\TestCase;
+
+/**
+ * Assert that creating a member or a user through the provisioning API produces the same
+ * database state as doing it through the web UI.
+ *
+ * The API controllers mirror the web controllers rather than calling them, because the web
+ * ones return redirects and push flash messages. Mirroring is only safe if something checks
+ * it stays true - that is this test. It posts the same payload to both entry points and
+ * compares the resulting rows attribute by attribute.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class MemberContractTest extends TestCase
+{
+    /**
+     * Attributes which are expected to differ between two separately created customers.
+     *
+     * @var array
+     */
+    private const array CUSTOMER_IGNORED = [
+        'id', 'shortname', 'name', 'abbreviatedName',
+        'company_registered_detail_id', 'company_billing_details_id',
+        'created_at', 'updated_at',
+    ];
+
+    /**
+     * Prefix used by every row this test creates, so that leftovers can be identified.
+     */
+    private const string PREFIX = 'provtest';
+
+    /**
+     * Remove leftovers from an earlier, aborted run.
+     *
+     * Without this the suite is not repeatable: a test which fails after the insert but
+     * before tearDown leaves a row behind, and the next run then fails on `unique:shortname`
+     * instead of on whatever actually broke - which hides the real fault.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->purgeLeftovers();
+    }
+
+    public function tearDown(): void
+    {
+        $this->purgeLeftovers();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Remove every row this test class can create, in an order the foreign keys allow:
+     * links first, then users and customers, and only then the detail records the customer
+     * row points at.
+     */
+    private function purgeLeftovers(): void
+    {
+        $custs = DB::table( 'cust' )
+            ->where( 'shortname', 'like', self::PREFIX . '%' )
+            ->get( [ 'id', 'company_registered_detail_id', 'company_billing_details_id' ] );
+
+        $userIds = DB::table( 'user' )->where( 'username', 'like', self::PREFIX . '%' )->pluck( 'id' );
+
+        if( $userIds->isNotEmpty() ) {
+            DB::table( 'customer_to_users' )->whereIn( 'user_id', $userIds )->delete();
+            DB::table( 'user' )->whereIn( 'id', $userIds )->delete();
+        }
+
+        if( $custs->isEmpty() ) {
+            return;
+        }
+
+        DB::table( 'customer_to_users' )->whereIn( 'customer_id', $custs->pluck( 'id' ) )->delete();
+        DB::table( 'cust' )->whereIn( 'id', $custs->pluck( 'id' ) )->delete();
+
+        if( ( $ids = $custs->pluck( 'company_registered_detail_id' )->filter() )->isNotEmpty() ) {
+            DB::table( 'company_registration_detail' )->whereIn( 'id', $ids )->delete();
+        }
+
+        if( ( $ids = $custs->pluck( 'company_billing_details_id' )->filter() )->isNotEmpty() ) {
+            DB::table( 'company_billing_detail' )->whereIn( 'id', $ids )->delete();
+        }
+    }
+
+    /**
+     * Base payload for creating a customer. Shortname must be unique per call.
+     */
+    private function customerPayload( string $shortname ): array
+    {
+        return [
+            'name'              => "Provisioning Test {$shortname}",
+            'shortname'         => $shortname,
+            'abbreviatedName'   => $shortname,
+            'type'              => Customer::TYPE_FULL,
+            'status'            => Customer::STATUS_NORMAL,
+            'datejoin'          => '2026-01-01',
+            'autsys'            => 65550,
+            'maxprefixes'       => 100,
+            'maxprefixesv6'     => 100,
+            'peeringemail'      => 'peering@example.com',
+            'nocemail'          => 'noc@example.com',
+        ];
+    }
+
+    private function fetchCustomer( string $shortname ): ?Customer
+    {
+        return Customer::where( 'shortname', $shortname )->first();
+    }
+
+    /**
+     * The web UI and the API must produce equivalent customer rows.
+     */
+    public function testCustomerCreationMatchesWebUi(): void
+    {
+        $this->actingAs( $this->getSuperUser() );
+        $this->post( route( 'customer@store' ), $this->customerPayload( 'provtestweb' ) )
+            ->assertStatus( 302 );
+
+        $viaWeb = $this->fetchCustomer( 'provtestweb' );
+        $this->assertNotNull( $viaWeb, 'the web UI did not create the customer' );
+
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( '/admin/api/v4/provisioning/member', $this->customerPayload( 'provtestapi' ) );
+
+        $response->assertStatus( 201 );
+        $response->assertJsonPath( 'member.shortname', 'provtestapi' );
+        $response->assertJsonPath( 'member.autsys', 65550 );
+
+        $viaApi = $this->fetchCustomer( 'provtestapi' );
+        $this->assertNotNull( $viaApi, 'the API did not create the customer' );
+
+        $this->assertEquals(
+            array_diff_key( $viaWeb->getAttributes(), array_flip( self::CUSTOMER_IGNORED ) ),
+            array_diff_key( $viaApi->getAttributes(), array_flip( self::CUSTOMER_IGNORED ) ),
+            'a member created through the API differs from one created through the web UI'
+        );
+    }
+
+    /**
+     * Both paths must create the two detail records the customer depends on.
+     */
+    public function testCustomerCreationCreatesDetailRecords(): void
+    {
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( '/admin/api/v4/provisioning/member', $this->customerPayload( 'provtestdet' ) );
+
+        $response->assertStatus( 201 );
+
+        $cust = $this->fetchCustomer( 'provtestdet' );
+        $this->assertNotNull( $cust );
+
+        $this->assertNotNull( $cust->company_registered_detail_id );
+        $this->assertNotNull( $cust->company_billing_details_id );
+        $this->assertNotNull( $cust->companyRegisteredDetail );
+        $this->assertNotNull( $cust->companyBillingDetail );
+        $this->assertSame( $cust->name, $cust->companyRegisteredDetail->registeredName );
+
+    }
+
+    /**
+     * An invalid payload must come back as 422 JSON.
+     *
+     * This is what the ForceJsonResponse middleware buys us: without it a ValidationException
+     * on a route outside the `web` group renders as a 302 redirect, which a machine caller
+     * would read as anything but a validation failure.
+     */
+    public function testInvalidPayloadReturnsJsonValidationError(): void
+    {
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( '/admin/api/v4/provisioning/member', [ 'name' => 'missing everything else' ] );
+
+        $response->assertStatus( 422 );
+        $response->assertJsonStructure( [ 'message', 'errors' ] );
+        $response->assertJsonValidationErrors( [ 'shortname', 'type', 'status', 'datejoin', 'abbreviatedName' ] );
+    }
+
+    /**
+     * A duplicate shortname must be rejected, not silently create a second member.
+     */
+    public function testDuplicateShortnameIsRejected(): void
+    {
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( '/admin/api/v4/provisioning/member', $this->customerPayload( 'provtestdup' ) )
+            ->assertStatus( 201 );
+
+        $cust = $this->fetchCustomer( 'provtestdup' );
+
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( '/admin/api/v4/provisioning/member', $this->customerPayload( 'provtestdup' ) )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'shortname' ] );
+
+        $this->assertEquals( 1, Customer::where( 'shortname', 'provtestdup' )->count() );
+    }
+
+    /**
+     * Creating a user must persist the user, the customer link and fire the event which
+     * sends the welcome email - without that event the account is unreachable.
+     */
+    public function testUserCreationPersistsAndSendsWelcome(): void
+    {
+        Event::fake( [ UserCreatedEvent::class ] );
+
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( '/admin/api/v4/provisioning/member', $this->customerPayload( 'provtestusr' ) )
+            ->assertStatus( 201 );
+
+        $cust = $this->fetchCustomer( 'provtestusr' );
+
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( "/admin/api/v4/provisioning/member/{$cust->id}/user", [
+                'name'      => 'Provisioning Test User',
+                'username'  => 'provtestuser',
+                'email'     => 'provtestuser@example.com',
+                'privs'     => User::AUTH_CUSTUSER,
+            ] );
+
+        $response->assertStatus( 201 );
+        $response->assertJsonPath( 'user.username', 'provtestuser' );
+        $response->assertJsonPath( 'user.custid', $cust->id );
+        $response->assertJsonPath( 'user.enabled', true );
+
+        $user = User::where( 'username', 'provtestuser' )->first();
+        $this->assertNotNull( $user );
+
+        $this->assertSame( $cust->id, $user->custid );
+        $this->assertSame( 0, (int)$user->disabled );
+
+        $c2u = CustomerToUser::where( 'user_id', $user->id )->first();
+        $this->assertNotNull( $c2u, 'the customer-to-user link was not created' );
+        $this->assertSame( User::AUTH_CUSTUSER, (int)$c2u->privs );
+
+        Event::assertDispatched( UserCreatedEvent::class );
+    }
+
+    /**
+     * The customer is taken from the route, so a body which disagrees must not win.
+     */
+    public function testUserCreationIgnoresCustidInBody(): void
+    {
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( '/admin/api/v4/provisioning/member', $this->customerPayload( 'provtestrte' ) )
+            ->assertStatus( 201 );
+
+        $cust = $this->fetchCustomer( 'provtestrte' );
+
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( "/admin/api/v4/provisioning/member/{$cust->id}/user", [
+                'name'      => 'Route Wins',
+                'username'  => 'provtestroute',
+                'email'     => 'provtestroute@example.com',
+                'privs'     => User::AUTH_CUSTUSER,
+                'custid'    => 99999,
+            ] )
+            ->assertStatus( 201 );
+
+        $user = User::where( 'username', 'provtestroute' )->first();
+        $this->assertNotNull( $user );
+
+        if( $c2u = CustomerToUser::where( 'user_id', $user->id )->first() ) {
+        }
+
+        $this->assertSame( $cust->id, $user->custid, 'the body overrode the customer from the route' );
+    }
+
+    /**
+     * Reading a member back must work and must not leak unrelated columns.
+     */
+    public function testShowMember(): void
+    {
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( '/admin/api/v4/provisioning/member', $this->customerPayload( 'provtestshw' ) )
+            ->assertStatus( 201 );
+
+        $cust = $this->fetchCustomer( 'provtestshw' );
+
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->get( "/admin/api/v4/provisioning/member/{$cust->id}" );
+
+        $response->assertStatus( 200 );
+        $response->assertJsonPath( 'member.id', $cust->id );
+        $response->assertJsonPath( 'member.shortname', 'provtestshw' );
+        $response->assertJsonMissingPath( 'member.creator' );
+    }
+
+    /**
+     * An unknown member must be a clean 404, not a crash.
+     */
+    public function testShowUnknownMemberIs404(): void
+    {
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->get( '/admin/api/v4/provisioning/member/99999999' )
+            ->assertStatus( 404 );
+    }
+}

--- a/tests/Api/Provisioning/MemberContractTest.php
+++ b/tests/Api/Provisioning/MemberContractTest.php
@@ -93,6 +93,10 @@ class MemberContractTest extends TestCase
      */
     private function purgeLeftovers(): void
     {
+        // password reset rows are created by the welcome email and are keyed by address,
+        // not by any id this test holds - without this they accumulate on every run:
+        DB::table( 'password_resets' )->where( 'email', 'like', self::PREFIX . '%' )->delete();
+
         $custs = DB::table( 'cust' )
             ->where( 'shortname', 'like', self::PREFIX . '%' )
             ->get( [ 'id', 'company_registered_detail_id', 'company_billing_details_id' ] );
@@ -295,10 +299,40 @@ class MemberContractTest extends TestCase
         $user = User::where( 'username', 'provtestroute' )->first();
         $this->assertNotNull( $user );
 
-        if( $c2u = CustomerToUser::where( 'user_id', $user->id )->first() ) {
-        }
-
         $this->assertSame( $cust->id, $user->custid, 'the body overrode the customer from the route' );
+
+        $c2u = CustomerToUser::where( 'user_id', $user->id )->first();
+
+        $this->assertNotNull( $c2u, 'the customer-to-user link was not created' );
+        $this->assertSame( $cust->id, (int)$c2u->customer_id, 'the body overrode the customer on the c2u link' );
+    }
+
+    /**
+     * An `id` in the body must not be able to steer the username uniqueness rule.
+     *
+     * The inherited rule exempts `$this->id` from the unique check so an edit can keep its own
+     * username. This endpoint only creates, so an id here could only exempt somebody else's -
+     * turning a 422 into a database-level failure.
+     */
+    public function testUserCreationIgnoresIdInBody(): void
+    {
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( '/admin/api/v4/provisioning/member', $this->customerPayload( 'provtestuid' ) )
+            ->assertStatus( 201 );
+
+        $cust     = $this->fetchCustomer( 'provtestuid' );
+        $existing = User::firstOrFail();
+
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->post( "/admin/api/v4/provisioning/member/{$cust->id}/user", [
+                'name'      => 'Duplicate Attempt',
+                'username'  => $existing->username,
+                'email'     => 'provtestuid@example.com',
+                'privs'     => User::AUTH_CUSTUSER,
+                'id'        => $existing->id,
+            ] )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'username' ] );
     }
 
     /**

--- a/tests/Api/Provisioning/OnboardingTest.php
+++ b/tests/Api/Provisioning/OnboardingTest.php
@@ -65,6 +65,10 @@ class OnboardingTest extends TestCase
 
     private function purge(): void
     {
+        // password reset rows are created by the welcome email and are keyed by address,
+        // not by any id this test holds - without this they accumulate on every run:
+        DB::table( 'password_resets' )->where( 'email', 'like', self::PREFIX . '%' )->delete();
+
         DB::table( 'provisioning_references' )->where( 'reference', 'like', self::PREFIX . '%' )->delete();
 
         $custIds = DB::table( 'cust' )->where( 'shortname', 'like', self::PREFIX . '%' )->pluck( 'id' );
@@ -303,5 +307,137 @@ class OnboardingTest extends TestCase
         $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_CUSTADMIN )
             ->post( '/admin/api/v4/provisioning/onboarding', [] )
             ->assertStatus( 403 );
+    }
+
+    /**
+     * Onboarding must not grant IXP Manager superuser rights that the dedicated endpoint
+     * refuses.
+     *
+     * Regression test. Collecting rules() from the sub-requests does not carry their
+     * withValidator() hooks across, and User\Store's hook is the only thing preventing
+     * AUTH_SUPERUSER on a non-internal customer. Without it an order could create a full
+     * administrator on an arbitrary member company - and the welcome email would deliver the
+     * password-reset link to whoever ordered it.
+     */
+    public function testOnboardingRefusesSuperuserPrivilegesOnANormalMember(): void
+    {
+        $order = $this->order( 'g', [ 'user' => [ 'privs' => User::AUTH_SUPERUSER ] ] );
+        unset( $order[ 'connection' ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'user.privs' ] );
+
+        $this->assertNull( Customer::where( 'shortname', self::PREFIX . 'g' )->first() );
+        $this->assertNull( User::where( 'username', self::PREFIX . 'guser' )->first() );
+    }
+
+    /**
+     * The same guard as the dedicated endpoint applies: superuser is acceptable on an internal
+     * customer. Asserting this keeps the guard from being over-tightened into "never".
+     */
+    public function testOnboardingAllowsSuperuserOnAnInternalMember(): void
+    {
+        $order = $this->order( 'h', [
+            'member' => [ 'type' => Customer::TYPE_INTERNAL ],
+            'user'   => [ 'privs' => User::AUTH_SUPERUSER ],
+        ] );
+        unset( $order[ 'connection' ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )->assertStatus( 201 );
+
+        $this->assertNotNull( User::where( 'username', self::PREFIX . 'huser' )->first() );
+    }
+
+    /**
+     * A resold member with no reseller named must be refused, as at the dedicated endpoint -
+     * rather than being silently created without the reseller link.
+     */
+    public function testOnboardingRefusesResoldMemberWithoutReseller(): void
+    {
+        $order = $this->order( 'i', [ 'member' => [ 'isResold' => true ] ] );
+        unset( $order[ 'user' ], $order[ 'connection' ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'member.reseller' ] );
+
+        $this->assertNull( Customer::where( 'shortname', self::PREFIX . 'i' )->first() );
+    }
+
+    /**
+     * Unvalidated fields must not reach the models.
+     *
+     * Regression test: the onboarding path used the raw request array, so any fillable column
+     * without a rule - lastupdatedby, channelgroup, notes - was writable by the caller.
+     */
+    public function testOnboardingIgnoresUnvalidatedFields(): void
+    {
+        $order = $this->order( 'j', [
+            'member'     => [ 'lastupdatedby' => 99999 ],
+            'connection' => [ 'channelgroup' => 777, 'notes' => 'injected' ],
+        ] );
+        unset( $order[ 'user' ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )->assertStatus( 201 );
+
+        $cust = Customer::where( 'shortname', self::PREFIX . 'j' )->first();
+        $this->assertNotNull( $cust );
+        $this->assertNotSame( 99999, (int)$cust->lastupdatedby, 'an unvalidated field reached the customer' );
+
+        $vi = VirtualInterface::where( 'custid', $cust->id )->first();
+        $this->assertNotSame( 777, (int)$vi->channelgroup, 'an unvalidated field reached the virtual interface' );
+    }
+
+    /**
+     * A connection with an enabled address family but no address must be refused.
+     *
+     * Regression test for the same defect as in ConnectionTest: such a row breaks the whole
+     * route server configuration for the VLAN.
+     */
+    public function testOnboardingRefusesEnabledFamilyWithoutAddress(): void
+    {
+        $order = $this->order( 'k' );
+        unset( $order[ 'user' ], $order[ 'connection' ][ 'ipv4address' ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'connection.ipv4address' ] );
+
+        $this->assertNull( Customer::where( 'shortname', self::PREFIX . 'k' )->first() );
+    }
+
+    /**
+     * A switch port belonging to a different switch must be refused here too - the dedicated
+     * endpoint checks it, so onboarding must not be the softer way in.
+     */
+    public function testOnboardingRejectsMismatchedSwitchAndPort(): void
+    {
+        $sp    = $this->freePort();
+        $other = DB::table( 'switch' )->where( 'id', '!=', $sp->switchid )->value( 'id' );
+
+        if( !$other ) {
+            $this->markTestSkipped( 'the CI dataset has only one switch' );
+        }
+
+        $order = $this->order( 'l', [ 'connection' => [ 'switch' => $other ] ] );
+        unset( $order[ 'user' ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )->assertStatus( 422 );
+
+        $this->assertNull( Customer::where( 'shortname', self::PREFIX . 'l' )->first() );
+    }
+
+    /**
+     * An array where a string belongs must be a 422, not a 500 from a string cast.
+     */
+    public function testOnboardingArrayAddressIsRejectedCleanly(): void
+    {
+        $order = $this->order( 'm', [ 'connection' => [ 'ipv4address' => [ 'not', 'a', 'string' ] ] ] );
+        unset( $order[ 'user' ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'connection.ipv4address' ] );
     }
 }

--- a/tests/Api/Provisioning/OnboardingTest.php
+++ b/tests/Api/Provisioning/OnboardingTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Tests\Api\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+use IXP\Events\User\UserCreated as UserCreatedEvent;
+use IXP\Models\Customer;
+use IXP\Models\IPv4Address;
+use IXP\Models\SwitchPort;
+use IXP\Models\User;
+use IXP\Models\VirtualInterface;
+use IXP\Models\Vlan;
+
+use Tests\TestCase;
+
+/**
+ * Test the composite onboarding endpoint.
+ *
+ * The assertions that matter here are about atomicity and repeat calls: a partial failure must
+ * leave nothing behind, and a retry must not create a second member.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class OnboardingTest extends TestCase
+{
+    private const string PREFIX = 'onbtest';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->purge();
+    }
+
+    public function tearDown(): void
+    {
+        $this->purge();
+        parent::tearDown();
+    }
+
+    private function purge(): void
+    {
+        DB::table( 'provisioning_references' )->where( 'reference', 'like', self::PREFIX . '%' )->delete();
+
+        $custIds = DB::table( 'cust' )->where( 'shortname', 'like', self::PREFIX . '%' )->pluck( 'id' );
+        $userIds = DB::table( 'user' )->where( 'username', 'like', self::PREFIX . '%' )->pluck( 'id' );
+
+        if( $userIds->isNotEmpty() ) {
+            DB::table( 'customer_to_users' )->whereIn( 'user_id', $userIds )->delete();
+            DB::table( 'user' )->whereIn( 'id', $userIds )->delete();
+        }
+
+        if( $custIds->isEmpty() ) {
+            return;
+        }
+
+        $viIds = DB::table( 'virtualinterface' )->whereIn( 'custid', $custIds )->pluck( 'id' );
+
+        if( $viIds->isNotEmpty() ) {
+            $vliIds = DB::table( 'vlaninterface' )->whereIn( 'virtualinterfaceid', $viIds )->pluck( 'id' );
+
+            if( $vliIds->isNotEmpty() ) {
+                DB::table( 'l2address' )->whereIn( 'vlan_interface_id', $vliIds )->delete();
+            }
+
+            $spIds = DB::table( 'physicalinterface' )->whereIn( 'virtualinterfaceid', $viIds )
+                ->whereNotNull( 'switchportid' )->pluck( 'switchportid' );
+
+            DB::table( 'vlaninterface' )->whereIn( 'virtualinterfaceid', $viIds )->delete();
+            DB::table( 'physicalinterface' )->whereIn( 'virtualinterfaceid', $viIds )->delete();
+            DB::table( 'macaddress' )->whereIn( 'virtualinterfaceid', $viIds )->delete();
+            DB::table( 'virtualinterface' )->whereIn( 'id', $viIds )->delete();
+
+            if( $spIds->isNotEmpty() ) {
+                DB::table( 'switchport' )->whereIn( 'id', $spIds )->update( [ 'type' => SwitchPort::TYPE_UNSET ] );
+            }
+        }
+
+        $details = DB::table( 'cust' )->whereIn( 'id', $custIds )
+            ->get( [ 'company_registered_detail_id', 'company_billing_details_id' ] );
+
+        DB::table( 'customer_to_users' )->whereIn( 'customer_id', $custIds )->delete();
+        DB::table( 'cust' )->whereIn( 'id', $custIds )->delete();
+
+        if( ( $ids = $details->pluck( 'company_registered_detail_id' )->filter() )->isNotEmpty() ) {
+            DB::table( 'company_registration_detail' )->whereIn( 'id', $ids )->delete();
+        }
+
+        if( ( $ids = $details->pluck( 'company_billing_details_id' )->filter() )->isNotEmpty() ) {
+            DB::table( 'company_billing_detail' )->whereIn( 'id', $ids )->delete();
+        }
+    }
+
+    private function key(): static
+    {
+        return $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER );
+    }
+
+    private function vlan(): Vlan
+    {
+        return Vlan::findOrFail( IPv4Address::whereDoesntHave( 'vlanInterface' )->value( 'vlanid' ) );
+    }
+
+    private function freePort(): SwitchPort
+    {
+        return SwitchPort::whereIn( 'type', [ SwitchPort::TYPE_UNSET, SwitchPort::TYPE_PEERING ] )
+            ->whereDoesntHave( 'physicalInterface' )
+            ->whereHas( 'switcher', fn( $q ) => $q->where( 'active', true ) )
+            ->firstOrFail();
+    }
+
+    private function order( string $suffix, array $overrides = [] ): array
+    {
+        $vlan = $this->vlan();
+        $sp   = $this->freePort();
+
+        return array_replace_recursive( [
+            'reference'  => self::PREFIX . '-' . $suffix,
+            'member'     => [
+                'name'              => "Onboarding Test {$suffix}",
+                'shortname'         => self::PREFIX . $suffix,
+                'abbreviatedName'   => self::PREFIX . $suffix,
+                'type'              => Customer::TYPE_FULL,
+                'status'            => Customer::STATUS_NORMAL,
+                'datejoin'          => '2026-01-01',
+                'autsys'            => 65552,
+            ],
+            'user'       => [
+                'name'      => 'Onboarding Test User',
+                'username'  => self::PREFIX . $suffix . 'user',
+                'email'     => self::PREFIX . $suffix . '@example.com',
+                'privs'     => User::AUTH_CUSTUSER,
+            ],
+            'connection' => [
+                'vlanid'        => $vlan->id,
+                'switch'        => $sp->switchid,
+                'switchportid'  => $sp->id,
+                'speed'         => 10000,
+                'ipv4enabled'   => true,
+                'ipv4address'   => 'auto',
+                'ipv4hostname'  => 'onbtest.example.com',
+                'ipv6enabled'   => false,
+                'rsclient'      => true,
+                'irrdbfilter'   => true,
+            ],
+        ], $overrides );
+    }
+
+    public function testFullOrderCreatesEverything(): void
+    {
+        Event::fake( [ UserCreatedEvent::class ] );
+
+        $response = $this->key()->post( '/admin/api/v4/provisioning/onboarding', $this->order( 'a' ) );
+
+        $response->assertStatus( 201 );
+        $response->assertJsonPath( 'created', true );
+
+        $cust = Customer::where( 'shortname', self::PREFIX . 'a' )->first();
+        $this->assertNotNull( $cust );
+
+        $this->assertNotNull( User::where( 'username', self::PREFIX . 'auser' )->first() );
+        $this->assertNotNull( VirtualInterface::where( 'custid', $cust->id )->first() );
+
+        Event::assertDispatched( UserCreatedEvent::class );
+    }
+
+    /**
+     * Member only: user and connection are optional.
+     */
+    public function testMemberOnlyOrder(): void
+    {
+        $order = $this->order( 'b' );
+        unset( $order[ 'user' ], $order[ 'connection' ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )->assertStatus( 201 );
+
+        $cust = Customer::where( 'shortname', self::PREFIX . 'b' )->first();
+
+        $this->assertNotNull( $cust );
+        $this->assertSame( 0, VirtualInterface::where( 'custid', $cust->id )->count() );
+    }
+
+    /**
+     * The same reference twice must return the first result, not create a second member.
+     */
+    public function testRepeatedReferenceIsIdempotent(): void
+    {
+        $order = $this->order( 'c' );
+
+        $first = $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order );
+        $first->assertStatus( 201 )->assertJsonPath( 'created', true );
+
+        $id = $first->json( 'member.id' );
+
+        $second = $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order );
+        $second->assertStatus( 200 )
+            ->assertJsonPath( 'created', false )
+            ->assertJsonPath( 'member.id', $id );
+
+        $this->assertSame( 1, Customer::where( 'shortname', self::PREFIX . 'c' )->count() );
+    }
+
+    /**
+     * A failure in the connection section must roll back the member and the user with it.
+     *
+     * This is the whole reason the endpoint exists: calling the three endpoints in sequence
+     * would leave the member and user behind when the third call failed.
+     */
+    public function testConnectionFailureRollsBackTheWholeOrder(): void
+    {
+        Event::fake( [ UserCreatedEvent::class ] );
+
+        $order = $this->order( 'd', [ 'connection' => [ 'ipv4address' => '203.0.113.249' ] ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )->assertStatus( 422 );
+
+        $this->assertNull( Customer::where( 'shortname', self::PREFIX . 'd' )->first(), 'the member was not rolled back' );
+        $this->assertNull( User::where( 'username', self::PREFIX . 'duser' )->first(), 'the user was not rolled back' );
+
+        // and no welcome email may have gone out for a user which no longer exists:
+        Event::assertNotDispatched( UserCreatedEvent::class );
+
+        $this->assertSame(
+            0,
+            DB::table( 'provisioning_references' )->where( 'reference', self::PREFIX . '-d' )->count(),
+            'a reference was recorded for an order which failed'
+        );
+    }
+
+    /**
+     * A taken switch port must fail the order rather than half-create it.
+     */
+    public function testTakenSwitchPortRollsBackTheOrder(): void
+    {
+        $taken = DB::table( 'physicalinterface' )->whereNotNull( 'switchportid' )->value( 'switchportid' );
+
+        $order = $this->order( 'e', [ 'connection' => [ 'switchportid' => $taken ] ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )->assertStatus( 422 );
+
+        $this->assertNull( Customer::where( 'shortname', self::PREFIX . 'e' )->first() );
+    }
+
+    public function testInvalidMemberSectionReturnsNestedErrors(): void
+    {
+        $response = $this->key()->post( '/admin/api/v4/provisioning/onboarding', [
+            'member' => [ 'name' => 'incomplete' ],
+        ] );
+
+        $response->assertStatus( 422 );
+        $response->assertJsonValidationErrors( [ 'member.shortname', 'member.type', 'member.status' ] );
+    }
+
+    public function testMissingMemberSectionIsRejected(): void
+    {
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', [] )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'member' ] );
+    }
+
+    /**
+     * An order without a reference still works - idempotency is opt-in.
+     */
+    public function testOrderWithoutReference(): void
+    {
+        $order = $this->order( 'f' );
+        unset( $order[ 'reference' ], $order[ 'connection' ] );
+
+        $this->key()->post( '/admin/api/v4/provisioning/onboarding', $order )
+            ->assertStatus( 201 )
+            ->assertJsonPath( 'reference', null );
+
+        $this->assertNotNull( Customer::where( 'shortname', self::PREFIX . 'f' )->first() );
+    }
+
+    public function testOnboardingRequiresSuperuser(): void
+    {
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_CUSTADMIN )
+            ->post( '/admin/api/v4/provisioning/onboarding', [] )
+            ->assertStatus( 403 );
+    }
+}

--- a/tests/Api/Provisioning/PingTest.php
+++ b/tests/Api/Provisioning/PingTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Api\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use Tests\TestCase;
+
+/**
+ * Test the provisioning API authentication chain.
+ *
+ * This deliberately tests the scaffolding rather than any business logic: if the route
+ * group, the API key middleware and the superuser privilege assertion do not line up, every
+ * later endpoint fails the same way. Proving it once here keeps those failures legible.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class PingTest extends TestCase
+{
+    private const string URL = '/admin/api/v4/provisioning/ping';
+
+    /**
+     * A superuser API key is accepted and the key's owner is resolved.
+     */
+    public function testPingWithSuperuserKey(): void
+    {
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->get( self::URL );
+
+        $response->assertStatus( 200 );
+        $response->assertJson( [ 'pong' => true ] );
+
+        // the API key middleware logs the key's owner in, so the controller sees a user:
+        $this->assertNotEmpty( $response->json( 'user' ) );
+    }
+
+    /**
+     * Without a key the request is rejected outright - and, crucially, not redirected to
+     * the login form, which a machine caller could not follow.
+     */
+    public function testPingWithoutKeyIsUnauthorised(): void
+    {
+        $response = $this->get( self::URL );
+
+        $response->assertStatus( 401 );
+    }
+
+    /**
+     * A valid key belonging to a non-superuser must not reach the provisioning API.
+     */
+    public function testPingWithCustAdminKeyIsForbidden(): void
+    {
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_CUSTADMIN )
+            ->get( self::URL );
+
+        $response->assertStatus( 403 );
+    }
+
+    /**
+     * The same, for an ordinary customer user.
+     */
+    public function testPingWithCustUserKeyIsForbidden(): void
+    {
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_CUSTUSER )
+            ->get( self::URL );
+
+        $response->assertStatus( 403 );
+    }
+}

--- a/tests/Api/Provisioning/PortTest.php
+++ b/tests/Api/Provisioning/PortTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Api\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use IXP\Models\PhysicalInterface;
+use IXP\Models\SwitchPort;
+
+use Tests\TestCase;
+
+/**
+ * Test the read-only port discovery endpoints.
+ *
+ * The important assertions here are the negative ones: a port which is already in use, or
+ * which belongs to the infrastructure rather than to a member, must never be offered to an
+ * ordering system.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class PortTest extends TestCase
+{
+    private function key(): static
+    {
+        return $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER );
+    }
+
+    public function testFreePortsExcludeThoseInUse(): void
+    {
+        $used = PhysicalInterface::whereNotNull( 'switchportid' )->first();
+        $this->assertNotNull( $used, 'the CI dataset has no physical interface to test against' );
+
+        $response = $this->key()->get( '/admin/api/v4/provisioning/port/free?limit=1000' );
+        $response->assertStatus( 200 );
+
+        $offered = array_column( $response->json( 'ports' ), 'switchport' );
+
+        $this->assertNotContains(
+            $used->switchportid,
+            $offered,
+            'a switch port which already has a physical interface was offered as free'
+        );
+    }
+
+    /**
+     * Core, management, monitor, fanout and reseller ports are infrastructure, not member
+     * capacity - offering them would let a caller reassign the fabric.
+     */
+    public function testFreePortsOnlyOfferUnsetOrPeeringTypes(): void
+    {
+        $response = $this->key()->get( '/admin/api/v4/provisioning/port/free?limit=1000' );
+        $response->assertStatus( 200 );
+
+        foreach( $response->json( 'ports' ) as $port ) {
+            $this->assertContains(
+                $port[ 'type' ],
+                [ SwitchPort::TYPE_UNSET, SwitchPort::TYPE_PEERING ],
+                "port {$port['name']} on {$port['switch_name']} has type {$port['type']}, which must not be offered"
+            );
+        }
+    }
+
+    /**
+     * A genuinely free port must actually appear, or the endpoint is uselessly conservative.
+     */
+    public function testAKnownFreePortIsOffered(): void
+    {
+        $free = SwitchPort::whereIn( 'type', [ SwitchPort::TYPE_UNSET, SwitchPort::TYPE_PEERING ] )
+            ->whereDoesntHave( 'physicalInterface' )
+            ->whereHas( 'switcher', fn( $q ) => $q->where( 'active', true ) )
+            ->first();
+
+        $this->assertNotNull( $free, 'the CI dataset has no free switch port to test against' );
+
+        $response = $this->key()->get( '/admin/api/v4/provisioning/port/free?limit=1000' );
+
+        $this->assertContains( $free->id, array_column( $response->json( 'ports' ), 'switchport' ) );
+    }
+
+    public function testFreePortsRespectLimit(): void
+    {
+        $response = $this->key()->get( '/admin/api/v4/provisioning/port/free?limit=2' );
+
+        $response->assertStatus( 200 );
+        $this->assertLessThanOrEqual( 2, count( $response->json( 'ports' ) ) );
+    }
+
+    public function testFreePortsRejectUnknownSwitch(): void
+    {
+        $this->key()->get( '/admin/api/v4/provisioning/port/free?switch=99999999' )
+            ->assertStatus( 422 )
+            ->assertJsonValidationErrors( [ 'switch' ] );
+    }
+
+    public function testSwitchListing(): void
+    {
+        $response = $this->key()->get( '/admin/api/v4/provisioning/switch' );
+
+        $response->assertStatus( 200 );
+        $response->assertJsonStructure( [ 'switches' => [ [ 'id', 'name', 'infrastructure' ] ] ] );
+    }
+
+    public function testInfrastructureListingIncludesVlans(): void
+    {
+        $response = $this->key()->get( '/admin/api/v4/provisioning/infrastructure' );
+
+        $response->assertStatus( 200 );
+        $response->assertJsonStructure( [ 'infrastructures' => [ [ 'id', 'name', 'vlans' ] ] ] );
+    }
+
+    public function testPortEndpointsRequireSuperuser(): void
+    {
+        $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_CUSTADMIN )
+            ->get( '/admin/api/v4/provisioning/port/free' )
+            ->assertStatus( 403 );
+    }
+}

--- a/tests/Api/Provisioning/RulesParityTest.php
+++ b/tests/Api/Provisioning/RulesParityTest.php
@@ -24,7 +24,9 @@ namespace Tests\Api\Provisioning;
 
 use IXP\Http\Requests\Api\V4\Provisioning\StoreCustomer;
 use IXP\Http\Requests\Api\V4\Provisioning\StoreUser;
+use IXP\Http\Requests\Api\V4\Provisioning\StoreConnection;
 use IXP\Http\Requests\Customer\Store as WebStoreCustomer;
+use IXP\Http\Requests\StoreVirtualInterfaceWizard as WebStoreWizard;
 use IXP\Http\Requests\User\Store as WebStoreUser;
 use IXP\Models\Customer;
 
@@ -109,5 +111,59 @@ class RulesParityTest extends TestCase
             array_intersect_key( StoreUser::delta(), $web->rules() ),
             'The user delta shadows a rule which already exists upstream.'
         );
+    }
+
+    /**
+     * Connection rules must match the wizard's, once the additions and the deliberate
+     * overrides are set aside.
+     */
+    public function testConnectionRulesMatchWizard(): void
+    {
+        $web = WebStoreWizard::create( '/', 'POST', [] );
+        $api = StoreConnection::create( '/', 'POST', [] );
+
+        $inherited = array_diff_key(
+            $api->rules(),
+            StoreConnection::delta(),
+            StoreConnection::overrides()
+        );
+
+        $this->assertEquals(
+            array_diff_key( $web->rules(), StoreConnection::overrides() ),
+            $inherited,
+            'Connection validation rules have diverged from the virtual interface wizard.'
+        );
+    }
+
+    /**
+     * The connection delta must add only.
+     */
+    public function testConnectionDeltaAddsOnly(): void
+    {
+        $web = WebStoreWizard::create( '/', 'POST', [] );
+
+        $this->assertEmpty(
+            array_intersect_key( StoreConnection::delta(), $web->rules() ),
+            'The connection delta shadows a rule which already exists upstream - it belongs in overrides().'
+        );
+    }
+
+    /**
+     * Every override must genuinely replace an upstream rule.
+     *
+     * An entry here which upstream no longer has is a rule we think we are overriding but are
+     * not - the most likely way for the two to drift apart without anyone noticing.
+     */
+    public function testConnectionOverridesReplaceExistingRules(): void
+    {
+        $web = WebStoreWizard::create( '/', 'POST', [] );
+
+        foreach( array_keys( StoreConnection::overrides() ) as $field ) {
+            $this->assertArrayHasKey(
+                $field,
+                $web->rules(),
+                "'{$field}' is declared as an override but upstream has no such rule."
+            );
+        }
     }
 }

--- a/tests/Api/Provisioning/RulesParityTest.php
+++ b/tests/Api/Provisioning/RulesParityTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Api\Provisioning;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use IXP\Http\Requests\Api\V4\Provisioning\StoreCustomer;
+use IXP\Http\Requests\Api\V4\Provisioning\StoreUser;
+use IXP\Http\Requests\Customer\Store as WebStoreCustomer;
+use IXP\Http\Requests\User\Store as WebStoreUser;
+use IXP\Models\Customer;
+
+use Tests\TestCase;
+
+/**
+ * Assert that the provisioning API validates exactly as the web UI does, plus a declared
+ * delta and nothing else.
+ *
+ * This is the guard for upstream merges. The API requests inherit their rules rather than
+ * restating them, so a rule changed upstream is picked up automatically - but a rule we have
+ * shadowed would silently drift apart. Subtracting the declared delta and comparing what
+ * remains turns that drift into a failing test at merge time instead of a behavioural
+ * difference discovered later.
+ *
+ * If this test fails after a merge, upstream has changed a rule we override. Decide
+ * deliberately whether to follow, then update the delta.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api\Provisioning
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class RulesParityTest extends TestCase
+{
+    /**
+     * Customer rules must match, for both branches of the type-dependent rule set.
+     */
+    public function testCustomerRulesMatchWebForm(): void
+    {
+        foreach( [ Customer::TYPE_FULL, Customer::TYPE_ASSOCIATE ] as $type ) {
+            $payload = [ 'type' => $type ];
+
+            $web = WebStoreCustomer::create( '/', 'POST', $payload );
+            $api = StoreCustomer::create( '/', 'POST', $payload );
+
+            $this->assertEquals(
+                $web->rules(),
+                array_diff_key( $api->rules(), StoreCustomer::delta() ),
+                "Customer validation rules have diverged from the web form for type {$type}."
+            );
+        }
+    }
+
+    /**
+     * Every key in the customer delta must genuinely be an addition, never a shadowed rule.
+     */
+    public function testCustomerDeltaAddsOnly(): void
+    {
+        $web = WebStoreCustomer::create( '/', 'POST', [ 'type' => Customer::TYPE_FULL ] );
+
+        $this->assertEmpty(
+            array_intersect_key( StoreCustomer::delta(), $web->rules() ),
+            'The customer delta shadows a rule which already exists upstream.'
+        );
+    }
+
+    /**
+     * User rules must match.
+     */
+    public function testUserRulesMatchWebForm(): void
+    {
+        $web = WebStoreUser::create( '/', 'POST', [] );
+        $api = StoreUser::create( '/', 'POST', [] );
+
+        $this->assertEquals(
+            $web->rules(),
+            array_diff_key( $api->rules(), StoreUser::delta() ),
+            'User validation rules have diverged from the web form.'
+        );
+    }
+
+    /**
+     * The user delta must likewise add only.
+     */
+    public function testUserDeltaAddsOnly(): void
+    {
+        $web = WebStoreUser::create( '/', 'POST', [] );
+
+        $this->assertEmpty(
+            array_intersect_key( StoreUser::delta(), $web->rules() ),
+            'The user delta shadows a rule which already exists upstream.'
+        );
+    }
+}

--- a/tests/Api/Provisioning/RulesParityTest.php
+++ b/tests/Api/Provisioning/RulesParityTest.php
@@ -122,17 +122,43 @@ class RulesParityTest extends TestCase
         $web = WebStoreWizard::create( '/', 'POST', [] );
         $api = StoreConnection::create( '/', 'POST', [] );
 
-        $inherited = array_diff_key(
-            $api->rules(),
-            StoreConnection::delta(),
-            StoreConnection::overrides()
-        );
+        $overridden = array_flip( StoreConnection::overriddenFields() );
+
+        $inherited = array_diff_key( $api->rules(), StoreConnection::delta(), $overridden );
 
         $this->assertEquals(
-            array_diff_key( $web->rules(), StoreConnection::overrides() ),
+            array_diff_key( $web->rules(), $overridden ),
             $inherited,
             'Connection validation rules have diverged from the virtual interface wizard.'
         );
+    }
+
+    /**
+     * An overridden address rule must keep the wizard's conditional requirement.
+     *
+     * Regression test. The override initially replaced the whole rule with a flat `nullable`,
+     * which let a caller create a VLAN interface with ipv4enabled=1 and no address. Such a row
+     * renders as `neighbor  as 65551;` in the route server config - a parse error which
+     * invalidates the generated configuration for the entire VLAN, not just that peer.
+     */
+    public function testEnabledAddressFamilyStillRequiresAnAddress(): void
+    {
+        foreach( [ 'ipv4', 'ipv6' ] as $proto ) {
+            $enabled  = StoreConnection::create( '/', 'POST', [ "{$proto}enabled" => true ] );
+            $disabled = StoreConnection::create( '/', 'POST', [ "{$proto}enabled" => false ] );
+
+            $this->assertStringContainsString(
+                'required',
+                $enabled->rules()[ "{$proto}address" ],
+                "{$proto}address must be required when {$proto}enabled is set"
+            );
+
+            $this->assertStringContainsString(
+                'nullable',
+                $disabled->rules()[ "{$proto}address" ],
+                "{$proto}address must be optional when {$proto}enabled is not set"
+            );
+        }
     }
 
     /**
@@ -158,7 +184,7 @@ class RulesParityTest extends TestCase
     {
         $web = WebStoreWizard::create( '/', 'POST', [] );
 
-        foreach( array_keys( StoreConnection::overrides() ) as $field ) {
+        foreach( StoreConnection::overriddenFields() as $field ) {
             $this->assertArrayHasKey(
                 $field,
                 $web->rules(),

--- a/tests/Api/UserJsonLeakTest.php
+++ b/tests/Api/UserJsonLeakTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Api;
+
+/*
+ * Copyright (C) 2026 KleyReX. All Rights Reserved.
+ *
+ * This file is part of IXP Manager.
+ *
+ * IXP Manager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version v2.0 of the License.
+ *
+ * IXP Manager is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2.0
+ * along with IXP Manager.  If not, see:
+ *
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+use IXP\Models\User;
+use Tests\TestCase;
+
+/**
+ * A serialised user must never carry the password hash.
+ *
+ * `GET admin/api/v4/user/json` answered with `User::byPrivs()->get()->toArray()`, and the
+ * model declared no $hidden - so the endpoint returned the bcrypt hash of every user of every
+ * customer. It sits in routes/apiv4-ext-auth-superuser.php: reachable with an API key, with
+ * no CSRF token in the way.
+ *
+ * @author     KleyReX
+ * @category   IXP
+ * @package    Tests\Api
+ * @copyright  Copyright (C) 2026 KleyReX
+ * @license    http://www.gnu.org/licenses/gpl-2.0.html GNU GPL V2.0
+ */
+class UserJsonLeakTest extends TestCase
+{
+    public function test_the_user_endpoint_does_not_return_password_hashes(): void
+    {
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->get( '/admin/api/v4/user/json' );
+
+        $response->assertStatus( 200 );
+
+        $users = $response->json();
+
+        $this->assertNotEmpty( $users, 'ohne Benutzer beweist dieser Test nichts' );
+
+        foreach( $users as $user ) {
+            $this->assertArrayNotHasKey( 'password', $user );
+        }
+
+        // and not anywhere in the raw body either - a differently named key would still leak
+        $this->assertStringNotContainsString( '$2y$', $response->getContent(), 'bcrypt-Hash im Antworttext' );
+    }
+
+    /**
+     * The guard belongs on the model, so that anything serialising a user is covered - not
+     * only the one endpoint which was found to leak.
+     */
+    public function test_serialising_a_user_never_includes_the_password(): void
+    {
+        $user = User::firstOrFail();
+
+        $this->assertNotEmpty( $user->password, 'der Testbenutzer hat kein Passwort gesetzt' );
+
+        $this->assertArrayNotHasKey( 'password', $user->toArray() );
+        $this->assertStringNotContainsString( '$2y$', $user->toJson() );
+        $this->assertStringNotContainsString( '$2y$', json_encode( [ 'user' => $user ] ) );
+    }
+
+    /**
+     * Direct access must keep working: authentication reads it through getAuthPassword(), and
+     * the console server and RADIUS templates under resources/views/api/v4/user/formatted/
+     * emit it deliberately. $hidden affects serialisation only - this asserts that boundary.
+     */
+    public function test_direct_access_to_the_password_still_works(): void
+    {
+        $user = User::firstOrFail();
+
+        $this->assertNotEmpty( $user->password );
+        $this->assertSame( $user->password, $user->getAuthPassword() );
+    }
+
+    /**
+     * The formatted endpoint exists to hand password hashes to console servers. It must not
+     * have been broken by hiding the attribute.
+     */
+    public function test_the_formatted_endpoint_still_emits_what_it_is_for(): void
+    {
+        $response = $this->withHeader( 'X-IXP-Manager-API-Key', self::API_KEY_SUPERUSER )
+            ->get( '/admin/api/v4/user/formatted' );
+
+        $response->assertStatus( 200 );
+        $this->assertNotEmpty( $response->getContent() );
+    }
+}


### PR DESCRIPTION
[NF] Provisioning API: create members, users and connections over HTTP

## Why

API v4 is, in practice, a read and export surface. It publishes switch configuration,
route server configuration, Nagios targets and DNS data — but nothing in it creates a
member, a portal user or a port. That logic lives only in the web controllers, so an IXP
wanting to provision from an ordering or billing system has to either drive the web UI or
write to the database directly, and writing directly means losing the validation, the
events, the cache invalidation and the IP collision checks that make those controllers
correct.

At KleyReX we want an order to provision itself end to end. This is the part of that which
belongs in IXP Manager; everything else (switch rollout, route server reload, rDNS) stays
outside and talks to these endpoints.

Worth noting for anyone who has tried: the existing POST endpoints under `admin/api/v4`
cannot be called from outside a browser at all. That group carries the `web` middleware and
`VerifyCsrfToken` excepts only `login`, so an external caller can issue GET and nothing
else. This PR therefore adds its own route group, modelled on
`mapApiExternalAuthSuperuserRoutes()`.

## What

Eleven endpoints under `admin/api/v4/provisioning`, all requiring a superuser API key:

```
GET    /ping                       verify the auth chain without creating anything
GET    /switch  /infrastructure    resolve names to ids
GET    /port/free                  free ports across every active switch
GET    /vlan/{vlan}/address        the address pool, optionally only free entries
POST   /member                     create a member
GET    /member/{cust}              read a member
POST   /member/{cust}/user         create a portal user (fires the welcome email)
POST   /member/{cust}/connection   VI + PI + VLI + addresses, in one transaction
GET    /member/{cust}/connection   list a member's connections
DELETE /connection/{vi}            tear a connection down
POST   /onboarding                 all of the above atomically, idempotent on retry
```

## How it stays consistent with the web UI

This is the part I would most like reviewed, because it is the part that decides whether
the two drift apart later.

**Logic is inherited, not copied.** `ConnectionController` extends
`Http\Controllers\Interfaces\Common`, so `setIp()` and the fanout-aware `deletePi()` are
the same code the web UI runs. Only the orchestration that `storeWizard()` wraps in
redirects is reimplemented.

**Validation is inherited too.** The API form requests extend the web ones and add a
declared `delta()`. `RulesParityTest` subtracts that delta and asserts the remainder is
identical to the web rules. It has already earned its place: rebasing this branch from
v7.3.1 onto main failed exactly there, because main had since added `rate_limit` and
`autoneg` to the wizard request — see the last commit.

**Where duplication was unavoidable** — `Customer::create()` and `User::create()`, about a
dozen lines each — a contract test posts the same payload to both entry points and diffs
the resulting rows attribute by attribute.

## Deliberate differences from the web path

- `ipv4address`/`ipv6address` accept `"auto"`, resolved to the next free address in the
  VLAN. The wizard requires an explicit address because an operator picks one from a list
  rendered in the browser; an unattended caller has no list. The conditional requirement is
  kept — an enabled address family still requires an address.
- An explicit address must already exist in the VLAN's pool. `setIp()` creates one on
  demand, which for an unattended caller turns a typo into a stray address record.
- Member and user creation run in a transaction. The web path does not, so a failure there
  can leave orphaned company detail records behind.
- The user endpoint takes `enabled` rather than the web form's `disabled`, whose value
  `UserController@store` inverts.

## Notes for review

- **One line changed in an existing file**: the provider registration in `config/app.php`.
  Everything else is additive. `data/ci/ci_test_db.sql` also carries the new table and its
  migration row, so CI keeps loading rather than migrating.
- **No suspend or offboard endpoints.** Suspension needs somewhere to record the prior value
  of each field it changes so that restoring is exact, and there is no such place in the
  schema. That seemed worth discussing separately rather than inventing here.
- **No endpoint reserves an address on its own** — one held by nothing but a promise leaks
  if the caller then fails. Allocation happens inside the connection transaction.
- **Session caveat, stated rather than glossed over**: `apibase` starts a session and
  `ApiAuthenticate` only looks for a key when `Auth::check()` is false, so a logged-in
  superuser's browser reaches these routes on its cookie without a key and — since `web` is
  absent — without a CSRF token. That is inherited from the existing external route group
  rather than introduced here, and it is documented in the provider docblock. If you would
  rather these routes were key-only, say so and I will add a middleware for it.

## Testing

75 tests in `tests/Api/Provisioning/`, covering the auth chain, contract parity with the web
UI, rule parity, IPv6-only and dual-stack connections, LAG persistence, concurrent address
allocation, rollback on partial failure, and idempotent retries.

An adversarial review over the finished branch produced 31 confirmed findings, all fixed in
`provisioning api: fix defects found by review`. Two were serious enough to name here: an
override had dropped the "address required when the family is enabled" condition, which
would have produced `neighbor  as 65551;` in the generated route server config and broken it
for the whole VLAN; and the composite endpoint collected `rules()` from its sub-requests
without their `withValidator()` hooks, so the guard refusing `AUTH_SUPERUSER` on a
non-internal customer never applied. Both have regression tests.

In addition to the above, I have:

 - [x] ensured unit tests all run without error — 455 tests; the 36 errors are `Bgpq3Test`
       and `Bgpq4Test`, which need the `bgpq3`/`bgpq4` binaries and fail identically on a
       clean checkout of main here
 - [x] ran psalm and corrected any static analysis issues — no new findings, and nothing
       added to `psalm-baseline.xml`
 - [x] ensured all relevant template output is escaped to avoid XSS — no templates added;
       every response is JSON built from an explicit field list rather than `toArray()`
 - [x] ensured appropriate checks against user privilege / resources accessed —
       `assert.privilege:AUTH_SUPERUSER` on the group, inherited `authorize()` on each
       request, and the superuser-privilege guard restated for the composite endpoint
 - [x] API calls for add/edit/delete are not implemented with GET — all writes are POST,
       PUT or DELETE. CSRF tokens do not apply: the group deliberately omits `web`, as
       `mapApiExternalAuthSuperuserRoutes()` does, because a machine caller cannot obtain
       one. See the session caveat above.

Documentation is in `docs/provisioning-api.md` in this branch; I will open the parallel PR
against `ixp-manager-docs-md` once you have had a look at the shape of this.

The CLA has not been sent yet. I am aware nothing can be merged until it has been, and will
follow up — I opened this now so the approach can be discussed before more is built on it.
If you would rather review only after the CLA is on file, say so and I will close this and
reopen once it is.
