### PR TITLE
Rewrite migration to not use unsigned

### DIFF
--- a/database/migrations/2021_03_30_124916_create_atlas_probes.php
+++ b/database/migrations/2021_03_30_124916_create_atlas_probes.php
@@ -14,7 +14,7 @@ class CreateAtlasProbes extends Migration
     public function up(): void
     {
         Schema::create('atlas_probes', function (Blueprint $table) {
-            $table->bigIncrements('id')->unsigned(false);
+            $table->bigInteger('id', true, false);
             $table->integer('cust_id');
             $table->string('address_v4', 15)->nullable();
             $table->string('address_v6', 39)->nullable();

--- a/database/migrations/2021_03_30_125238_create_atlas_runs.php
+++ b/database/migrations/2021_03_30_125238_create_atlas_runs.php
@@ -14,7 +14,7 @@ class CreateAtlasRuns extends Migration
     public function up()
     {
         Schema::create('atlas_runs', function (Blueprint $table) {
-            $table->increments('id')->unsigned(false);
+            $table->integer('id', true, false);
             $table->integer('vlan_id' )->nullable();
             $table->integer('protocol' )->nullable();
             $table->dateTime('scheduled_at' )->nullable();

--- a/database/migrations/2021_03_30_125422_create_atlas_measurements.php
+++ b/database/migrations/2021_03_30_125422_create_atlas_measurements.php
@@ -14,7 +14,7 @@ class CreateAtlasMeasurements extends Migration
     public function up()
     {
         Schema::create('atlas_measurements', function (Blueprint $table) {
-            $table->increments('id')->unsigned(false);
+            $table->integer('id', true, false);
             $table->integer('run_id' );
             $table->integer('cust_source' )->nullable();
             $table->integer('cust_dest' )->nullable();

--- a/database/migrations/2021_03_30_125723_create_atlas_results.php
+++ b/database/migrations/2021_03_30_125723_create_atlas_results.php
@@ -14,7 +14,7 @@ class CreateAtlasResults extends Migration
     public function up()
     {
         Schema::create('atlas_results', function (Blueprint $table) {
-            $table->increments('id')->unsigned(false);
+            $table->integer('id', true, false);
             $table->integer('measurement_id' )->nullable()->unique();
             $table->string('routing', 255)->nullable();
             $table->longText('path' )->nullable();


### PR DESCRIPTION
My PR against laravel was released, but it turns out psalm maintains their own stubs files...

Taking the quick way out here and just rewrote the line using `unsigned(false)` so that it has the same effect without using the undocumented parameter.

Verified per:
```
vagrant@vagrant:/vagrant$ git checkout main && git rev-parse HEAD && mysql -u root -ppassword ixp -e 'drop database ixp; create database ixp' && ./artisan migrate 2>1 > /dev/null && mysqldump -u root -ppassword ixp > before.sql
Switched to branch 'main'
1c0920f1a398fdb77ed2c750c7ecce2711c03018
mysql: [Warning] Using a password on the command line interface can be insecure.
mysqldump: [Warning] Using a password on the command line interface can be insecure.

vagrant@vagrant:/vagrant$ git checkout rw-migration && git rev-parse HEAD && mysql -u root -ppassword ixp -e 'drop database ixp; create database ixp' && ./artisan migrate 2>1 > /dev/null && mysqldump -u root -ppassword ixp > after.sql
Switched to branch 'rw-migration'
Your branch is up to date with 'inex/rw-migration'.
bbf433f4ae6bf77c6d268f1325a8c7d70851ea88
mysql: [Warning] Using a password on the command line interface can be insecure.
mysqldump: [Warning] Using a password on the command line interface can be insecure.

vagrant@vagrant:/vagrant$ diff before.sql after.sql
3138c3138
< -- Dump completed on 2026-08-13 13:02:50
---
> -- Dump completed on 2026-08-13 13:02:56
vagrant@vagrant:/vagrant$
```