### PR TITLE
[BF] Improve memory efficiency of irrdb:update-{prefix,asn}-db jobs (Fixes #1074)

### DIFF
--- a/app/Models/Aggregators/IrrdbAggregator.php
+++ b/app/Models/Aggregators/IrrdbAggregator.php
@@ -98,13 +98,16 @@ final class IrrdbAggregator
 
         // Pull these out of the cache if possible, otherwise the database.
         return Cache::store()->rememberForever( 'irrdb:prefix:ipv' . $protocol . ':' . $cust->asMacro( $protocol ), function() use ($cust,$protocol) {
-            return IrrdbPrefix::select('prefix')
-                ->where( 'customer_id', $cust->id )
-                ->where('protocol', $protocol )
-                ->orderByRaw( 'INET' . ( $protocol === 6 ? '6' : '' ) . '_ATON( prefix ) ASC' )
-                ->orderBy( 'id', 'ASC' )
-                ->pluck('prefix')
-                ->toArray();
+            $list = [];
+            foreach( DB::table( 'irrdb_prefix' )
+                         ->where( 'customer_id', $cust->id )
+                         ->where( 'protocol', $protocol )
+                         ->orderByRaw( 'INET' . ( $protocol === 6 ? '6' : '' ) . '_ATON( prefix ) ASC' )
+                         ->orderBy( 'id', 'ASC' )
+                         ->select( 'prefix' )->cursor() as $r ) {
+                $list[] = $r->prefix;
+            }
+            return $list;
         });
     }
 
@@ -133,13 +136,16 @@ final class IrrdbAggregator
 
         // Pull these out of the cache if possible, otherwise the database.
         return Cache::store()->rememberForever( 'irrdb:asn:ipv' . $protocol . ':' . $cust->asMacro( $protocol ), function() use ($cust,$protocol) {
-            return IrrdbAsn::select('asn')
-                ->where( 'customer_id', $cust->id )
-                ->where('protocol', $protocol )
-                ->orderBy( 'asn', 'ASC' )
-                ->orderBy( 'id', 'ASC' )
-                ->pluck('asn')
-                ->toArray();
+            $list = [];
+            foreach( DB::table( 'irrdb_asn' )
+                         ->where( 'customer_id', $cust->id )
+                         ->where( 'protocol', $protocol )
+                         ->orderBy( 'asn', 'ASC' )
+                         ->orderBy( 'id', 'ASC' )
+                         ->select( 'asn' )->cursor() as $r ) {
+                $list[] = $r->asn;
+            }
+            return $list;
         });
     }
 }

--- a/app/Tasks/Irrdb/UpdateDb.php
+++ b/app/Tasks/Irrdb/UpdateDb.php
@@ -217,18 +217,22 @@ abstract class UpdateDb
                 throw new GeneralException( 'Unknown type for updating: ' . $type );
         }
 
+        $table  = ( new $model )->getTable();
+        $field  = $type;                         // 'prefix' | 'asn' — column name equals $type
+        $custId = $this->customer()->id;
+
         $this->startTimer();
-        $fromDb = IrrdbAggregator::forCustomerAndProtocol( $this->customer()->id, $protocol, $type );
+        $existingCount = DB::table( $table )->where( 'customer_id', $custId )
+            ->where( 'protocol', $protocol )->count();
         $this->result['dbTime'] += $this->timeElapsed();
 
         // The calling function and the Bgpq3 class does a lot of validation and error
         // checking. But the last thing we need to do is start filtering all prefixes/ASNs if
         // something falls through to here. So, as a basic check, make sure we do not accept
         // an empty array of prefixes/ASNs for a customer that has a lot.
