### PR TITLE
CheckEloquent2Frontend: refactor to avoid psalm issues

### DIFF
--- a/app/Console/QaCommands/CheckEloquent2FrontendLinks.php
+++ b/app/Console/QaCommands/CheckEloquent2FrontendLinks.php
@@ -111,12 +111,12 @@ class CheckEloquent2FrontendLinks extends  Command
 
     private function getFeParamsForController(string $class): \stdClass
     {
-        $class = new $class();
-        $class->feInit();
-        $accessorClosure = \Closure::bind(function() {
-            return $this->feParams;
-        }, $class, get_class($class));
-        return $accessorClosure($class);
+        $controller = new $class();
+        $controller->feInit();
+        $reflection = new \ReflectionProperty($class, 'feParams');
+
+        /** @var \stdClass */
+        return $reflection->getValue($controller);
     }
 
     /**


### PR DESCRIPTION
Psalm doesn't realize the closure was rebound so complained $this->feParams didn't exist