### PR TITLE
DotEnv: catch more nested vars

### DIFF
--- a/app/Utils/DotEnv/DotEnvParser.php
+++ b/app/Utils/DotEnv/DotEnvParser.php
@@ -106,7 +106,7 @@ class DotEnvParser
                 if( preg_match( '/^(\s*=)|([\w_]+\s+=)|([\w_]+=\s+[\w_"\']+).*/', $line ) ) {
                     throw new DotEnvParserException( "Cannot parse .env line: " . $line );
 
-                } else if( preg_match( '/^[\w_]+=["\']?.*\${[\w_]+}.*[#]?.*$/', $line ) ) {
+                } else if( preg_match( '/^\s*[\w_]+=\s*[^#]*\$(\{[^}]+\}|[\w_]+)/', $line ) ) {
                     throw new DotEnvParserException( "Cannot parse .env line as nested variables are not supported: " . $line );
 
                 } else if( mb_strlen( $line ) && mb_strpos( $line, '#' ) !== 0 && mb_strpos( $line, '=' ) > 1 ) {

--- a/tests/Utils/DotEnv/DotEnvParserTest.php
+++ b/tests/Utils/DotEnv/DotEnvParserTest.php
@@ -213,7 +213,8 @@ final class DotEnvParserTest extends TestCase
     {
         return [
             [ "=jkkjk"], [ "  =jkkfewfew" ], [ "THT_JKHK= hjkhke" ], [ "TEST =kdjfdf" ], [ "SOME#VAR=1" ], [ "TEST= kdjfdf" ],
-            [ "TEST=\${OTHER_VAR}"], [ "TEST=\"there was \${SOME_OTHER_VAR} also\""], [ "TEST_VAR='\${OTHER_VAR}'"], [ "TEST=\"aa\${OTHER_VAR}aa\" # comment" ],
+            [ "TEST=\${OTHER_VAR}"], [ "TEST=\"there was \${SOME_OTHER_VAR} also\""], [ "TEST_VAR='\${OTHER_VAR}'"], [ "TEST=\"aa\${OTHER_VAR}aa\" # comment" ], [ "TEST=\$VAR" ], [ "TEST=\"\$VAR\"" ],
+            [ "FOO=\${BAR:-localhost}" ], [ "FOO=\${!PREFIX}" ],
             [ "kjjdf k e\n" ], [ "=kjjdf\n" ]
         ];
     }


### PR DESCRIPTION
Add test cases that fail on main for other nested env var syntax, and add regex that catches them and older fixtures

assisted by gemini 👀 