-
         if( count( $fromIrrdb ) === 0 ) {
             // make sure the customer doesn't have a non-empty prefix/ASN set that we're about to delete
-            if( count( $fromDb ) !== 0 ) {
+            if( $existingCount !== 0 ) {
                 $msg = "IRRDB {$type}: {$this->customer()->name} has a non-zero {$type} count for IPv{$protocol} in the database but "
                     . "BGPQ3 returned none. Please examine manually. No databases changes made for this customer.";
                 Log::alert( $msg );
@@ -241,27 +245,33 @@ abstract class UpdateDb
 
         $this->startTimer();
 
-        $fromIrrdbSet = new \Ds\Set( $fromIrrdb );
+        // Diff without materialising the existing set: start from the IRRDB set, then
+        // stream the rows already in the database, removing common members and collecting
+        // the stale rows. Runs and closes before beginTransaction() so no result set is open.
+        $toInsert = new \Ds\Set( $fromIrrdb );
+        $stale    = [];
 
-        foreach( $fromDb as $i => $p ) {
-            if( $fromIrrdbSet->contains( $p[ $type ] ) ) {
-                // ASN/prefix exists in both db and IRRDB - no action required
-                unset( $fromDb[ $i ] );
-                $fromIrrdbSet->remove( $p[$type] );
+        foreach( DB::table( $table )->where( 'customer_id', $custId )->where( 'protocol', $protocol )
+                     ->select( 'id', $field )->cursor() as $row ) {
+            if( $toInsert->contains( $row->{$field} ) ) {
+                // prefix/ASN exists in both db and IRRDB - no action required
+                $toInsert->remove( $row->{$field} );
+            } else {
+                $stale[] = [ 'id' => $row->id, $field => $row->{$field} ];
             }
         }
 
-        $fromIrrdb = $fromIrrdbSet->toArray();
+        $new = $toInsert->toArray();
+        unset( $toInsert );
 
-        // at this stage, the arrays are now:
-        // $fromDb      => asns/prefixes in the database that need to be deleted
-        // $fromIrrdb   => new asns/prefixes that need to be added
-
-        $this->result[ 'v'.$protocol ][ 'stale' ] = $fromDb;
-        $this->result[ 'v'.$protocol ][ 'new' ]   = $fromIrrdb;
+        // at this stage:
+        // $stale => prefixes/ASNs in the database that need to be deleted
+        // $new   => new prefixes/ASNs that need to be added
+        $this->result[ 'v'.$protocol ][ 'stale' ] = $stale;
+        $this->result[ 'v'.$protocol ][ 'new' ]   = $new;
 
         // validate any remaining IRRDB prefixes/ASNs before we put them near the database
-        $fromIrrdb = $this->validate( $fromIrrdb, $protocol );
+        $new = $this->validate( $new, $protocol );
 
         $this->result['procTime'] += $this->timeElapsed();
 
@@ -272,27 +282,29 @@ abstract class UpdateDb
         try {
             $now = now()->format( 'Y-m-d H:i:s' );
 
-            foreach( $fromIrrdb as $p ) {
-                Log::debug( "INSERT [{$type}]: {$this->customer()->shortname} IPv{$protocol} {$p}" );
-                $model::create(
-                    [
-                        'customer_id'   => $this->customer()->id,
-                        $type           => $p,
-                        'protocol'      => $protocol,
-                        'last_seen'     => $now,
-                        'first_seen'    => $now,
-                    ]
-                );
+            foreach( array_chunk( $new, 1000 ) as $chunk ) {
+                $insrows = [];
+                foreach( $chunk as $v ) {
+                    $insrows[] = [
+                        'customer_id' => $custId,
+                        $field        => $v,
+                        'protocol'    => $protocol,
+                        'first_seen'  => $now,
+                        'last_seen'   => $now,
+                        'created_at'  => $now,
+                        'updated_at'  => $now,
+                    ];
+                }
+                DB::table( $table )->insert( $insrows );
             }
 
-            foreach( $fromDb as $i => $p ) {
-                Log::debug( "DELETE [{$type}]: {$this->customer()->shortname} IPv{$protocol} ID:{$p['id']} {$p[$type]}" );
-                $model::where( 'id', $p['id'] )->delete();
+            foreach( array_chunk( array_column( $stale, 'id' ), 1000 ) as $ids ) {
+                DB::table( $table )->whereIn( 'id', $ids )->delete();
             }
 
-            $model::where( 'customer_id', $this->customer()->id )
+            DB::table( $table )->where( 'customer_id', $custId )
                 ->where( 'protocol', $protocol )
-                ->update( [ 'last_seen' => $now ] );
+                ->update( [ 'last_seen' => $now, 'updated_at' => $now ] );
 
             DB::commit();
             $this->result['dbTime'] += $this->timeElapsed();

--- a/app/Utils/BgpqBase.php
+++ b/app/Utils/BgpqBase.php
@@ -83,7 +83,6 @@ abstract class BgpqBase implements IrrQuerier
      *
      * @return array The array of prefixes (or empty array).
      *
-     * @throws GeneralException On a JSON decoding error
      * @throws ProcessException if process returns non-zero exit code
      *
      * @psalm-return list{0?: mixed,...}
@@ -93,24 +92,8 @@ abstract class BgpqBase implements IrrQuerier
     {
         $minSubnetSize = config( 'ixp.irrdb.min_v' . $proto . '_subnet_size' );
 
-        $json = $this->execute( [ '-l', 'pl', '-j', '-m', $minSubnetSize, $asmacro ], $proto );
-        $array = json_decode( $json, true );
-
-        if( $array === null ){
-            throw new GeneralException( "Could not decode JSON response from " . $this->utility );
-        }
-
-        if( !isset( $array[ 'pl' ] ) ){
-            throw new GeneralException( "Named prefix list [pl] expected in decoded JSON but not found!" );
-        }
-
-        $prefixes = [];
-        // we're going to ignore the 'exact' for now.
-        foreach( $array[ 'pl' ] as $ar ){
-            $prefixes[] = $ar['prefix'];
-        }
-
-        return $prefixes;
+        $out = $this->execute( [ '-F', "%n/%l\n", '-m', $minSubnetSize, $asmacro ], $proto );
+        return preg_split( '/\R/', $out, -1, PREG_SPLIT_NO_EMPTY ) ?: [];
     }
 
     /**

--- a/tests/Utils/Bgpq3Test.php
+++ b/tests/Utils/Bgpq3Test.php
@@ -184,9 +184,9 @@ class Bgpq3Test extends TestCase
 
     public function testGetPrefixListDefaultProto()
     {
-        // test command without specific flags..
+        // -F emits one "network/masklen" per line (see BgpqBase::getPrefixList).
         Process::fake([
-            "*" => Process::result( $this->getV4PrefixSampleData() ),
+            "*" => Process::result( $this->getPrefixSampleDataF( 4 ) ),
         ]);
 
         $expectingPrefixes = $this->getExpectedPrefixes( 4 );
@@ -194,61 +194,54 @@ class Bgpq3Test extends TestCase
         $program = config('ixp.irrdb.bgpq3.path');
         $bgp = new Bgpq3( $program );
         $this->assertEquals( $expectingPrefixes, $bgp->getPrefixList( "AS-HEANET" ) );
-        $this->assertRan("'$program' '-l' 'pl' '-j' '-m' '24' 'AS-HEANET'");
+        $this->assertRan("'$program' '-F' '%n/%l\n' '-m' '24' 'AS-HEANET'");
 
         // test command when invoked with whois + sources
         $bgp->setWhois( "whois.radb.net" );
         $bgp->setSources( "RIPE" );
         $this->assertEquals( $expectingPrefixes, $bgp->getPrefixList( "AS-HEANET" ) );
-        $this->assertRan("'$program' '-S' 'RIPE' '-h' 'whois.radb.net' '-l' 'pl' '-j' '-m' '24' 'AS-HEANET'");
+        $this->assertRan("'$program' '-S' 'RIPE' '-h' 'whois.radb.net' '-F' '%n/%l\n' '-m' '24' 'AS-HEANET'");
     }
 
     public function testGetPrefixListV4()
     {
         Process::fake([
-            "*" => Process::result( $this->getV4PrefixSampleData() ),
+            "*" => Process::result( $this->getPrefixSampleDataF( 4 ) ),
         ]);
 
         $program = config('ixp.irrdb.bgpq3.path');
         $bgp = new Bgpq3( $program );
         $this->assertEquals($this->getExpectedPrefixes( 4 ), $bgp->getPrefixList("AS-HEANET", 4));
-        $this->assertRan("'$program' '-l' 'pl' '-j' '-m' '24' 'AS-HEANET'");
+        $this->assertRan("'$program' '-F' '%n/%l\n' '-m' '24' 'AS-HEANET'");
     }
 
     public function testGetPrefixListV6()
     {
         Process::fake([
-            "*" => Process::result( $this->getV6PrefixSampleData() ),
+            "*" => Process::result( $this->getPrefixSampleDataF( 6 ) ),
         ]);
 
         $program = config('ixp.irrdb.bgpq3.path');
         $bgp = new Bgpq3( $program );
         $this->assertEquals($this->getExpectedPrefixes( 6 ), $bgp->getPrefixList("AS-HEANET", 6));
-        $this->assertRan("'$program' '-6' '-l' 'pl' '-j' '-m' '48' 'AS-HEANET'");
+        $this->assertRan("'$program' '-6' '-F' '%n/%l\n' '-m' '48' 'AS-HEANET'");
     }
 
-    public function testGetPrefixListInvalidJson()
+    /**
+     * getPrefixList must split on any line ending (\R) and drop empties, so trailing
+     * newlines, blank lines and CR/LF from bgpq never yield phantom prefixes.
+     */
+    public function testGetPrefixListParsesFFormat()
     {
         Process::fake([
-            "*" => Process::result('{'),
+            "*" => Process::result( "10.0.0.0/24\r\n10.0.1.0/24\n\n192.0.2.0/24\n" ),
         ]);
 
         $bgp = new Bgpq3( config('ixp.irrdb.bgpq3.path') );
-        $this->expectException(GeneralException::class);
-        $this->expectExceptionMessage("Could not decode JSON response from BGPQ");
-        $bgp->getPrefixList("AS-HEANET");
-    }
-
-    public function testGetPrefixListMissingPl()
-    {
-        Process::fake([
-            "*" => Process::result('{}'),
-        ]);
-
-        $bgp = new Bgpq3( config('ixp.irrdb.bgpq3.path') );
-        $this->expectException(GeneralException::class);
-        $this->expectExceptionMessage("Named prefix list [pl] expected in decoded JSON but not found!");
-        $bgp->getPrefixList("AS-HEANET");
+        $this->assertEquals(
+            [ '10.0.0.0/24', '10.0.1.0/24', '192.0.2.0/24' ],
+            $bgp->getPrefixList("AS-HEANET")
+        );
     }
 
     public function testProcessFailure()
@@ -260,7 +253,7 @@ class Bgpq3Test extends TestCase
         $program = config('ixp.irrdb.bgpq3.path');
         $bgp = new Bgpq3( $program );
         $this->expectException(ProcessException::class);
-        $this->expectExceptionMessage("Error executing command with: '$program' '-l' 'pl' '-j' '-m' '24' 'AS-HEANET'" );
+        $this->expectExceptionMessage("Error executing command with: '$program' '-F' '%n/%l\n' '-m' '24' 'AS-HEANET'" );
         $bgp->getPrefixList("AS-HEANET");
     }
 
@@ -316,13 +309,9 @@ class Bgpq3Test extends TestCase
         return \file_get_contents("data/ci/known-good/bgpq3/heanet-asns.json");
     }
 
-    private function getV4PrefixSampleData(): string
+    private function getPrefixSampleDataF( int $proto ): string
     {
-        return \file_get_contents( "data/ci/known-good/bgpq3/heanet-prefixes-v4.json" );
-    }
-
-    private function getV6PrefixSampleData(): string
-    {
-        return \file_get_contents( "data/ci/known-good/bgpq3/heanet-prefixes-v6.json" );
+        // Reproduce bgpq3 -F '%n/%l\n' output from the known-good prefix list.
+        return implode( "\n", $this->getExpectedPrefixes( $proto ) ) . "\n";
     }
 }

--- a/tests/Utils/Bgpq4Test.php
+++ b/tests/Utils/Bgpq4Test.php
@@ -184,9 +184,9 @@ class Bgpq4Test extends TestCase
 
     public function testGetPrefixListDefaultProto()
     {
-        // test command without specific flags..
+        // -F emits one "network/masklen" per line (see BgpqBase::getPrefixList).
         Process::fake([
-            "*" => Process::result( $this->getV4PrefixSampleData() ),
+            "*" => Process::result( $this->getPrefixSampleDataF( 4 ) ),
         ]);
 
         $expectingPrefixes = $this->getExpectedPrefixes( 4 );
@@ -194,61 +194,54 @@ class Bgpq4Test extends TestCase
         $program = config('ixp.irrdb.bgpq4.path');
         $bgp = new Bgpq4( $program );
         $this->assertEquals( $expectingPrefixes, $bgp->getPrefixList( "AS-HEANET" ) );
-        $this->assertRan("'$program' '-l' 'pl' '-j' '-m' '24' 'AS-HEANET'" );
+        $this->assertRan("'$program' '-F' '%n/%l\n' '-m' '24' 'AS-HEANET'");
 
         // test command when invoked with whois + sources
         $bgp->setWhois( "whois.radb.net" );
         $bgp->setSources( "RIPE" );
         $this->assertEquals( $expectingPrefixes, $bgp->getPrefixList( "AS-HEANET" ) );
-        $this->assertRan("'$program' '-S' 'RIPE' '-h' 'whois.radb.net' '-l' 'pl' '-j' '-m' '24' 'AS-HEANET'" );
+        $this->assertRan("'$program' '-S' 'RIPE' '-h' 'whois.radb.net' '-F' '%n/%l\n' '-m' '24' 'AS-HEANET'");
     }
 
     public function testGetPrefixListV4()
     {
         Process::fake([
-            "*" => Process::result( $this->getV4PrefixSampleData() ),
+            "*" => Process::result( $this->getPrefixSampleDataF( 4 ) ),
         ]);
 
         $program = config('ixp.irrdb.bgpq4.path');
         $bgp = new Bgpq4( $program );
         $this->assertEquals($this->getExpectedPrefixes( 4 ), $bgp->getPrefixList("AS-HEANET", 4));
-        $this->assertRan("'$program' '-l' 'pl' '-j' '-m' '24' 'AS-HEANET'" );
+        $this->assertRan("'$program' '-F' '%n/%l\n' '-m' '24' 'AS-HEANET'");
     }
 
     public function testGetPrefixListV6()
     {
         Process::fake([
-            "*" => Process::result( $this->getV6PrefixSampleData() ),
+            "*" => Process::result( $this->getPrefixSampleDataF( 6 ) ),
         ]);
 
         $program = config('ixp.irrdb.bgpq4.path');
         $bgp = new Bgpq4( $program );
         $this->assertEquals($this->getExpectedPrefixes( 6 ), $bgp->getPrefixList("AS-HEANET", 6));
-        $this->assertRan("'$program' '-6' '-l' 'pl' '-j' '-m' '48' 'AS-HEANET'" );
+        $this->assertRan("'$program' '-6' '-F' '%n/%l\n' '-m' '48' 'AS-HEANET'");
     }
 
-    public function testGetPrefixListInvalidJson()
+    /**
+     * getPrefixList must split on any line ending (\R) and drop empties, so trailing
+     * newlines, blank lines and CR/LF from bgpq4 never yield phantom prefixes.
+     */
+    public function testGetPrefixListParsesFFormat()
     {
         Process::fake([
-            "*" => Process::result('{'),
+            "*" => Process::result( "10.0.0.0/24\r\n10.0.1.0/24\n\n192.0.2.0/24\n" ),
         ]);
 
         $bgp = new Bgpq4( config('ixp.irrdb.bgpq4.path') );
-        $this->expectException(GeneralException::class);
-        $this->expectExceptionMessage("Could not decode JSON response from BGPQ");
-        $bgp->getPrefixList("AS-HEANET");
-    }
-
-    public function testGetPrefixListMissingPl()
-    {
-        Process::fake([
-            "*" => Process::result('{}'),
-        ]);
-
-        $bgp = new Bgpq4( config('ixp.irrdb.bgpq4.path') );
-        $this->expectException(GeneralException::class);
-        $this->expectExceptionMessage("Named prefix list [pl] expected in decoded JSON but not found!");
-        $bgp->getPrefixList("AS-HEANET");
+        $this->assertEquals(
+            [ '10.0.0.0/24', '10.0.1.0/24', '192.0.2.0/24' ],
+            $bgp->getPrefixList("AS-HEANET")
+        );
     }
 
     public function testProcessFailure()
@@ -260,7 +253,7 @@ class Bgpq4Test extends TestCase
         $program = config('ixp.irrdb.bgpq4.path');
         $bgp = new Bgpq4( $program );
         $this->expectException(ProcessException::class);
-        $this->expectExceptionMessage("Error executing command with: '$program' '-l' 'pl' '-j' '-m' '24' 'AS-HEANET'" );
+        $this->expectExceptionMessage("Error executing command with: '$program' '-F' '%n/%l\n' '-m' '24' 'AS-HEANET'" );
         $bgp->getPrefixList("AS-HEANET");
     }
 
@@ -316,13 +309,9 @@ class Bgpq4Test extends TestCase
         return \file_get_contents("data/ci/known-good/bgpq3/heanet-asns.json");
     }
 
-    private function getV4PrefixSampleData(): string
+    private function getPrefixSampleDataF( int $proto ): string
     {
-        return \file_get_contents( "data/ci/known-good/bgpq3/heanet-prefixes-v4.json" );
-    }
-
-    private function getV6PrefixSampleData(): string
-    {
-        return \file_get_contents( "data/ci/known-good/bgpq3/heanet-prefixes-v6.json" );
+        // Reproduce bgpq4 -F '%n/%l\n' output from the known-good prefix list.
+        return implode( "\n", $this->getExpectedPrefixes( $proto ) ) . "\n";
     }
 }


### PR DESCRIPTION
 * Read bgpq output with user-defined format instead of parsing JSON
 * Stream rows with cursor and bulk INSERT/DELETE instead of loading all rows
 * Populate cache with cursor instead of pluck+toArray
 
The `irrdb:update-{prefix,asn}-db` commands OOM'd on members with large AS-SETs because three locations load the whole list into PHP arrays. Since the fatal is an \Error, it aborts the run silently and skips every later member.

In addition to the above, I have:

 - [x] ensured unit tests all run without error
 - [x] ran psalm and corrected any static analysis issues
 - `N/A` ensured all relevant template output is escaped to avoid XSS attached with `<?= $t->ee( $data ) ?>` or equivalent
 - `N/A` ensured appropriate checks against user privilege / resources accessed
 - `N/A` API calls (particular for add/edit/delete/toggle) are not implemented with GET and use CSRF tokens to avoid CSRF attacks
  
